### PR TITLE
feat(prompt): introduce template-based AI prompt generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,17 +130,24 @@ Generated files:
 - `report.md`
 - `ai_prompt_documentation.md`
 - `ai_prompt_error_analysis.md`
+- `dependency-graph.json`
+- `dependency-graph.mmd`
+- `dependency-graph.md`
 
 `context.json` contains top-level keys:
 
 - `program`
 - `scannedAt`
+- `sourceRoot`
 - `sourceFiles`
-- `tables`
-- `calls`
-- `copyMembers`
-- `sqlStatements`
+- `summary`
+- `dependencies`
+- `sql`
+- `graph`
+- `aiContext`
 - `notes`
+
+`context.json` is the central AI-ready artifact. Prompt generation and report generation both consume this unified context model, and `graph` provides compact references to dependency graph artifacts.
 
 `report.md` includes sections:
 
@@ -150,6 +157,7 @@ Generated files:
 - `Program Calls`
 - `Copy Members`
 - `SQL Statements`
+- `Dependency Graph`
 - `Next Steps`
 
 ## AI Prompt Templates

--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -8,6 +8,12 @@ const { buildContext } = require('../src/context/contextBuilder');
 const { buildPrompts } = require('../src/prompt/promptBuilder');
 const { generateMarkdownReport } = require('../src/report/markdownReport');
 const { writeJsonReport } = require('../src/report/jsonReport');
