### PR TITLE
feat(scanner): improve RPG source scanning

### DIFF
--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -3,8 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const { collectSourceFiles } = require('../src/collector/sourceCollector');
-const { scanRpgFile } = require('../src/scanner/rpgScanner');
-const { aggregateDependencies } = require('../src/scanner/dependencyScanner');
+const { scanSourceFiles } = require('../src/scanner/rpgScanner');
 const { buildContext } = require('../src/context/contextBuilder');
 const { buildPrompts } = require('../src/prompt/promptBuilder');
 const { generateMarkdownReport } = require('../src/report/markdownReport');
@@ -57,7 +56,7 @@ function resolveConfig(args) {
 
   const extensions = args.extensions
     ? String(args.extensions).split(',').map((ext) => ext.trim()).filter(Boolean)
-    : ((profile && profile.extensions) || ['.rpgle', '.rpg', '.sqlrpgle', '.rpgleinc']);
+    : ((profile && profile.extensions) || ['.rpg', '.rpgle', '.sqlrpgle', '.rpgile', '.clle', '.dds', '.dspf', '.prtf', '.pf', '.lf']);
 
   return {
     sourceRoot,
@@ -72,11 +71,16 @@ function pickSourceSnippet(sourceFiles, programName) {
     return 'No source files were found.';
   }
 
+  const paths = sourceFiles.map((entry) => (typeof entry === 'string' ? entry : entry.path)).filter(Boolean);
+  if (paths.length === 0) {
+    return 'No source files were found.';
+  }
+
   const normalizedProgram = String(programName || '').toLowerCase();
-  const preferred = sourceFiles.find((file) => {
+  const preferred = paths.find((file) => {
     const base = path.basename(file).toLowerCase();
     return base.startsWith(normalizedProgram);
-  }) || sourceFiles[0];
+  }) || paths[0];
 
   const content = fs.readFileSync(preferred, 'utf8');
   return content.split(/\r?\n/).slice(0, 120).join('\n');
@@ -131,10 +135,15 @@ function main() {
 
   const sourceFiles = collectSourceFiles(sourceRoot, config.extensions);
   logVerbose(`Collected source files: ${sourceFiles.length}`);
-  const scanResults = sourceFiles.map((filePath) => scanRpgFile(filePath));
-  const dependencies = aggregateDependencies(scanResults);
+  const scanSummary = scanSourceFiles(sourceFiles);
+  const dependencies = {
+    tables: scanSummary.tables,
+    calls: scanSummary.calls,
+    copyMembers: scanSummary.copyMembers,
+    sqlStatements: scanSummary.sqlStatements,
+  };
 
-  const notes = [];
+  const notes = [...(scanSummary.notes || [])];
   if (sourceFiles.length === 0) {
     const warning = 'No source files found for provided sourceRoot/extensions.';
     notes.push(warning);
@@ -146,12 +155,12 @@ function main() {
 
   const context = buildContext({
     program,
-    sourceFiles,
+    sourceFiles: scanSummary.sourceFiles || [],
     dependencies,
     notes,
   });
 
-  const sourceSnippet = pickSourceSnippet(sourceFiles, program);
+  const sourceSnippet = pickSourceSnippet(scanSummary.sourceFiles, program);
   const prompts = buildPrompts({
     program,
     context,
@@ -170,7 +179,7 @@ function main() {
   fs.writeFileSync(path.join(outputProgramDir, 'ai_prompt_error_analysis.md'), prompts.errorAnalysis, 'utf8');
 
   console.log(`Analysis complete for program ${program}`);
-  console.log(`Source files scanned: ${sourceFiles.length}`);
+  console.log(`Source files scanned: ${(scanSummary.sourceFiles || []).length}`);
   console.log(`Output written to: ${outputProgramDir}`);
 }
 

--- a/src/prompt/promptBuilder.js
+++ b/src/prompt/promptBuilder.js
@@ -10,7 +10,25 @@ function asBulletList(values) {
   if (!values || values.length === 0) {
     return '- None detected';
   }
-  return values.map((value) => `- ${value}`).join('\n');
+  return values.map((value) => {
+    if (typeof value === 'string') {
+      return `- ${value}`;
+    }
+
+    if (value && typeof value === 'object') {
+      if (value.name && value.kind) {
+        return `- ${value.name} (${value.kind})`;
+      }
+      if (value.name) {
+        return `- ${value.name}`;
+      }
+      if (value.text && value.type) {
+        return `- [${value.type}] ${value.text}`;
+      }
+    }
+
+    return `- ${String(value)}`;
+  }).join('\n');
 }
 
 function renderTemplate(template, data) {

--- a/src/report/markdownReport.js
+++ b/src/report/markdownReport.js
@@ -2,7 +2,34 @@ function sectionList(values) {
   if (!values || values.length === 0) {
     return '- None detected';
   }
-  return values.map((value) => `- ${value}`).join('\n');
+  return values.map((value) => {
+    if (typeof value === 'string') {
+      return `- ${value}`;
+    }
+
+    if (value && typeof value === 'object') {
+      if (value.path) {
+        const details = [];
+        if (typeof value.sizeBytes === 'number') details.push(`${value.sizeBytes} bytes`);
+        if (typeof value.lines === 'number') details.push(`${value.lines} lines`);
+        return `- ${value.path}${details.length ? ` (${details.join(', ')})` : ''}`;
+      }
+
+      if (value.name && value.kind) {
+        return `- ${value.name} (${value.kind})`;
+      }
+
+      if (value.name) {
+        return `- ${value.name}`;
+      }
+
+      if (value.text && value.type) {
+        return `- [${value.type}] ${value.text}`;
+      }
+    }
+
+    return `- ${String(value)}`;
+  }).join('\n');
 }
 
 function generateMarkdownReport(context) {

--- a/src/scanner/dependencyScanner.js
+++ b/src/scanner/dependencyScanner.js
@@ -1,19 +1,98 @@
-function aggregateUnique(scanResults, key) {
-  const set = new Set();
-  for (const result of scanResults) {
-    for (const value of result[key] || []) {
-      set.add(value);
+function normalizeName(name) {
+  return String(name || '').trim().toUpperCase();
+}
+
+function mergeEntityList(scanResults, key, includeKindDefault) {
+  const map = new Map();
+
+  for (const result of scanResults || []) {
+    for (const item of result[key] || []) {
+      const normalized = normalizeName(item.name || item);
+      if (!normalized) continue;
+
+      if (!map.has(normalized)) {
+        const base = {
+          name: normalized,
+          evidence: [],
+        };
+        if (item.kind || includeKindDefault) {
+          base.kind = item.kind || includeKindDefault;
+        }
+        map.set(normalized, base);
+      }
+
+      const target = map.get(normalized);
+      if (!target.kind && item.kind) {
+        target.kind = item.kind;
+      }
+
+      const evidenceList = item.evidence || [];
+      for (const evidence of evidenceList) {
+        const serialized = JSON.stringify(evidence);
+        const exists = target.evidence.some((entry) => JSON.stringify(entry) === serialized);
+        if (!exists) {
+          target.evidence.push(evidence);
+        }
+      }
     }
   }
-  return Array.from(set).sort();
+
+  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function mergeSqlStatements(scanResults) {
+  const map = new Map();
+
+  for (const result of scanResults || []) {
+    for (const sql of result.sqlStatements || []) {
+      const key = `${sql.type || 'OTHER'}|${String(sql.text || '').toUpperCase()}`;
+      if (!map.has(key)) {
+        map.set(key, {
+          type: sql.type || 'OTHER',
+          text: sql.text || '',
+          tables: Array.from(new Set((sql.tables || []).map((name) => normalizeName(name)))).sort(),
+          evidence: [],
+        });
+      }
+
+      const target = map.get(key);
+      target.tables = Array.from(new Set([...(target.tables || []), ...((sql.tables || []).map((name) => normalizeName(name)))]))
+        .filter(Boolean)
+        .sort();
+
+      for (const evidence of sql.evidence || []) {
+        const serialized = JSON.stringify(evidence);
+        const exists = target.evidence.some((entry) => JSON.stringify(entry) === serialized);
+        if (!exists) {
+          target.evidence.push(evidence);
+        }
+      }
+    }
+  }
+
+  return Array.from(map.values());
 }
 
 function aggregateDependencies(scanResults) {
+  const sourceFiles = [];
+  const notes = [];
+
+  for (const result of scanResults || []) {
+    if (result.sourceFile) {
+      sourceFiles.push(result.sourceFile);
+    }
+    for (const note of result.notes || []) {
+      notes.push(note);
+    }
+  }
+
   return {
-    tables: aggregateUnique(scanResults, 'tables'),
-    calls: aggregateUnique(scanResults, 'calls'),
-    copyMembers: aggregateUnique(scanResults, 'copyMembers'),
-    sqlStatements: aggregateUnique(scanResults, 'sqlStatements'),
+    sourceFiles,
+    tables: mergeEntityList(scanResults, 'tables', 'FILE'),
+    calls: mergeEntityList(scanResults, 'calls', 'PROGRAM'),
+    copyMembers: mergeEntityList(scanResults, 'copyMembers'),
+    sqlStatements: mergeSqlStatements(scanResults),
+    notes,
   };
 }
 

--- a/src/scanner/rpgScanner.js
+++ b/src/scanner/rpgScanner.js
@@ -1,103 +1,369 @@
 const fs = require('fs');
 
-function uniquePush(target, value) {
-  if (!value) return;
-  if (!target.includes(value)) {
-    target.push(value);
+function normalizeWhitespace(text) {
+  return String(text || '').replace(/\s+/g, ' ').trim();
+}
+
+function isCommentLine(rawLine) {
+  if (!rawLine) return true;
+  if (rawLine.length >= 7 && rawLine[6] === '*') {
+    return true;
   }
+
+  const trimmed = rawLine.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith('*')) return true;
+  if (trimmed.startsWith('//')) return true;
+  return false;
+}
+
+function normalizeName(name) {
+  return String(name || '').trim().toUpperCase();
+}
+
+function normalizeTableName(rawName) {
+  const cleaned = String(rawName || '').trim().replace(/^"(.*)"$/, '$1').replace(/\//g, '.');
+  if (!cleaned) return '';
+  const segments = cleaned.split('.').filter(Boolean);
+  const table = segments.length > 0 ? segments[segments.length - 1] : cleaned;
+  return normalizeName(table);
+}
+
+function addEntity(map, name, payload) {
+  const normalized = normalizeName(name);
+  if (!normalized) return;
+
+  if (!map.has(normalized)) {
+    map.set(normalized, {
+      ...payload,
+      name: normalized,
+      evidence: [],
+    });
+  }
+
+  const entity = map.get(normalized);
+  const evidenceKey = JSON.stringify(payload.evidence);
+  const hasEvidence = entity.evidence.some((item) => JSON.stringify(item) === evidenceKey);
+  if (!hasEvidence) {
+    entity.evidence.push(payload.evidence);
+  }
+}
+
+function detectSqlType(sqlText) {
+  const normalized = normalizeWhitespace(sqlText).toUpperCase();
+  if (/\bSELECT\b/.test(normalized)) return 'SELECT';
+  if (/\bINSERT\b/.test(normalized)) return 'INSERT';
+  if (/\bUPDATE\b/.test(normalized)) return 'UPDATE';
+  if (/\bDELETE\b/.test(normalized)) return 'DELETE';
+  if (/\bMERGE\b/.test(normalized)) return 'MERGE';
+  return 'OTHER';
+}
+
+function extractSqlTables(sqlText) {
+  const tables = new Set();
+  const regex = /\b(?:FROM|JOIN|UPDATE|INTO|MERGE\s+INTO)\s+("[^"]+"|[A-Z0-9_#$@./]+)/gi;
+  let match = regex.exec(sqlText);
+
+  while (match) {
+    const normalized = normalizeTableName(match[1]);
+    if (normalized) {
+      tables.add(normalized);
+    }
+    match = regex.exec(sqlText);
+  }
+
+  return Array.from(tables).sort();
+}
+
+function scanContent(filePath, content) {
+  const lines = content.split(/\r?\n/);
+  const tablesMap = new Map();
+  const callsMap = new Map();
+  const copyMembersMap = new Map();
+  const sqlStatements = [];
+
+  let inExecSql = false;
+  let execStartLine = 0;
+  let execBuffer = [];
+
+  const finalizeExecSql = (endLine) => {
+    if (execBuffer.length === 0) return;
+
+    const sqlText = normalizeWhitespace(execBuffer.join(' '));
+    const tables = extractSqlTables(sqlText);
+    sqlStatements.push({
+      type: detectSqlType(sqlText),
+      text: sqlText,
+      tables,
+      evidence: [
+        {
+          file: filePath,
+          startLine: execStartLine,
+          endLine,
+        },
+      ],
+    });
+
+    for (const tableName of tables) {
+      addEntity(tablesMap, tableName, {
+        kind: 'SQL',
+        evidence: { file: filePath, line: execStartLine, text: sqlText },
+      });
+    }
+
+    execBuffer = [];
+    inExecSql = false;
+    execStartLine = 0;
+  };
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const rawLine = lines[i];
+    const lineNo = i + 1;
+
+    if (isCommentLine(rawLine)) {
+      continue;
+    }
+
+    const trimmed = rawLine.trim();
+
+    const dclFMatch = rawLine.match(/^\s*dcl-f\s+([A-Z0-9_#$@]+)/i);
+    if (dclFMatch) {
+      const upperLine = rawLine.toUpperCase();
+      let kind = 'FILE';
+      if (upperLine.includes('WORKSTN')) kind = 'WORKSTN';
+      if (upperLine.includes('PRINTER')) kind = 'PRINTER';
+      if (upperLine.includes('DISK')) kind = 'DISK';
+      addEntity(tablesMap, dclFMatch[1], {
+        kind,
+        evidence: { file: filePath, line: lineNo, text: trimmed },
+      });
+    }
+
+    const fixedFSpecMatch = rawLine.match(/^\s*F[A-Z0-9_#$@]/i);
+    if (fixedFSpecMatch) {
+      const trimmedUpper = trimmed.toUpperCase();
+      if (!trimmedUpper.startsWith('FROM ')) {
+        const tokenMatch = rawLine.match(/^\s*F([A-Z0-9_#$@]+)/i);
+        const fIndex = rawLine.search(/F/i);
+        const fixedColName = fIndex >= 0 ? rawLine.slice(fIndex + 1, fIndex + 11).replace(/\s+/g, '') : '';
+        const tableName = ((tokenMatch ? tokenMatch[1] : '') || fixedColName).trim();
+        if (tableName) {
+          const upperLine = rawLine.toUpperCase();
+          let kind = 'FILE';
+          if (upperLine.includes('WORKSTN')) kind = 'WORKSTN';
+          if (upperLine.includes('PRINTER')) kind = 'PRINTER';
+          if (upperLine.includes('DISK')) kind = 'DISK';
+          addEntity(tablesMap, tableName, {
+            kind,
+            evidence: { file: filePath, line: lineNo, text: trimmed },
+          });
+        }
+      }
+    }
+
+    const copyMatch = rawLine.match(/^\s*\/(?:COPY|INCLUDE)\s+(.+)$/i) || rawLine.match(/^\s*COPY\s+(.+)$/i);
+    if (copyMatch) {
+      const copyName = normalizeName(copyMatch[1].replace(/["']/g, '').trim());
+      if (copyName) {
+        addEntity(copyMembersMap, copyName, {
+          evidence: { file: filePath, line: lineNo, text: trimmed },
+        });
+      }
+    }
+
+    const callPatterns = [
+      { regex: /\bCALL\s+PGM\s*\(\s*['"]?([A-Z0-9_#$@./]+)['"]?\s*\)/i, kind: 'PROGRAM' },
+      { regex: /\bCALL\s+['"]([A-Z0-9_#$@]+)['"]/i, kind: 'PROGRAM' },
+      { regex: /\bCALL\s+(?!PGM\b)([A-Z0-9_#$@]+)\b/i, kind: 'PROGRAM' },
+      { regex: /\bCALLP\s*\(\s*['"]([A-Z0-9_#$@]+)['"]\s*\)/i, kind: 'PROCEDURE' },
+      { regex: /\bCALLP\s+([A-Z0-9_#$@]+)\b/i, kind: 'PROCEDURE' },
+      { regex: /\bCALLPRC\s*\(\s*['"]([A-Z0-9_#$@]+)['"]\s*\)/i, kind: 'PROCEDURE' },
+      { regex: /\bCALLPRC\s*\(\s*([A-Z0-9_#$@]+)\s*\)/i, kind: 'PROCEDURE' },
+      { regex: /\bCALLB\s+['"]?([A-Z0-9_#$@]+)['"]?/i, kind: 'PROCEDURE' },
+    ];
+
+    for (const pattern of callPatterns) {
+      const match = rawLine.match(pattern.regex);
+      if (match) {
+        addEntity(callsMap, match[1], {
+          kind: pattern.kind,
+          evidence: { file: filePath, line: lineNo, text: trimmed },
+        });
+      }
+    }
+
+    if (/\bCALLP\s*\(/i.test(rawLine) && !/\bCALLP\s*\(\s*['"][A-Z0-9_#$@]+['"]\s*\)/i.test(rawLine)) {
+      addEntity(callsMap, '<DYNAMIC>', {
+        kind: 'DYNAMIC',
+        evidence: { file: filePath, line: lineNo, text: trimmed },
+      });
+    }
+
+    const execSqlMatch = rawLine.match(/\bEXEC\s+SQL\b/i);
+    if (execSqlMatch) {
+      if (inExecSql) {
+        finalizeExecSql(lineNo - 1);
+      }
+
+      inExecSql = true;
+      execStartLine = lineNo;
+      const sqlPart = rawLine.slice(execSqlMatch.index);
+      execBuffer.push(sqlPart.trim());
+      if (rawLine.includes(';')) {
+        finalizeExecSql(lineNo);
+      }
+      continue;
+    }
+
+    if (inExecSql) {
+      execBuffer.push(trimmed);
+      if (rawLine.includes(';')) {
+        finalizeExecSql(lineNo);
+      }
+      continue;
+    }
+
+    if (/\b(SELECT|INSERT|UPDATE|DELETE|MERGE|WITH)\b/i.test(rawLine)) {
+      const sqlText = normalizeWhitespace(trimmed);
+      const tables = extractSqlTables(sqlText);
+      sqlStatements.push({
+        type: detectSqlType(sqlText),
+        text: sqlText,
+        tables,
+        evidence: [
+          {
+            file: filePath,
+            startLine: lineNo,
+            endLine: lineNo,
+          },
+        ],
+      });
+
+      for (const tableName of tables) {
+        addEntity(tablesMap, tableName, {
+          kind: 'SQL',
+          evidence: { file: filePath, line: lineNo, text: sqlText },
+        });
+      }
+    }
+  }
+
+  if (inExecSql) {
+    finalizeExecSql(lines.length);
+  }
+
+  return {
+    sourceFile: {
+      path: filePath,
+      sizeBytes: Buffer.byteLength(content, 'utf8'),
+      lines: lines.length,
+    },
+    tables: Array.from(tablesMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    calls: Array.from(callsMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    copyMembers: Array.from(copyMembersMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    sqlStatements,
+    notes: [],
+  };
 }
 
 function scanRpgFile(filePath) {
   const content = fs.readFileSync(filePath, 'utf8');
-  const lines = content.split(/\r?\n/);
+  return scanContent(filePath, content);
+}
 
-  const tables = [];
-  const calls = [];
-  const copyMembers = [];
-  const sqlStatements = [];
-
-  let inSqlBlock = false;
-  let sqlBuffer = [];
-
-  for (const rawLine of lines) {
-    const line = rawLine.trim();
-
-    const fixedFSpec = rawLine.match(/^\s*F([A-Z0-9_#$@]+)/i);
-    if (fixedFSpec) {
-      uniquePush(tables, fixedFSpec[1].toUpperCase());
+function mergeEntities(targetMap, entities, withKind) {
+  for (const entity of entities) {
+    const key = normalizeName(entity.name);
+    if (!targetMap.has(key)) {
+      const base = {
+        name: key,
+        evidence: [],
+      };
+      if (withKind) {
+        base.kind = entity.kind || withKind;
+      }
+      targetMap.set(key, base);
     }
 
-    const freeFSpec = rawLine.match(/^\s*dcl-f\s+([A-Z0-9_#$@]+)/i);
-    if (freeFSpec) {
-      uniquePush(tables, freeFSpec[1].toUpperCase());
+    const target = targetMap.get(key);
+    if (withKind && !target.kind && entity.kind) {
+      target.kind = entity.kind;
     }
 
-    const copyMatch = rawLine.match(/^\s*\/(?:COPY|INCLUDE)\s+(.+)$/i);
-    if (copyMatch) {
-      uniquePush(copyMembers, copyMatch[1].trim());
-    }
-
-    const copyKeywordMatch = rawLine.match(/^\s*COPY\s+(.+)$/i);
-    if (copyKeywordMatch) {
-      uniquePush(copyMembers, copyKeywordMatch[1].trim());
-    }
-
-    const callPatterns = [
-      /\bCALL\s+['"]?([A-Z0-9_#$@]+)['"]?/i,
-      /\bCALLP\s+([A-Z0-9_#$@]+)\b/i,
-      /\bCALLP\s*\(\s*['"]?([A-Z0-9_#$@]+)['"]?\s*\)/i,
-      /\bCALLB\s+['"]?([A-Z0-9_#$@]+)['"]?/i,
-      /\bCALLPRC\s*\(\s*['"]?([A-Z0-9_#$@]+)['"]?\s*\)/i,
-      /\bCALLPRC\s+['"]?([A-Z0-9_#$@]+)['"]?/i,
-    ];
-
-    for (const pattern of callPatterns) {
-      const match = rawLine.match(pattern);
-      if (match) {
-        uniquePush(calls, match[1].toUpperCase());
+    for (const evidence of entity.evidence || []) {
+      const evidenceKey = JSON.stringify(evidence);
+      const exists = target.evidence.some((item) => JSON.stringify(item) === evidenceKey);
+      if (!exists) {
+        target.evidence.push(evidence);
       }
     }
+  }
+}
 
-    const startsExecSql = /\bEXEC\s+SQL\b/i.test(rawLine);
-    if (startsExecSql) {
-      inSqlBlock = true;
-      sqlBuffer.push(line);
-      if (line.includes(';')) {
-        uniquePush(sqlStatements, sqlBuffer.join(' ').trim());
-        sqlBuffer = [];
-        inSqlBlock = false;
+function mergeSqlStatements(scanResults) {
+  const map = new Map();
+  for (const result of scanResults) {
+    for (const sql of result.sqlStatements || []) {
+      const key = `${sql.type}|${sql.text.toUpperCase()}`;
+      if (!map.has(key)) {
+        map.set(key, {
+          type: sql.type,
+          text: sql.text,
+          tables: Array.from(new Set(sql.tables || [])).sort(),
+          evidence: [],
+        });
       }
-      continue;
-    }
 
-    if (inSqlBlock) {
-      sqlBuffer.push(line);
-      if (line.includes(';')) {
-        uniquePush(sqlStatements, sqlBuffer.join(' ').trim());
-        sqlBuffer = [];
-        inSqlBlock = false;
+      const item = map.get(key);
+      item.tables = Array.from(new Set([...(item.tables || []), ...(sql.tables || [])])).sort();
+
+      for (const evidence of sql.evidence || []) {
+        const evidenceKey = JSON.stringify(evidence);
+        const exists = item.evidence.some((entry) => JSON.stringify(entry) === evidenceKey);
+        if (!exists) {
+          item.evidence.push(evidence);
+        }
       }
-      continue;
     }
+  }
+  return Array.from(map.values());
+}
 
-    if (/\b(SELECT|INSERT|UPDATE|DELETE)\b/i.test(rawLine) && !inSqlBlock) {
-      uniquePush(sqlStatements, line);
+function scanSourceFiles(filePaths) {
+  const scanResults = [];
+  const notes = [];
+
+  for (const filePath of filePaths || []) {
+    try {
+      scanResults.push(scanRpgFile(filePath));
+    } catch (error) {
+      notes.push(`Skipped file ${filePath}: ${error.message}`);
     }
   }
 
-  if (sqlBuffer.length > 0) {
-    uniquePush(sqlStatements, sqlBuffer.join(' ').trim());
+  const sourceFiles = [];
+  for (const result of scanResults) {
+    sourceFiles.push(result.sourceFile);
   }
+
+  const tablesMap = new Map();
+  const callsMap = new Map();
+  const copyMembersMap = new Map();
+  mergeEntities(tablesMap, scanResults.flatMap((item) => item.tables || []), 'FILE');
+  mergeEntities(callsMap, scanResults.flatMap((item) => item.calls || []), 'PROGRAM');
+  mergeEntities(copyMembersMap, scanResults.flatMap((item) => item.copyMembers || []));
 
   return {
-    filePath,
-    tables,
-    calls,
-    copyMembers,
-    sqlStatements,
+    sourceFiles,
+    tables: Array.from(tablesMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    calls: Array.from(callsMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    copyMembers: Array.from(copyMembersMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
+    sqlStatements: mergeSqlStatements(scanResults),
+    notes,
   };
 }
 
 module.exports = {
   scanRpgFile,
+  scanSourceFiles,
 };


### PR DESCRIPTION
## Summary\n- implement richer heuristic RPG scanner output with evidence metadata\n- detect tables from F-spec, dcl-f, and SQL table references\n- detect calls (CALL/CALLP/CALLB/CALLPRC and CL CALL PGM variants) with PROGRAM/PROCEDURE/DYNAMIC kinds\n- detect copy members from /COPY, /INCLUDE, and COPY directives\n- capture EXEC SQL blocks and plain SQL lines with type/table extraction\n- wire CLI/report/prompt pipeline to render object-based scanner results\n\n## Validation\n- npm run analyze -- --source ./output/ORDERPGM --program ORDERPGM\n- verified required output files and context/report contract\n\nCloses #3