### PR TITLE
test: add V1 acceptance smoke coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ node cli/zeus.js analyze --source ./rpg --program ORDERPGM
 npm run analyze -- --source ./rpg --program ORDERPGM
 ```
 
+Run the smoke tests with:
+
+```bash
+npm test
+```
+
 ## Usage
 
 Command syntax:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "impact": "node ./cli/zeus.js impact",
     "fetch": "node ./cli/zeus.js fetch",
     "lint": "echo \"No lint configured\"",
-    "test": "echo \"No tests configured\""
+    "test": "node --test"
   },
   "dependencies": {
     "adm-zip": "^0.5.16",

--- a/tests/fixtures/v1-smoke/src/INVPGM.rpgle
+++ b/tests/fixtures/v1-smoke/src/INVPGM.rpgle
@@ -1,0 +1,10 @@
+ctl-opt dftactgrp(*no);
+
+dcl-f INVOICE disk;
+
+dcl-proc main;
+  exec sql
+    update INVOICE
+       set STATUS = 'READY'
+     where STATUS = 'NEW';
+end-proc;

--- a/tests/fixtures/v1-smoke/src/ORDERPGM.rpgle
+++ b/tests/fixtures/v1-smoke/src/ORDERPGM.rpgle
@@ -1,0 +1,17 @@
+ctl-opt dftactgrp(*no);
+
+dcl-f ORDERS usage(*input) keyed;
+dcl-f CUSTOMER disk;
+
+/copy QRPGLESRC,ORDCOPY
+
+dcl-proc main;
+  call INVPGM;
+  callp ProcessOrder();
+
+  exec sql
+    select ORDER_ID, CUSTOMER_ID
+      from MYLIB/ORDERS
+      join CUSTOMER
+        on CUSTOMER.CUSTOMER_ID = ORDERS.CUSTOMER_ID;
+end-proc;

--- a/tests/v1-smoke.test.js
+++ b/tests/v1-smoke.test.js
@@ -1,0 +1,137 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const AdmZip = require('adm-zip');
+
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'cli', 'zeus.js');
+const fixtureRoot = path.join(__dirname, 'fixtures', 'v1-smoke', 'src');
+
+function runCli(args, cwd) {
+  return execFileSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('V1 smoke flow generates analysis artifacts and bundle outputs', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-v1-smoke-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const outputRoot = path.join(tempRoot, 'output');
+  const bundleRoot = path.join(tempRoot, 'bundles');
+
+  fs.cpSync(fixtureRoot, sourceRoot, { recursive: true });
+
+  try {
+    runCli([
+      'analyze',
+      '--source',
+      sourceRoot,
+      '--program',
+      'ORDERPGM',
+      '--out',
+      outputRoot,
+      '--optimize-context',
+      '--test-data-limit',
+      '25',
+    ], projectRoot);
+
+    const programOutputDir = path.join(outputRoot, 'ORDERPGM');
+    const expectedFiles = [
+      'context.json',
+      'optimized-context.json',
+      'report.md',
+      'architecture-report.md',
+      'ai_prompt_documentation.md',
+      'ai_prompt_error_analysis.md',
+      'dependency-graph.json',
+      'dependency-graph.md',
+      'dependency-graph.mmd',
+      'program-call-tree.json',
+      'program-call-tree.md',
+      'program-call-tree.mmd',
+      'architecture.html',
+    ];
+
+    for (const fileName of expectedFiles) {
+      assert.equal(fs.existsSync(path.join(programOutputDir, fileName)), true, `missing ${fileName}`);
+    }
+
+    const context = readJson(path.join(programOutputDir, 'context.json'));
+    assert.equal(context.program, 'ORDERPGM');
+    assert.deepEqual(
+      context.dependencies.tables.map((entry) => entry.name),
+      ['CUSTOMER', 'INVOICE', 'ORDERS'],
+    );
+    assert.deepEqual(
+      context.dependencies.programCalls.map((entry) => entry.name),
+      ['INVPGM', 'PROCESSORDER'],
+    );
+    assert.deepEqual(
+      context.dependencies.copyMembers.map((entry) => entry.name),
+      ['QRPGLESRC,ORDCOPY'],
+    );
+    assert.equal(context.sql.statements.length, 2);
+    assert.deepEqual(
+      context.sql.statements.map((statement) => statement.tables.join(',')).sort(),
+      ['CUSTOMER,ORDERS', 'INVOICE'],
+    );
+    assert.equal(context.db2Metadata.status, 'skipped');
+    assert.equal(context.testData.status, 'skipped');
+    assert.equal(context.testData.rowLimit, 25);
+    assert.match(
+      context.notes.join('\n'),
+      /Test data extraction was skipped because no DB2 connection configuration was available\./,
+    );
+
+    const optimizedContext = readJson(path.join(programOutputDir, 'optimized-context.json'));
+    assert.equal(optimizedContext.program, 'ORDERPGM');
+
+    const report = fs.readFileSync(path.join(programOutputDir, 'report.md'), 'utf8');
+    assert.match(report, /## Test Data Extract/);
+    assert.match(report, /Test data extraction was skipped because no DB2 connection configuration was available\./);
+
+    const prompt = fs.readFileSync(path.join(programOutputDir, 'ai_prompt_documentation.md'), 'utf8');
+    assert.match(prompt, /Representative sample rows are not available in this analysis run\./);
+
+    const graph = readJson(path.join(programOutputDir, 'program-call-tree.json'));
+    assert.equal(graph.summary.programCount, 3);
+    assert.equal(graph.summary.tableCount, 3);
+
+    runCli([
+      'bundle',
+      '--program',
+      'ORDERPGM',
+      '--source-output-root',
+      outputRoot,
+      '--output',
+      bundleRoot,
+    ], projectRoot);
+
+    const bundlePath = path.join(bundleRoot, 'ORDERPGM-analysis-bundle.zip');
+    assert.equal(fs.existsSync(bundlePath), true);
+
+    const manifest = readJson(path.join(programOutputDir, 'bundle-manifest.json'));
+    assert.equal(manifest.program, 'ORDERPGM');
+    assert.ok(manifest.files.includes('context.json'));
+    assert.ok(manifest.files.includes('report.md'));
+    assert.ok(manifest.files.includes('architecture.html'));
+
+    const zip = new AdmZip(bundlePath);
+    const entryNames = zip.getEntries().map((entry) => entry.entryName).sort();
+    assert.ok(entryNames.includes('context.json'));
+    assert.ok(entryNames.includes('report.md'));
+    assert.ok(entryNames.includes('architecture.html'));
+    assert.ok(entryNames.includes('manifest.json'));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a deterministic end-to-end smoke test for the V1 analyze flow using ASCII RPG fixtures
- verify generated context, prompts, reports, graphs, optimizer output, and bundle packaging on a fresh temp workspace
- wire the package test script to 
ode --test and document the smoke-test entrypoint in the README

## Verification
- cmd /c npm test

## Notes
- The only remaining open issue was epic #1. The feature set was already present in code; this change adds explicit acceptance coverage for the shipped V1 workflow and closes the epic through test-backed verification.