### PR TITLE
Add workflow presets and guided analysis bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ Command syntax:
 zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--test-data-limit <n>] [--skip-test-data] [--verbose]
 ```
 
+Workflow command syntax:
+
+```bash
+zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--list-presets] [--test-data-limit <n>] [--skip-test-data] [--verbose]
+```
+
 Guided analyze modes:
 
 - use `--list-modes` to inspect supported workflow presets
@@ -107,6 +113,15 @@ Guided analyze modes:
 - use `--mode impact` to highlight dependency artifacts and the next `zeus impact` step
 
 When a guided mode is selected, Zeus records the mode and derived behavior in `analyze-run-manifest.json`, writes `analysis-index.json`, and may auto-enable context optimization for prompt-heavy workflows.
+
+Named workflow presets build on top of those guided modes and package a shareable bundle in one step:
+
+- `architecture-review`
+- `modernization-review`
+- `onboarding`
+- `dependency-risk`
+
+Use `zeus workflow --list-presets` to inspect the available presets and `zeus workflow --preset modernization-review ...` to run analyze plus bundle with one command.
 
 Bundle command syntax:
 
@@ -202,6 +217,7 @@ Generated files:
 - `optimized-context.json` (when `--optimize-context` is enabled)
 - `ai-knowledge.json`
 - `analysis-index.json`
+- `workflow-run-manifest.json` (when `zeus workflow` is executed)
 - `report.md`
 - `architecture-report.md`
 - `ai_prompt_documentation.md`
@@ -245,6 +261,8 @@ Generated files:
 `ai-knowledge.json` is a versioned prompt-ready projection derived from the canonical model. It preserves evidence references, risk markers, uncertainty markers, and workflow-specific sections for prompt generation.
 
 `analysis-index.json` is a deterministic task-oriented index that maps common workflows to the relevant artifacts, prompt contracts, and recommended next actions.
+
+`workflow-run-manifest.json` records which named workflow preset produced the run, which guided analyze mode it resolved to, and which bundle was emitted for sharing.
 
 `canonical-analysis.json` is now the semantic source of truth for the analyze pipeline.
 
@@ -632,6 +650,7 @@ Both bundle manifest files are versioned and include:
 - included file list
 - artifact entries with `path`, `kind`, `sizeBytes`, and `sha256` when available
 - analyze-run linkage metadata when the bundle was created from an analyze manifest
+- workflow preset metadata when the bundle was created from `zeus workflow` or an analyze run tagged with a workflow preset
 
 Examples:
 
@@ -639,6 +658,7 @@ Examples:
 zeus bundle --program ORDERPGM
 zeus bundle --program ORDERPGM --output ./bundles --include-json
 zeus bundle --program ORDERPGM --source-output-root ./output --verbose
+zeus workflow --preset architecture-review --source ./rpg_sources --program ORDERPGM
 ```
 
 Produces:

--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -144,6 +144,12 @@ Target outcome:
 - developers choose a task, not a pile of files
 - broad search and targeted diagnostics sit next to semantic analysis instead of outside it
 
+Current workflow packaging now includes:
+
+- guided analyze modes for architecture, documentation, defect/error analysis, modernization, and impact
+- named workflow presets for `architecture-review`, `modernization-review`, `onboarding`, and `dependency-risk`
+- workflow-tagged bundle manifests so shared archives can describe which preset produced them
+
 ### Track E: AI Knowledge Projection and Safe Sharing
 
 The AI layer must improve in two directions at once: better evidence and safer outputs.

--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -18,10 +18,12 @@ const { runAnalyze } = require('../src/cli/commands/analyzeCommand');
 const { runImpact } = require('../src/cli/commands/impactCommand');
 const { runBundle } = require('../src/cli/commands/bundleCommand');
 const { runFetch } = require('../src/cli/commands/fetchCommand');