+const {
+  buildDependencyGraph,
+  renderMermaid,
+  renderMarkdown,
+  buildGraphSummary,
+} = require('../src/report/dependencyGraphReport');
 const { fetchSources, DEFAULT_SOURCE_FILES, DEFAULT_TRANSPORT } = require('../src/fetch/fetchService');
 
 function printHelp() {
@@ -189,10 +195,23 @@ function runAnalyze(args) {
 
   const context = buildContext({
     program,
+    sourceRoot,
     sourceFiles: scanSummary.sourceFiles || [],
     dependencies,
     notes,
+    graph: {
+      nodeCount: 0,
+      edgeCount: 0,
+      files: {
+        json: 'dependency-graph.json',
+        mermaid: 'dependency-graph.mmd',
+        markdown: 'dependency-graph.md',
+      },
+    },
   });
+
+  const graph = buildDependencyGraph(context);
+  context.graph = buildGraphSummary(graph);
 
   const sourceSnippet = pickSourceSnippet(scanSummary.sourceFiles, program);
   const reportMarkdown = generateMarkdownReport(context);
@@ -208,6 +227,9 @@ function runAnalyze(args) {
     sourceSnippet,
   });
   fs.writeFileSync(path.join(outputProgramDir, 'report.md'), reportMarkdown, 'utf8');
+  writeJsonReport(path.join(outputProgramDir, 'dependency-graph.json'), graph);
+  fs.writeFileSync(path.join(outputProgramDir, 'dependency-graph.mmd'), renderMermaid(graph), 'utf8');
+  fs.writeFileSync(path.join(outputProgramDir, 'dependency-graph.md'), renderMarkdown(graph, context), 'utf8');
 
   console.log(`Analysis complete for program ${program}`);
   console.log(`Source files scanned: ${(scanSummary.sourceFiles || []).length}`);

--- a/src/context/contextBuilder.js
+++ b/src/context/contextBuilder.js
@@ -1,13 +1,232 @@
-function buildContext({ program, sourceFiles, dependencies, notes }) {
+const path = require('path');
+
+function normalizeName(name) {
+  return String(name || '').trim().toUpperCase();
+}
+
+function normalizeEvidenceList(evidenceList, sourceRoot) {
+  return (evidenceList || [])
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') return null;
+      const filePath = entry.file || entry.path || '';
+      const normalizedFile = filePath
+        ? path.relative(sourceRoot, filePath).replace(/\\/g, '/')
+        : filePath;
+      return {
+        ...entry,
+        file: normalizedFile || filePath,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => {
+      const af = String(a.file || '');
+      const bf = String(b.file || '');
+      if (af !== bf) return af.localeCompare(bf);
+      const al = Number(a.line || a.startLine || 0);
+      const bl = Number(b.line || b.startLine || 0);
+      return al - bl;
+    });
+}
+
+function dedupeByName(items, sourceRoot, withKind) {
+  const map = new Map();
+
+  for (const item of items || []) {
+    const key = normalizeName(item && item.name ? item.name : item);
+    if (!key) continue;
+    if (!map.has(key)) {
+      map.set(key, {
+        name: key,
+        kind: withKind ? normalizeName(item && item.kind ? item.kind : withKind) : undefined,
+        evidence: [],
+      });
+    }
+
+    const target = map.get(key);
+    if (withKind && item && item.kind) {
+      target.kind = normalizeName(item.kind);
+    }
+    for (const evidence of normalizeEvidenceList(item && item.evidence, sourceRoot)) {
+      const marker = JSON.stringify(evidence);
+      const exists = target.evidence.some((entry) => JSON.stringify(entry) === marker);
+      if (!exists) {
+        target.evidence.push(evidence);
+      }
+    }
+  }
+
+  return Array.from(map.values())
+    .map((entry) => ({
+      name: entry.name,
+      kind: entry.kind,
+      evidenceCount: (entry.evidence || []).length,
+      evidence: entry.evidence || [],
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function sortSqlStatements(statements, sourceRoot) {
+  const normalized = (statements || []).map((statement) => {
+    const evidence = normalizeEvidenceList(statement.evidence || [], sourceRoot);
+    return {
+      type: normalizeName(statement.type || 'OTHER') || 'OTHER',
+      text: String(statement.text || '').trim(),
+      tables: Array.from(new Set((statement.tables || []).map((name) => normalizeName(name)).filter(Boolean))).sort(),
+      evidence,
+    };
+  });
+
+  return normalized.sort((a, b) => {
+    const ae = a.evidence[0];
+    const be = b.evidence[0];
+    if (ae && be) {
+      if (ae.file !== be.file) return String(ae.file).localeCompare(String(be.file));
+      const aLine = Number(ae.startLine || ae.line || 0);
+      const bLine = Number(be.startLine || be.line || 0);
+      if (aLine !== bLine) return aLine - bLine;
+    } else if (ae && !be) {
+      return -1;
+    } else if (!ae && be) {
+      return 1;
+    }
+
+    if (a.type !== b.type) return a.type.localeCompare(b.type);
+    return a.text.localeCompare(b.text);
+  });
+}
+
+function normalizeSourceFiles(sourceFiles, sourceRoot) {
+  return (sourceFiles || [])
+    .map((entry) => {
+      const absolutePath = entry && entry.path ? entry.path : String(entry || '');
+      const relPath = absolutePath
+        ? path.relative(sourceRoot, absolutePath).replace(/\\/g, '/')
+        : absolutePath;
+
+      return {
+        path: relPath || absolutePath,
+        sizeBytes: Number(entry && entry.sizeBytes ? entry.sizeBytes : 0),
+        lines: Number(entry && entry.lines ? entry.lines : 0),
+      };
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function buildRiskHints(dependencies, sql) {
+  const hints = [];
+  if ((sql.statements || []).length > 0) {
+    hints.push('Embedded SQL detected');
+  }
+  if ((dependencies.programCalls || []).some((call) => call.kind === 'DYNAMIC' || call.name === '<DYNAMIC>')) {
+    hints.push('Dynamic call detected');
+  }
+  if ((dependencies.programCalls || []).length > 0) {
+    hints.push('External program calls detected');
+  }
+  if ((dependencies.copyMembers || []).length >= 5) {
+    hints.push('Many copy members included');
+  }
+  if (((dependencies.tables || []).length + (dependencies.programCalls || []).length) >= 10) {
+    hints.push('Many external dependencies');
+  }
+  return hints;
+}
+
+function mergeSqlTablesIntoDependencies(tables, sqlTableNames) {
+  const existing = new Set(tables.map((table) => table.name));
+  const merged = [...tables];
+  for (const tableName of sqlTableNames) {
+    if (!existing.has(tableName)) {
+      merged.push({
+        name: tableName,
+        kind: 'TABLE',
+        evidenceCount: 0,
+        evidence: [],
+      });
+      existing.add(tableName);
+    }
+  }
+  return merged.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function buildContext({ program, sourceRoot, sourceFiles, dependencies, notes, graph }) {
+  const normalizedSourceRoot = path.resolve(process.cwd(), sourceRoot || '.');
+  const normalizedSourceFiles = normalizeSourceFiles(sourceFiles || [], normalizedSourceRoot);
+
+  const tables = dedupeByName(dependencies && dependencies.tables, normalizedSourceRoot, 'TABLE').map((table) => ({
+    ...table,
+    kind: table.kind || 'TABLE',
+  }));
+  const programCalls = dedupeByName(dependencies && dependencies.calls, normalizedSourceRoot, 'PROGRAM').map((call) => ({
+    ...call,
+    kind: call.kind || 'PROGRAM',
+  }));
+  const copyMembers = dedupeByName(dependencies && dependencies.copyMembers, normalizedSourceRoot);
+  const sqlStatements = sortSqlStatements(dependencies && dependencies.sqlStatements, normalizedSourceRoot);
+  const sqlTableNames = Array.from(
+    new Set(sqlStatements.flatMap((statement) => statement.tables || []).map((name) => normalizeName(name))),
+  ).filter(Boolean).sort();
+
+  const mergedTables = mergeSqlTablesIntoDependencies(tables, sqlTableNames);
+  const dependencyBlock = {
+    tables: mergedTables.map((entry) => ({
+      name: entry.name,
+      kind: entry.kind,
+      evidenceCount: entry.evidenceCount,
+    })),
+    programCalls: programCalls.map((entry) => ({
+      name: entry.name,
+      kind: entry.kind,
+      evidenceCount: entry.evidenceCount,
+    })),
+    copyMembers: copyMembers.map((entry) => ({
+      name: entry.name,
+      evidenceCount: entry.evidenceCount,
+    })),
+  };
+
+  const sqlBlock = {
+    statements: sqlStatements,
+    tableNames: sqlTableNames,
+  };
+
+  const summary = {
+    sourceFileCount: normalizedSourceFiles.length,
+    tableCount: dependencyBlock.tables.length,
+    programCallCount: dependencyBlock.programCalls.length,
+    copyMemberCount: dependencyBlock.copyMembers.length,
+    sqlStatementCount: sqlStatements.length,
+  };
+  summary.text = `Program ${program} references ${summary.tableCount} tables, calls ${summary.programCallCount} programs, includes ${summary.copyMemberCount} copy members, and contains ${summary.sqlStatementCount} SQL statements.`;
+
+  const aiContext = {
+    programPurposeHint: '',
+    primaryTables: dependencyBlock.tables.slice(0, 10).map((entry) => entry.name),
+    primaryCalls: dependencyBlock.programCalls.slice(0, 10).map((entry) => entry.name),
+    riskHints: buildRiskHints(dependencyBlock, sqlBlock),
+  };
+
+  const normalizedGraph = graph || {
+    nodeCount: 0,
+    edgeCount: 0,
+    files: {
+      json: 'dependency-graph.json',
+      mermaid: 'dependency-graph.mmd',
+      markdown: 'dependency-graph.md',
+    },
+  };
+
   return {
-    program,
+    program: normalizeName(program),
     scannedAt: new Date().toISOString(),
-    sourceFiles,
-    tables: dependencies.tables || [],
-    calls: dependencies.calls || [],
-    copyMembers: dependencies.copyMembers || [],
-    sqlStatements: dependencies.sqlStatements || [],
-    notes: notes || [],
+    sourceRoot: normalizedSourceRoot,
+    sourceFiles: normalizedSourceFiles,
+    summary,
+    dependencies: dependencyBlock,
+    sql: sqlBlock,
+    graph: normalizedGraph,
+    aiContext,
+    notes: (notes || []).map((note) => String(note)).sort((a, b) => a.localeCompare(b)),
   };
 }
 

--- a/src/report/dependencyGraphReport.js
+++ b/src/report/dependencyGraphReport.js
@@ -1,0 +1,92 @@
+function buildDependencyGraph(context) {
+  const nodes = [];
+  const edges = [];
+  const nodeSet = new Set();
+  const edgeSet = new Set();
+
+  function addNode(id, label, type) {
+    const key = `${id}|${type}`;
+    if (nodeSet.has(key)) return;
+    nodeSet.add(key);
+    nodes.push({ id, label, type });
+  }
+
+  function addEdge(from, to, relation) {
+    const key = `${from}|${to}|${relation}`;
+    if (edgeSet.has(key)) return;
+    edgeSet.add(key);
+    edges.push({ from, to, relation });
+  }
+
+  const programName = context.program;
+  addNode(`PGM:${programName}`, programName, 'PROGRAM');
+
+  for (const table of context.dependencies.tables || []) {
+    const id = `TABLE:${table.name}`;
+    addNode(id, table.name, 'TABLE');
+    addEdge(`PGM:${programName}`, id, 'USES');
+  }
+
+  for (const call of context.dependencies.programCalls || []) {
+    const id = `CALL:${call.name}`;
+    addNode(id, call.name, call.kind || 'PROGRAM');
+    addEdge(`PGM:${programName}`, id, 'CALLS');
+  }
+
+  for (const copy of context.dependencies.copyMembers || []) {
+    const id = `COPY:${copy.name}`;
+    addNode(id, copy.name, 'COPY');
+    addEdge(`PGM:${programName}`, id, 'INCLUDES');
+  }
+
+  nodes.sort((a, b) => a.id.localeCompare(b.id));
+  edges.sort((a, b) => {
+    if (a.from !== b.from) return a.from.localeCompare(b.from);
+    if (a.to !== b.to) return a.to.localeCompare(b.to);
+    return a.relation.localeCompare(b.relation);
+  });
+
+  return { nodes, edges };
+}
+
+function safeMermaidId(id) {
+  return id.replace(/[^A-Za-z0-9_]/g, '_');
+}
+
+function renderMermaid(graph) {
+  const lines = ['graph TD'];
+  for (const node of graph.nodes) {
+    const nodeId = safeMermaidId(node.id);
+    lines.push(`  ${nodeId}[${node.label}]`);
+  }
+  for (const edge of graph.edges) {
+    const fromId = safeMermaidId(edge.from);
+    const toId = safeMermaidId(edge.to);
+    lines.push(`  ${fromId} -->|${edge.relation}| ${toId}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function renderMarkdown(graph, context) {
+  return `# Dependency Graph\n\n- Program: ${context.program}\n- Nodes: ${graph.nodes.length}\n- Edges: ${graph.edges.length}\n\n\`\`\`mermaid\n${renderMermaid(graph).trim()}\n\`\`\`\n`;
+}
+
+function buildGraphSummary(graph) {
+  return {
+    nodeCount: graph.nodes.length,
+    edgeCount: graph.edges.length,
+    files: {
+      json: 'dependency-graph.json',
+      mermaid: 'dependency-graph.mmd',
+      markdown: 'dependency-graph.md',
+    },
+  };
+}
+
+module.exports = {
+  buildDependencyGraph,
+  renderMermaid,
+  renderMarkdown,
+  buildGraphSummary,
+};
+

--- a/src/report/markdownReport.js
+++ b/src/report/markdownReport.js
@@ -33,7 +33,12 @@ function sectionList(values) {
 }
 
 function generateMarkdownReport(context) {
-  return `# Zeus RPG Analysis Report\n\n## Overview\n- Program: ${context.program}\n- Scanned At: ${context.scannedAt}\n- Source File Count: ${context.sourceFiles.length}\n\n## Source Files\n${sectionList(context.sourceFiles)}\n\n## Tables\n${sectionList(context.tables)}\n\n## Program Calls\n${sectionList(context.calls)}\n\n## Copy Members\n${sectionList(context.copyMembers)}\n\n## SQL Statements\n${sectionList(context.sqlStatements)}\n\n## Next Steps\n- Validate table and call detection against known application design.\n- Enrich table metadata with java/Db2MetadataExporter.java if DB2 access is available.\n- Use generated AI prompts to produce deep documentation and error analysis.\n`;
+  const summary = context.summary || {};
+  const dependencies = context.dependencies || {};
+  const sql = context.sql || {};
+  const graph = context.graph || {};
+
+  return `# Zeus RPG Analysis Report\n\n## Overview\n- Program: ${context.program}\n- Scanned At: ${context.scannedAt}\n- Source Root: ${context.sourceRoot}\n- Source File Count: ${summary.sourceFileCount || 0}\n- Table Count: ${summary.tableCount || 0}\n- Program Call Count: ${summary.programCallCount || 0}\n- Copy Member Count: ${summary.copyMemberCount || 0}\n- SQL Statement Count: ${summary.sqlStatementCount || 0}\n${summary.text ? `- Summary: ${summary.text}\n` : ''}\n## Source Files\n${sectionList(context.sourceFiles)}\n\n## Tables\n${sectionList(dependencies.tables)}\n\n## Program Calls\n${sectionList(dependencies.programCalls)}\n\n## Copy Members\n${sectionList(dependencies.copyMembers)}\n\n## SQL Statements\n${sectionList(sql.statements)}\n\n## Dependency Graph\n- Nodes: ${graph.nodeCount || 0}\n- Edges: ${graph.edgeCount || 0}\n- JSON: ${(graph.files && graph.files.json) || 'dependency-graph.json'}\n- Mermaid: ${(graph.files && graph.files.mermaid) || 'dependency-graph.mmd'}\n- Markdown: ${(graph.files && graph.files.markdown) || 'dependency-graph.md'}\n\n## Next Steps\n- Validate detected dependencies with the application design and naming standards.\n- Use context.json as the canonical AI input and generated prompts for deeper analysis.\n- Enrich with DB metadata when available to improve table-level reasoning.\n`;
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary\n- refactor prompt generation to a template-based system with disk-loaded markdown templates\n- add generic uildPrompt(templateName, context, outputPath) and extensible uildPrompts(...)\n- support placeholders: program, summary, 	ables, programCalls, copyMembers, sqlStatements, dependencyGraphSummary, sourceSnippet\n- enforce deterministic formatting (sorted lists, stable bullets, consistent output)\n- update analyze pipeline to generate prompts from unified context object only\n- update documentation and templates for easy future prompt types\n\n## Validation\n- 
pm run analyze -- --source ./rpg_sources --program ORDERPGM\n- verified generated files:\n  - i_prompt_documentation.md\n  - i_prompt_error_analysis.md\n- verified prompt placeholders are fully resolved (no {{...}})\n\nCloses #6