### PR TITLE
chore(license): standardize repository licensing to Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,3 +467,11 @@ zeus analyze --source ./rpg_sources --program ORDERPGM --optimize-context
 ## Notes
 
 This initial version is intentionally lightweight and heuristic-driven. It is designed to be easy to read, easy to extend, and safe to evolve toward deeper RPG/SQL parsing in future iterations.
+
+## License
+
+This project is licensed under the Apache License 2.0.
+
+You may use, modify, and distribute this software in accordance with the terms of the Apache License.
+
+See the LICENSE file for details.

--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -1,5 +1,19 @@
 #!/usr/bin/env node
 
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
 const fs = require('fs');
 const path = require('path');
 const { collectSourceFiles } = require('../src/collector/sourceCollector');

--- a/java/Db2MetadataExporter.java
+++ b/java/Db2MetadataExporter.java
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;

--- a/java/IbmiCommandRunner.java
+++ b/java/IbmiCommandRunner.java
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 import com.ibm.as400.access.AS400;
 import com.ibm.as400.access.AS400Message;
 import com.ibm.as400.access.CommandCall;

--- a/java/IbmiIfsDownloader.java
+++ b/java/IbmiIfsDownloader.java
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 import com.ibm.as400.access.AS400;
 import com.ibm.as400.access.IFSFile;
 import com.ibm.as400.access.IFSFileInputStream;

--- a/java/IbmiMemberLister.java
+++ b/java/IbmiMemberLister.java
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;

--- a/package.json
+++ b/package.json
@@ -20,5 +20,5 @@
   "engines": {
     "node": ">=20"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/scripts/create_issues_from_roadmap.py
+++ b/scripts/create_issues_from_roadmap.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+# Copyright 2026 Guido Zeuner
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
 import os
 import re
 import json

--- a/src/ai/contextOptimizer.js
+++ b/src/ai/contextOptimizer.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 const path = require('path');
 const { estimateTokensFromObject } = require('./tokenEstimator');

--- a/src/ai/tokenEstimator.js
+++ b/src/ai/tokenEstimator.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 function clampNumber(value, fallback) {
   const number = Number(value);
   if (!Number.isFinite(number) || number <= 0) {

--- a/src/collector/sourceCollector.js
+++ b/src/collector/sourceCollector.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 const path = require('path');
 

--- a/src/context/contextBuilder.js
+++ b/src/context/contextBuilder.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const path = require('path');
 
 function normalizeName(name) {

--- a/src/dependency/crossProgramGraphBuilder.js
+++ b/src/dependency/crossProgramGraphBuilder.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const { scanSourceFiles } = require('../scanner/rpgScanner');
 const { buildSourceIndex, normalizeProgramName, resolveProgram } = require('./programSourceResolver');
 

--- a/src/dependency/dependencyGraphBuilder.js
+++ b/src/dependency/dependencyGraphBuilder.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 function normalizeIdentifier(value) {
   return String(value || '').trim().toUpperCase();
 }

--- a/src/dependency/graphSerializer.js
+++ b/src/dependency/graphSerializer.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 function toMermaidId(value) {
   const normalized = String(value || '').trim().replace(/[^A-Za-z0-9_]/g, '_');
   if (!normalized) return 'NODE';

--- a/src/dependency/programResolver.js
+++ b/src/dependency/programResolver.js
@@ -1,1 +1,14 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 module.exports = require('./programSourceResolver');

--- a/src/dependency/programSourceResolver.js
+++ b/src/dependency/programSourceResolver.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const path = require('path');
 
 function normalizeProgramName(value) {

--- a/src/fetch/fetchService.js
+++ b/src/fetch/fetchService.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const path = require('path');
 const { listMembers } = require('./jt400CommandRunner');
 const { exportMembersForSourceFile } = require('./ifsExporter');

--- a/src/fetch/ftpDownloader.js
+++ b/src/fetch/ftpDownloader.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 const path = require('path');
 const ftp = require('basic-ftp');

--- a/src/fetch/ifsExporter.js
+++ b/src/fetch/ifsExporter.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const path = require('path');
 const { runClCommand } = require('./jt400CommandRunner');
 

--- a/src/fetch/jt400CommandRunner.js
+++ b/src/fetch/jt400CommandRunner.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');

--- a/src/fetch/jt400Downloader.js
+++ b/src/fetch/jt400Downloader.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const path = require('path');
 const { ensureJavaHelperCompiled, runJavaHelper } = require('./jt400CommandRunner');
 

--- a/src/fetch/sftpDownloader.js
+++ b/src/fetch/sftpDownloader.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 const path = require('path');
 const SftpClient = require('ssh2-sftp-client');

--- a/src/impact/impactAnalyzer.js
+++ b/src/impact/impactAnalyzer.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 
 function normalizeId(value) {

--- a/src/prompt/promptBuilder.js
+++ b/src/prompt/promptBuilder.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 const path = require('path');
 

--- a/src/report/architectureReport.js
+++ b/src/report/architectureReport.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 
 function readJsonFile(filePath) {

--- a/src/report/jsonReport.js
+++ b/src/report/jsonReport.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 
 function writeJsonReport(filePath, data) {

--- a/src/report/markdownReport.js
+++ b/src/report/markdownReport.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 function sectionList(values) {
   if (!values || values.length === 0) {
     return '- None detected';

--- a/src/scanner/dependencyScanner.js
+++ b/src/scanner/dependencyScanner.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 function normalizeName(name) {
   return String(name || '').trim().toUpperCase();
 }

--- a/src/scanner/rpgScanner.js
+++ b/src/scanner/rpgScanner.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 
 function normalizeWhitespace(text) {

--- a/src/viewer/architectureViewerGenerator.js
+++ b/src/viewer/architectureViewerGenerator.js
@@ -1,3 +1,16 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
 const fs = require('fs');
 
 const VIS_NETWORK_CDN = 'https://unpkg.com/vis-network/standalone/umd/vis-network.min.js';


### PR DESCRIPTION
## Summary
- add Apache 2.0 license headers to source files in cli/, src/, scripts/, and java/ for .js, .py, and .java
- update package.json license metadata to Apache-2.0
- add a README license section aligned with Apache 2.0 wording

## Notes
- no functional logic changes
- existing LICENSE file remains unchanged