+const { runWorkflow } = require('../src/cli/commands/workflowCommand');
 
 function printHelp() {
   console.log('Usage:');
   console.log('  zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
+  console.log('  zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.rpg] [--list-presets] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
   console.log('  zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--profile <name>] [--verbose]');
   console.log('  zeus impact --target <name> [--program <name>] [--out <path>] [--profile <name>] [--source <path>] [--verbose]');
   console.log('  zeus fetch --host <hostname> --user <username> --password <password> --source-lib <lib> --ifs-dir <ifsPath> --out <localPath> [--files <list>] [--members <list>] [--replace true|false] [--streamfile-ccsid <ccsid>] [--transport auto|sftp|jt400|ftp] [--profile <name>] [--verbose]');
@@ -64,6 +66,11 @@ async function main() {
 
   if (command === 'bundle') {
     runBundle(args);
+    return;
+  }
+
+  if (command === 'workflow') {
+    runWorkflow(args);
     return;
   }
 

--- a/src/analyze/analyzeRunManifest.js
+++ b/src/analyze/analyzeRunManifest.js
@@ -189,6 +189,7 @@ function buildAnalyzeRunManifest({
         testDataLimit: Number(context.testDataLimit) || null,
         extensions: Array.isArray(context.extensions) ? context.extensions : [],
         guidedMode: context.guidedMode || null,
+        workflowPreset: context.workflowPreset || null,
       },
       sourceSnapshot,
     },

--- a/src/bundle/outputBundleBuilder.js
+++ b/src/bundle/outputBundleBuilder.js
@@ -80,6 +80,16 @@ function mapBundleFiles(programOutputDir, fileNames, includeTypes) {
     }));
 }
 
+function collectExplicitBundleFiles(programOutputDir, includeTypes, artifactPaths) {
+  return mapBundleFiles(
+    programOutputDir,
+    Array.from(new Set((Array.isArray(artifactPaths) ? artifactPaths : [])
+      .map((entry) => String(entry || '').trim())
+      .filter(Boolean))),
+    includeTypes,
+  ).filter((file) => fs.existsSync(file.path));
+}
+
 function collectLegacyBundleFiles(programOutputDir, includeTypes) {
   return mapBundleFiles(
     programOutputDir,
@@ -143,7 +153,7 @@ function buildArtifactMetadata(files, analyzeManifest) {
   });
 }
 
-function buildManifest(program, files, analyzeManifest) {
+function buildManifest(program, files, analyzeManifest, workflowPreset) {
   const artifacts = buildArtifactMetadata(files, analyzeManifest);
   const manifest = {
     schemaVersion: BUNDLE_MANIFEST_SCHEMA_VERSION,
@@ -176,16 +186,45 @@ function buildManifest(program, files, analyzeManifest) {
     };
   }
 
+  const effectiveWorkflowPreset = workflowPreset
+    || (analyzeManifest
+      && analyzeManifest.inputs
+      && analyzeManifest.inputs.options
+      && analyzeManifest.inputs.options.workflowPreset
+      ? analyzeManifest.inputs.options.workflowPreset
+      : null);
+  if (effectiveWorkflowPreset) {
+    manifest.workflowPreset = {
+      name: effectiveWorkflowPreset.name || null,
+      title: effectiveWorkflowPreset.title || null,
+      description: effectiveWorkflowPreset.description || null,
+      analyzeMode: effectiveWorkflowPreset.analyzeMode || null,
+      promptTemplates: Array.isArray(effectiveWorkflowPreset.promptTemplates)
+        ? effectiveWorkflowPreset.promptTemplates
+        : [],
+      workflowKeys: Array.isArray(effectiveWorkflowPreset.workflowKeys)
+        ? effectiveWorkflowPreset.workflowKeys
+        : [],
+      bundleArtifacts: Array.isArray(effectiveWorkflowPreset.bundleArtifacts)
+        ? effectiveWorkflowPreset.bundleArtifacts
+        : [],
+    };
+  }
+
   return manifest;
 }
 
 function buildReadmeText(program, manifest) {
-  return [
+  const lines = [
     `Program: ${normalizeProgramName(program).toUpperCase()}`,
     'Created by: zeus-rpg-promptkit',
     'Contents: reports, prompts, graphs, metadata',
     `Files: ${manifest.summary.totalFiles}`,
-  ].join('\n');
+  ];
+  if (manifest.workflowPreset && manifest.workflowPreset.name) {
+    lines.push(`Workflow preset: ${manifest.workflowPreset.name}`);
+  }
+  return lines.join('\n');
 }
 
 function addZipEntry(zip, entryName, content) {
@@ -203,6 +242,9 @@ function buildOutputBundle({
   includeJson = false,
   includeMd = false,
   includeHtml = false,
+  artifactPaths = null,
+  workflowPreset = null,
+  bundleFileName = null,
 }) {
   const resolvedProgram = normalizeProgramName(program);
   if (!resolvedProgram) {
@@ -219,8 +261,10 @@ function buildOutputBundle({
 
   const includeTypes = resolveIncludeTypes({ includeJson, includeMd, includeHtml });
   const analyzeManifest = readAnalyzeRunManifest(programOutputDir);
-  const files = collectManifestBundleFiles(programOutputDir, includeTypes, analyzeManifest);
-  const manifest = buildManifest(resolvedProgram, files, analyzeManifest);
+  const files = Array.isArray(artifactPaths) && artifactPaths.length > 0
+    ? collectExplicitBundleFiles(programOutputDir, includeTypes, artifactPaths)
+    : collectManifestBundleFiles(programOutputDir, includeTypes, analyzeManifest);
+  const manifest = buildManifest(resolvedProgram, files, analyzeManifest, workflowPreset);
   const zip = new AdmZip();
 
   for (const file of files) {
@@ -233,7 +277,12 @@ function buildOutputBundle({
   fs.mkdirSync(resolvedBundleRoot, { recursive: true });
   fs.writeFileSync(path.join(programOutputDir, MANIFEST_FILE), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
 
-  const zipPath = path.join(resolvedBundleRoot, `${resolvedProgram}-analysis-bundle.zip`);
+  const zipPath = path.join(
+    resolvedBundleRoot,
+    bundleFileName && String(bundleFileName).trim()
+      ? String(bundleFileName).trim()
+      : `${resolvedProgram}-analysis-bundle.zip`,
+  );
   zip.writeZip(zipPath);
 
   return {

--- a/src/cli/commands/analyzeCommand.js
+++ b/src/cli/commands/analyzeCommand.js
@@ -69,6 +69,14 @@ function runAnalyze(args) {
   const sourceRoot = path.resolve(process.cwd(), config.sourceRoot);
   const outputRoot = path.resolve(process.cwd(), config.outputRoot);
   const program = String(args.program).trim();
+  const workflowPreset = args['workflow-preset-settings'] && typeof args['workflow-preset-settings'] === 'object'
+    ? {
+      ...args['workflow-preset-settings'],
+      promptTemplates: [...(args['workflow-preset-settings'].promptTemplates || [])],
+      workflowKeys: [...(args['workflow-preset-settings'].workflowKeys || [])],
+      bundleArtifacts: [...(args['workflow-preset-settings'].bundleArtifacts || [])],
+    }
+    : null;
   let workflowModeSettings = null;
   if (args.mode) {
     try {
@@ -106,6 +114,9 @@ function runAnalyze(args) {
   if (guidedMode) {
     logVerbose(`Workflow mode: ${guidedMode.name}`);
     logVerbose(`Workflow prompt templates: ${promptTemplates.length > 0 ? promptTemplates.join(', ') : 'none'}`);
+  }
+  if (workflowPreset) {
+    logVerbose(`Workflow preset: ${workflowPreset.name}`);
   }
 
   if (!fs.existsSync(sourceRoot)) {
@@ -154,6 +165,7 @@ function runAnalyze(args) {
         testDataLimit,
         extensions: config.extensions,
         guidedMode,
+        workflowPreset,
       },
       result,
       previousManifest,
@@ -177,6 +189,7 @@ function runAnalyze(args) {
         testDataLimit,
         extensions: config.extensions,
         guidedMode,
+        workflowPreset,
       },
       error,
       previousManifest,
@@ -188,6 +201,9 @@ function runAnalyze(args) {
   console.log(`Analysis complete for program ${program}`);
   if (guidedMode) {
     console.log(`Guided mode: ${guidedMode.name}`);
+  }
+  if (workflowPreset) {
+    console.log(`Workflow preset: ${workflowPreset.name}`);
   }
   console.log(`Source files scanned: ${(result.scanSummary.sourceFiles || []).length}`);
   if (result.optimizationReport.enabled) {

--- a/src/cli/commands/bundleCommand.js
+++ b/src/cli/commands/bundleCommand.js
@@ -30,6 +30,9 @@ function runBundle(args) {
     includeJson: args['include-json'] === true,
     includeMd: args['include-md'] === true,
     includeHtml: args['include-html'] === true,
+    artifactPaths: Array.isArray(args['artifact-paths']) ? args['artifact-paths'] : null,
+    workflowPreset: args['workflow-preset-settings'] || null,
+    bundleFileName: args['bundle-file-name'] || null,
   });
 
   if (verbose) {
@@ -40,6 +43,7 @@ function runBundle(args) {
   console.log(`Bundle created for program ${result.program}`);
   console.log(`Files included: ${result.manifest.summary.totalFiles}`);
   console.log(`Bundle written to: ${result.zipPath}`);
+  return result;
 }
 
 module.exports = {

--- a/src/cli/commands/workflowCommand.js
+++ b/src/cli/commands/workflowCommand.js
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const path = require('path');
+const { readAnalyzeRunManifest } = require('../../analyze/analyzeRunManifest');
+const { runAnalyze } = require('./analyzeCommand');
+const { runBundle } = require('./bundleCommand');
+const { resolveAnalyzeConfig } = require('../../config/runtimeConfig');
+const { resolveWorkflowPresetSettings, listWorkflowPresets } = require('../../workflow/workflowPresetRegistry');
+const { buildWorkflowRunManifest, writeWorkflowRunManifest } = require('../../workflow/workflowRunManifest');
+
+function printWorkflowPresets() {
+  console.log('Supported workflow presets:');
+  for (const preset of listWorkflowPresets()) {
+    const settings = resolveWorkflowPresetSettings(preset.name);
+    console.log(`- ${preset.name}: ${preset.description}`);
+    console.log(`  analyze mode: ${settings.analyzeMode}`);
+    console.log(`  prompt templates: ${settings.promptTemplates.length > 0 ? settings.promptTemplates.join(', ') : 'none'}`);
+    console.log(`  bundle artifacts: ${settings.bundleArtifacts.length}`);
+  }
+}
+
+function runWorkflow(args) {
+  if (args['list-presets']) {
+    printWorkflowPresets();
+    return;
+  }
+
+  if (!args.preset || !String(args.preset).trim()) {
+    console.error('Missing required option: --preset <name>');
+    process.exit(2);
+  }
+
+  let preset;
+  try {
+    preset = resolveWorkflowPresetSettings(args.preset);
+  } catch (error) {
+    console.error(`${error.message}. Use --list-presets to inspect supported workflow presets.`);
+    process.exit(2);
+  }
+
+  const analyzeArgs = {
+    ...args,
+    mode: preset.analyzeMode,
+    'workflow-preset-settings': preset,
+  };
+  delete analyzeArgs.preset;
+  delete analyzeArgs['list-presets'];
+  delete analyzeArgs['bundle-output'];
+
+  runAnalyze(analyzeArgs);
+
+  const analyzeConfig = resolveAnalyzeConfig(analyzeArgs);
+  const outputRoot = path.resolve(process.cwd(), analyzeConfig.outputRoot);
+  const outputProgramDir = path.join(outputRoot, String(args.program || '').trim());
+  const analyzeManifest = readAnalyzeRunManifest(outputProgramDir);
+  const bundleResult = runBundle({
+    program: args.program,
+    profile: args.profile,
+    'source-output-root': outputRoot,
+    output: args['bundle-output'],
+    'artifact-paths': preset.bundleArtifacts,
+    'bundle-file-name': `${String(args.program || '').trim()}-${preset.bundleFileName}`,
+    'workflow-preset-settings': preset,
+    verbose: args.verbose,
+  });
+
+  const workflowManifest = buildWorkflowRunManifest({
+    preset,
+    analyzeManifest,
+    bundleManifest: bundleResult.manifest,
+    bundlePath: bundleResult.zipPath,
+  });
+  writeWorkflowRunManifest(outputProgramDir, workflowManifest);
+
+  console.log(`Workflow preset complete: ${preset.name}`);
+  console.log(`Workflow manifest written to: ${path.join(outputProgramDir, 'workflow-run-manifest.json')}`);
+}
+
+module.exports = {
+  runWorkflow,
+};

--- a/src/workflow/workflowPresetRegistry.js
+++ b/src/workflow/workflowPresetRegistry.js
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const { resolveWorkflowModeSettings } = require('./workflowModeRegistry');
+
+const WORKFLOW_PRESET_REGISTRY = Object.freeze({
+  'architecture-review': Object.freeze({
+    name: 'architecture-review',
+    title: 'Architecture Review',
+    description: 'Run a structure-first analysis and package graph, architecture, and documentation artifacts together.',
+    analyzeMode: 'architecture',
+    bundleArtifacts: Object.freeze([
+      'analyze-run-manifest.json',
+      'analysis-index.json',
+      'canonical-analysis.json',
+      'ai-knowledge.json',
+      'architecture-report.md',
+      'dependency-graph.md',
+      'program-call-tree.md',
+      'architecture.html',
+      'ai_prompt_documentation.md',
+    ]),
+  }),
+  'modernization-review': Object.freeze({
+    name: 'modernization-review',
+    title: 'Modernization Review',
+    description: 'Bundle modernization prompts, semantic architecture evidence, and change-boundary artifacts.',
+    analyzeMode: 'modernization',
+    bundleArtifacts: Object.freeze([
+      'analyze-run-manifest.json',
+      'analysis-index.json',
+      'canonical-analysis.json',
+      'ai-knowledge.json',
+      'architecture-report.md',
+      'report.md',
+      'program-call-tree.md',
+      'ai_prompt_documentation.md',
+      'ai_prompt_modernization.md',
+    ]),
+  }),
+  onboarding: Object.freeze({
+    name: 'onboarding',
+    title: 'Onboarding',
+    description: 'Produce a concise starter bundle for engineers who need orientation and documentation quickly.',
+    analyzeMode: 'documentation',
+    bundleArtifacts: Object.freeze([
+      'analyze-run-manifest.json',
+      'analysis-index.json',
+      'context.json',
+      'ai-knowledge.json',
+      'report.md',
+      'architecture-report.md',
+      'ai_prompt_documentation.md',
+    ]),
+  }),
+  'dependency-risk': Object.freeze({
+    name: 'dependency-risk',
+    title: 'Dependency Risk',
+    description: 'Package defect-oriented prompts and dependency artifacts for risk review and follow-up investigation.',
+    analyzeMode: 'defect-analysis',
+    bundleArtifacts: Object.freeze([
+      'analyze-run-manifest.json',
+      'analysis-index.json',
+      'canonical-analysis.json',
+      'ai-knowledge.json',
+      'report.md',
+      'dependency-graph.json',
+      'dependency-graph.md',
+      'program-call-tree.json',
+      'program-call-tree.md',
+      'ai_prompt_error_analysis.md',
+      'ai_prompt_defect_analysis.md',
+    ]),
+  }),
+});
+
+function normalizeWorkflowPresetName(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function getWorkflowPreset(presetName) {
+  const normalized = normalizeWorkflowPresetName(presetName);
+  const preset = WORKFLOW_PRESET_REGISTRY[normalized];
+  if (!preset) {
+    throw new Error(`Unknown workflow preset: ${presetName}`);
+  }
+  return preset;
+}
+
+function listWorkflowPresets() {
+  return Object.values(WORKFLOW_PRESET_REGISTRY);
+}
+
+function resolveWorkflowPresetSettings(presetName) {
+  if (!presetName) {
+    return null;
+  }
+
+  const preset = getWorkflowPreset(presetName);
+  const guidedMode = resolveWorkflowModeSettings(preset.analyzeMode);
+
+  return {
+    name: preset.name,
+    title: preset.title,
+    description: preset.description,
+    analyzeMode: guidedMode.name,
+    guidedMode,
+    promptTemplates: [...guidedMode.promptTemplates],
+    workflowKeys: [...guidedMode.workflowKeys],
+    autoOptimizeContext: Boolean(guidedMode.autoOptimizeContext),
+    bundleArtifacts: [...preset.bundleArtifacts],
+    bundleFileName: `${preset.name}-bundle.zip`,
+  };
+}
+
+module.exports = {
+  getWorkflowPreset,
+  listWorkflowPresets,
+  normalizeWorkflowPresetName,
+  resolveWorkflowPresetSettings,
+  WORKFLOW_PRESET_REGISTRY,
+};

--- a/src/workflow/workflowRunManifest.js
+++ b/src/workflow/workflowRunManifest.js
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_RUN_MANIFEST_FILE = 'workflow-run-manifest.json';
+const WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION = 1;
+
+function buildWorkflowRunManifest({ preset, analyzeManifest, bundleManifest, bundlePath }) {
+  return {
+    schemaVersion: WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION,
+    kind: 'workflow-run-manifest',
+    generatedAt: new Date().toISOString(),
+    program: analyzeManifest && analyzeManifest.inputs ? analyzeManifest.inputs.program : null,
+    preset: preset ? {
+      name: preset.name,
+      title: preset.title,
+      description: preset.description,
+      analyzeMode: preset.analyzeMode,
+      promptTemplates: [...(preset.promptTemplates || [])],
+      workflowKeys: [...(preset.workflowKeys || [])],
+      bundleArtifacts: [...(preset.bundleArtifacts || [])],
+    } : null,
+    analyzeRun: analyzeManifest ? {
+      manifestFile: 'analyze-run-manifest.json',
+      status: analyzeManifest.run ? analyzeManifest.run.status : null,
+      completedAt: analyzeManifest.run ? analyzeManifest.run.completedAt : null,
+      generatedArtifactCount: analyzeManifest.summary ? analyzeManifest.summary.generatedArtifactCount : 0,
+      guidedMode: analyzeManifest.inputs && analyzeManifest.inputs.options
+        ? analyzeManifest.inputs.options.guidedMode
+        : null,
+    } : null,
+    bundle: bundleManifest ? {
+      manifestFile: 'bundle-manifest.json',
+      zipPath: bundlePath ? path.basename(bundlePath) : null,
+      totalFiles: bundleManifest.summary ? bundleManifest.summary.totalFiles : 0,
+      totalSizeBytes: bundleManifest.summary ? bundleManifest.summary.totalSizeBytes : 0,
+    } : null,
+  };
+}
+
+function writeWorkflowRunManifest(outputProgramDir, manifest) {
+  const manifestPath = path.join(outputProgramDir, WORKFLOW_RUN_MANIFEST_FILE);
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  return manifestPath;
+}
+
+module.exports = {
+  WORKFLOW_RUN_MANIFEST_FILE,
+  WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION,
+  buildWorkflowRunManifest,
+  writeWorkflowRunManifest,
+};

--- a/tests/bundle-manifest.test.js
+++ b/tests/bundle-manifest.test.js
@@ -92,3 +92,68 @@ test('buildOutputBundle prefers analyze-run-manifest artifacts over directory sc
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
 });
+
+test('buildOutputBundle can package explicit workflow preset artifacts with preset metadata', () => {
+  const { tempRoot, outputRoot, bundleRoot, programOutputDir } = createTempBundleProject();
+
+  try {
+    fs.writeFileSync(path.join(programOutputDir, 'analysis-index.json'), '{"kind":"analysis-task-index"}\n', 'utf8');
+    fs.writeFileSync(path.join(programOutputDir, 'report.md'), '# Report\n', 'utf8');
+    fs.writeFileSync(path.join(programOutputDir, 'context.json'), '{"program":"ORDERPGM"}\n', 'utf8');
+    fs.writeFileSync(path.join(programOutputDir, 'analyze-run-manifest.json'), `${JSON.stringify({
+      run: {
+        status: 'succeeded',
+        completedAt: '2026-04-09T10:00:00.000Z',
+      },
+      inputs: {
+        options: {
+          workflowPreset: {
+            name: 'onboarding',
+            title: 'Onboarding',
+            analyzeMode: 'documentation',
+            promptTemplates: ['documentation'],
+            workflowKeys: ['documentation'],
+            bundleArtifacts: ['analyze-run-manifest.json', 'analysis-index.json', 'report.md'],
+          },
+        },
+        sourceSnapshot: {
+          fingerprint: 'wf-123',
+        },
+      },
+      artifacts: [
+        { path: 'analysis-index.json', kind: 'json', sizeBytes: 32, sha256: 'a' },
+        { path: 'report.md', kind: 'markdown', sizeBytes: 9, sha256: 'b' },
+        { path: 'context.json', kind: 'json', sizeBytes: 24, sha256: 'c' },
+      ],
+    }, null, 2)}\n`, 'utf8');
+
+    const result = buildOutputBundle({
+      program: 'ORDERPGM',
+      sourceOutputRoot: outputRoot,
+      bundleOutputRoot: bundleRoot,
+      artifactPaths: ['analyze-run-manifest.json', 'analysis-index.json', 'report.md'],
+      bundleFileName: 'ORDERPGM-onboarding-bundle.zip',
+    });
+
+    assert.deepEqual(result.manifest.files, [
+      'analysis-index.json',
+      'analyze-run-manifest.json',
+      'report.md',
+    ]);
+    assert.equal(result.manifest.workflowPreset.name, 'onboarding');
+    assert.deepEqual(result.manifest.workflowPreset.promptTemplates, ['documentation']);
+    assert.equal(path.basename(result.zipPath), 'ORDERPGM-onboarding-bundle.zip');
+
+    const zip = new AdmZip(result.zipPath);
+    const entryNames = zip.getEntries().map((entry) => entry.entryName).sort();
+    assert.deepEqual(entryNames, [
+      'README.txt',
+      'analysis-index.json',
+      'analyze-run-manifest.json',
+      'manifest.json',
+      'report.md',
+    ]);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/workflow-presets.test.js
+++ b/tests/workflow-presets.test.js
@@ -1,0 +1,90 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const AdmZip = require('adm-zip');
+
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'cli', 'zeus.js');
+const fixtureRoot = path.join(__dirname, 'fixtures', 'v1-smoke', 'src');
+
+function runCli(args, cwd) {
+  return execFileSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('workflow --list-presets exposes named guided workflow bundles', () => {
+  const output = runCli(['workflow', '--list-presets'], projectRoot);
+  assert.match(output, /Supported workflow presets:/);
+  assert.match(output, /- architecture-review:/);
+  assert.match(output, /- modernization-review:/);
+  assert.match(output, /- onboarding:/);
+  assert.match(output, /- dependency-risk:/);
+});
+
+test('workflow preset runs analyze plus bundle and records preset metadata in manifests', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-workflow-preset-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const outputRoot = path.join(tempRoot, 'output');
+  const bundleRoot = path.join(tempRoot, 'bundles');
+
+  fs.cpSync(fixtureRoot, sourceRoot, { recursive: true });
+
+  try {
+    runCli([
+      'workflow',
+      '--preset',
+      'modernization-review',
+      '--source',
+      sourceRoot,
+      '--program',
+      'ORDERPGM',
+      '--out',
+      outputRoot,
+      '--bundle-output',
+      bundleRoot,
+    ], projectRoot);
+
+    const programOutputDir = path.join(outputRoot, 'ORDERPGM');
+    const analyzeManifest = readJson(path.join(programOutputDir, 'analyze-run-manifest.json'));
+    const workflowManifest = readJson(path.join(programOutputDir, 'workflow-run-manifest.json'));
+    const bundleManifest = readJson(path.join(programOutputDir, 'bundle-manifest.json'));
+    const bundlePath = path.join(bundleRoot, 'ORDERPGM-modernization-review-bundle.zip');
+
+    assert.equal(analyzeManifest.inputs.options.guidedMode.name, 'modernization');
+    assert.equal(analyzeManifest.inputs.options.workflowPreset.name, 'modernization-review');
+    assert.deepEqual(
+      analyzeManifest.inputs.options.workflowPreset.promptTemplates,
+      ['documentation', 'modernization'],
+    );
+
+    assert.equal(workflowManifest.kind, 'workflow-run-manifest');
+    assert.equal(workflowManifest.preset.name, 'modernization-review');
+    assert.equal(workflowManifest.preset.analyzeMode, 'modernization');
+    assert.equal(workflowManifest.bundle.zipPath, 'ORDERPGM-modernization-review-bundle.zip');
+
+    assert.equal(bundleManifest.workflowPreset.name, 'modernization-review');
+    assert.equal(bundleManifest.workflowPreset.analyzeMode, 'modernization');
+    assert.ok(bundleManifest.files.includes('ai_prompt_modernization.md'));
+    assert.ok(bundleManifest.files.includes('architecture-report.md'));
+    assert.equal(bundleManifest.files.includes('context.json'), false);
+    assert.equal(fs.existsSync(bundlePath), true);
+
+    const zip = new AdmZip(bundlePath);
+    const entryNames = zip.getEntries().map((entry) => entry.entryName).sort();
+    assert.ok(entryNames.includes('ai_prompt_modernization.md'));
+    assert.ok(entryNames.includes('architecture-report.md'));
+    assert.equal(entryNames.includes('context.json'), false);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a new zeus workflow command that runs named workflow presets on top of the existing guided analyze modes
- introduce reusable workflow preset definitions for architecture review, modernization review, onboarding, and dependency risk
- carry workflow preset metadata into analyze and bundle manifests, emit workflow-run-manifest.json, and support explicit preset bundle artifact selection

## Testing
- node --test tests/bundle-manifest.test.js
- node --test tests/task-oriented-analysis-index.test.js
- node --test tests/workflow-presets.test.js
- node --test tests/v1-smoke.test.js
- npm test

Closes #50