### PR TITLE
Add review metadata to guided workflows and shareable bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ Named workflow presets build on top of those guided modes and package a shareabl
 
 Use `zeus workflow --list-presets` to inspect the available presets and `zeus workflow --preset modernization-review ...` to run analyze plus bundle with one command.
 
+Guided modes and workflow presets now also expose opinionated review metadata:
+
+- intended audience
+- key questions answered
+- expected decisions
+- interpretation guidance
+- recommended outputs for sharing
+
+`zeus analyze --list-modes` and `zeus workflow --list-presets` print the audience and decision framing so users can choose a workflow by review intent, not only by file list.
+
 Bundle command syntax:
 
 ```bash
@@ -260,9 +270,9 @@ Generated files:
 
 `ai-knowledge.json` is a versioned prompt-ready projection derived from the canonical model. It preserves evidence references, risk markers, uncertainty markers, and workflow-specific sections for prompt generation.
 
-`analysis-index.json` is a deterministic task-oriented index that maps common workflows to the relevant artifacts, prompt contracts, and recommended next actions.
+`analysis-index.json` is a deterministic task-oriented index that maps common workflows to the relevant artifacts, prompt contracts, intended audience, expected decisions, interpretation guidance, and recommended next actions.
 
-`workflow-run-manifest.json` records which named workflow preset produced the run, which guided analyze mode it resolved to, and which bundle was emitted for sharing.
+`workflow-run-manifest.json` records which named workflow preset produced the run, which guided analyze mode it resolved to, which review metadata shaped the run, and which bundle was emitted for sharing.
 
 `canonical-analysis.json` is now the semantic source of truth for the analyze pipeline.
 
@@ -639,7 +649,7 @@ If any include filter is passed, only the selected file types are packaged.
 The ZIP also contains:
 
 - `manifest.json` with the included file list and summary counts
-- `README.txt` with a short bundle description
+- `README.txt` with a short bundle description, intended audience, expected decisions, interpretation guidance, and recommended outputs for the selected workflow preset
 
 `zeus bundle` also writes `bundle-manifest.json` to `output/<program>/` for local reference.
 
@@ -650,7 +660,7 @@ Both bundle manifest files are versioned and include:
 - included file list
 - artifact entries with `path`, `kind`, `sizeBytes`, and `sha256` when available
 - analyze-run linkage metadata when the bundle was created from an analyze manifest
-- workflow preset metadata when the bundle was created from `zeus workflow` or an analyze run tagged with a workflow preset
+- workflow preset metadata, including intended audience, key questions answered, expected decisions, interpretation guidance, and recommended outputs, when the bundle was created from `zeus workflow` or an analyze run tagged with a workflow preset
 
 Examples:
 

--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -149,6 +149,7 @@ Current workflow packaging now includes:
 - guided analyze modes for architecture, documentation, defect/error analysis, modernization, and impact
 - named workflow presets for `architecture-review`, `modernization-review`, `onboarding`, and `dependency-risk`
 - workflow-tagged bundle manifests so shared archives can describe which preset produced them
+- review-oriented metadata on modes and presets so manifests, analysis indexes, and shared bundle README files identify intended audience, key questions, expected decisions, interpretation guidance, and recommended outputs
 
 ### Track E: AI Knowledge Projection and Safe Sharing
 

--- a/src/analyze/analyzePipeline.js
+++ b/src/analyze/analyzePipeline.js
@@ -450,6 +450,7 @@ function writeArtifactsStage(state) {
     promptTemplates,
     workflowMode,
     workflowModeSettings,
+    workflowPreset,
   } = state;
   const selectedPromptTemplates = resolvePromptTemplates(promptTemplates);
 
@@ -519,6 +520,7 @@ function writeArtifactsStage(state) {
     generatedFiles,
     selectedMode: workflowMode,
     derivedModeSettings: workflowModeSettings,
+    selectedPreset: workflowPreset,
   });
   writeJsonReport(path.join(outputProgramDir, 'analysis-index.json'), analysisIndex);
 
@@ -531,6 +533,7 @@ function writeArtifactsStage(state) {
       fileCount: generatedFiles.length,
       generatedFiles,
       workflowMode: workflowMode || null,
+      workflowPreset: workflowPreset ? workflowPreset.name : null,
       promptTemplateCount: selectedPromptTemplates.length,
     },
   };

--- a/src/bundle/outputBundleBuilder.js
+++ b/src/bundle/outputBundleBuilder.js
@@ -19,6 +19,7 @@ const {
   ANALYZE_RUN_MANIFEST_FILE,
   readAnalyzeRunManifest,
 } = require('../analyze/analyzeRunManifest');
+const { cloneReviewWorkflow } = require('../workflow/reviewWorkflowMetadata');
 
 const MANIFEST_FILE = 'bundle-manifest.json';
 const ZIP_MANIFEST_FILE = 'manifest.json';
@@ -208,6 +209,7 @@ function buildManifest(program, files, analyzeManifest, workflowPreset) {
       bundleArtifacts: Array.isArray(effectiveWorkflowPreset.bundleArtifacts)
         ? effectiveWorkflowPreset.bundleArtifacts
         : [],
+      reviewWorkflow: cloneReviewWorkflow(effectiveWorkflowPreset.reviewWorkflow),
     };
   }
 
@@ -223,6 +225,36 @@ function buildReadmeText(program, manifest) {
   ];
   if (manifest.workflowPreset && manifest.workflowPreset.name) {
     lines.push(`Workflow preset: ${manifest.workflowPreset.name}`);
+  }
+  if (manifest.workflowPreset && manifest.workflowPreset.reviewWorkflow) {
+    const reviewWorkflow = manifest.workflowPreset.reviewWorkflow;
+    if (reviewWorkflow.intendedAudience.length > 0) {
+      lines.push(`Intended audience: ${reviewWorkflow.intendedAudience.join('; ')}`);
+    }
+    if (reviewWorkflow.keyQuestionsAnswered.length > 0) {
+      lines.push('Key questions answered:');
+      for (const question of reviewWorkflow.keyQuestionsAnswered) {
+        lines.push(`- ${question}`);
+      }
+    }
+    if (reviewWorkflow.expectedDecisions.length > 0) {
+      lines.push('Expected decisions:');
+      for (const decision of reviewWorkflow.expectedDecisions) {
+        lines.push(`- ${decision}`);
+      }
+    }
+    if (reviewWorkflow.interpretationGuidance.length > 0) {
+      lines.push('Interpretation guidance:');
+      for (const guidance of reviewWorkflow.interpretationGuidance) {
+        lines.push(`- ${guidance}`);
+      }
+    }
+    if (reviewWorkflow.recommendedOutputs.length > 0) {
+      lines.push('Recommended outputs:');
+      for (const output of reviewWorkflow.recommendedOutputs) {
+        lines.push(`- ${output.path}: ${output.purpose}`);
+      }
+    }
   }
   return lines.join('\n');
 }

--- a/src/cli/commands/analyzeCommand.js
+++ b/src/cli/commands/analyzeCommand.js
@@ -38,6 +38,10 @@ function printWorkflowModes() {
     console.log(`- ${mode.name}: ${mode.description}`);
     console.log(`  auto-optimize-context: ${mode.autoOptimizeContext ? 'yes' : 'no'}`);
     console.log(`  prompt templates: ${templates.length > 0 ? templates.join(', ') : 'none'}`);
+    if (mode.reviewWorkflow) {
+      console.log(`  intended audience: ${(mode.reviewWorkflow.intendedAudience || []).join('; ') || 'n/a'}`);
+      console.log(`  expected decisions: ${(mode.reviewWorkflow.expectedDecisions || []).join('; ') || 'n/a'}`);
+    }
   }
 }
 
@@ -146,6 +150,7 @@ function runAnalyze(args) {
       workflowMode: guidedMode ? guidedMode.name : null,
       workflowModeSettings: guidedMode,
       promptTemplates,
+      workflowPreset,
       logVerbose,
     });
     const durationMs = Number((process.hrtime.bigint() - startedNs) / 1000000n);

--- a/src/cli/commands/workflowCommand.js
+++ b/src/cli/commands/workflowCommand.js
@@ -27,6 +27,10 @@ function printWorkflowPresets() {
     console.log(`  analyze mode: ${settings.analyzeMode}`);
     console.log(`  prompt templates: ${settings.promptTemplates.length > 0 ? settings.promptTemplates.join(', ') : 'none'}`);
     console.log(`  bundle artifacts: ${settings.bundleArtifacts.length}`);
+    if (settings.reviewWorkflow) {
+      console.log(`  intended audience: ${(settings.reviewWorkflow.intendedAudience || []).join('; ') || 'n/a'}`);
+      console.log(`  expected decisions: ${(settings.reviewWorkflow.expectedDecisions || []).join('; ') || 'n/a'}`);
+    }
   }
 }
 

--- a/src/workflow/analysisIndex.js
+++ b/src/workflow/analysisIndex.js
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 const { getPromptContract } = require('../prompt/promptRegistry');
 const { validatePromptApplicability } = require('../prompt/promptBuilder');
 const { listWorkflowModes, normalizeWorkflowModeName } = require('./workflowModeRegistry');
+const { cloneReviewWorkflow } = require('./reviewWorkflowMetadata');
 
 const ANALYSIS_INDEX_SCHEMA_VERSION = 1;
 
@@ -151,6 +152,7 @@ function buildTask(mode, aiKnowledge, context, generatedFiles, selectedMode) {
     autoOptimizeContext: Boolean(mode.autoOptimizeContext),
     prompts: promptEntries,
     artifacts: buildArtifactRefs(mode.primaryArtifacts, generatedFiles),
+    reviewWorkflow: cloneReviewWorkflow(mode.reviewWorkflow),
     evidenceSummary: buildEvidenceSummary(mode, aiKnowledge, context),
     nextActions: buildNextActions(mode, context && context.program),
   };
@@ -163,8 +165,32 @@ function buildGuidedModeSummary(modes, selectedMode) {
     description: mode.description,
     autoOptimizeContext: Boolean(mode.autoOptimizeContext),
     promptTemplates: [...mode.promptTemplates],
+    reviewWorkflow: cloneReviewWorkflow(mode.reviewWorkflow),
     selected: normalizeWorkflowModeName(selectedMode) === mode.name,
   }));
+}
+
+function buildSelectedPresetSummary(selectedPreset) {
+  if (!selectedPreset || typeof selectedPreset !== 'object') {
+    return null;
+  }
+
+  return {
+    name: selectedPreset.name || null,
+    title: selectedPreset.title || null,
+    description: selectedPreset.description || null,
+    analyzeMode: selectedPreset.analyzeMode || null,
+    promptTemplates: Array.isArray(selectedPreset.promptTemplates)
+      ? [...selectedPreset.promptTemplates]
+      : [],
+    workflowKeys: Array.isArray(selectedPreset.workflowKeys)
+      ? [...selectedPreset.workflowKeys]
+      : [],
+    bundleArtifacts: Array.isArray(selectedPreset.bundleArtifacts)
+      ? [...selectedPreset.bundleArtifacts]
+      : [],
+    reviewWorkflow: cloneReviewWorkflow(selectedPreset.reviewWorkflow),
+  };
 }
 
 function buildAnalysisIndex({
@@ -174,9 +200,11 @@ function buildAnalysisIndex({
   generatedFiles,
   selectedMode = null,
   derivedModeSettings = null,
+  selectedPreset = null,
 }) {
   const modes = listWorkflowModes();
   const tasks = modes.map((mode) => buildTask(mode, aiKnowledge, context, generatedFiles, selectedMode));
+  const selectedPresetSummary = buildSelectedPresetSummary(selectedPreset);
 
   return {
     schemaVersion: ANALYSIS_INDEX_SCHEMA_VERSION,
@@ -186,11 +214,13 @@ function buildAnalysisIndex({
     sourceRoot: canonicalAnalysis.sourceRoot,
     selectedMode: selectedMode ? normalizeWorkflowModeName(selectedMode) : null,
     derivedModeSettings: derivedModeSettings || null,
+    selectedPreset: selectedPresetSummary,
     summary: {
       taskCount: tasks.length,
       selectedTaskCount: tasks.filter((task) => task.selected).length,
       generatedArtifactCount: uniqueSortedStrings(generatedFiles).length,
       applicablePromptCount: tasks.reduce((count, task) => count + task.prompts.filter((prompt) => prompt.applicable).length, 0),
+      selectedPresetCount: selectedPresetSummary ? 1 : 0,
     },
     guidedModes: buildGuidedModeSummary(modes, selectedMode),
     tasks,

--- a/src/workflow/reviewWorkflowMetadata.js
+++ b/src/workflow/reviewWorkflowMetadata.js
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+function normalizeStrings(values) {
+  return Object.freeze((Array.isArray(values) ? values : [])
+    .map((value) => String(value || '').trim())
+    .filter(Boolean));
+}
+
+function normalizeOutputEntries(entries) {
+  return Object.freeze((Array.isArray(entries) ? entries : [])
+    .map((entry) => ({
+      path: String(entry && entry.path || '').trim(),
+      purpose: String(entry && entry.purpose || '').trim(),
+    }))
+    .filter((entry) => entry.path && entry.purpose)
+    .map((entry) => Object.freeze(entry)));
+}
+
+function freezeReviewWorkflow(reviewWorkflow) {
+  if (!reviewWorkflow || typeof reviewWorkflow !== 'object') {
+    return null;
+  }
+
+  return Object.freeze({
+    intendedAudience: normalizeStrings(reviewWorkflow.intendedAudience),
+    keyQuestionsAnswered: normalizeStrings(reviewWorkflow.keyQuestionsAnswered),
+    expectedDecisions: normalizeStrings(reviewWorkflow.expectedDecisions),
+    interpretationGuidance: normalizeStrings(reviewWorkflow.interpretationGuidance),
+    requiredInputs: normalizeStrings(reviewWorkflow.requiredInputs),
+    recommendedOutputs: normalizeOutputEntries(reviewWorkflow.recommendedOutputs),
+  });
+}
+
+function cloneReviewWorkflow(reviewWorkflow) {
+  if (!reviewWorkflow || typeof reviewWorkflow !== 'object') {
+    return null;
+  }
+
+  return {
+    intendedAudience: [...(reviewWorkflow.intendedAudience || [])],
+    keyQuestionsAnswered: [...(reviewWorkflow.keyQuestionsAnswered || [])],
+    expectedDecisions: [...(reviewWorkflow.expectedDecisions || [])],
+    interpretationGuidance: [...(reviewWorkflow.interpretationGuidance || [])],
+    requiredInputs: [...(reviewWorkflow.requiredInputs || [])],
+    recommendedOutputs: (reviewWorkflow.recommendedOutputs || []).map((entry) => ({
+      path: entry.path,
+      purpose: entry.purpose,
+    })),
+  };
+}
+
+module.exports = {
+  cloneReviewWorkflow,
+  freezeReviewWorkflow,
+};

--- a/src/workflow/workflowModeRegistry.js
+++ b/src/workflow/workflowModeRegistry.js
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const { getPromptContract } = require('../prompt/promptRegistry');
 const { resolvePromptTemplates } = require('../prompt/promptBuilder');
+const { cloneReviewWorkflow, freezeReviewWorkflow } = require('./reviewWorkflowMetadata');
 
 const WORKFLOW_MODE_REGISTRY = Object.freeze({
   architecture: Object.freeze({
@@ -29,6 +30,37 @@ const WORKFLOW_MODE_REGISTRY = Object.freeze({
       'program-call-tree.md',
       'ai_prompt_documentation.md',
     ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'IBM i architects',
+        'Platform maintainers',
+        'Engineers reviewing structural boundaries before change',
+      ],
+      keyQuestionsAnswered: [
+        'What are the dominant program, table, and copy-member dependencies?',
+        'Which unresolved edges or ambiguous calls still weaken the architecture picture?',
+        'Which artifacts should anchor a structure-first architecture review?',
+      ],
+      expectedDecisions: [
+        'Choose the next subsystem or dependency path for deeper review.',
+        'Decide whether the current architecture evidence is sufficient for planned change work.',
+      ],
+      interpretationGuidance: [
+        'Use architecture-report.md together with dependency and call-tree artifacts; summaries alone can hide structural context.',
+        'Treat unresolved calls or ambiguous source resolution as follow-up work before making strong architecture claims.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and selected root program.',
+        'Canonical semantic analysis, AI knowledge projection, and dependency graph artifacts.',
+        'The documentation prompt contract for architecture-facing narrative output.',
+      ],
+      recommendedOutputs: [
+        { path: 'architecture-report.md', purpose: 'Narrative architecture summary for review and sharing.' },
+        { path: 'dependency-graph.md', purpose: 'Single-program dependency structure for quick inspection.' },
+        { path: 'program-call-tree.md', purpose: 'Cross-program call chain view for boundary tracing.' },
+        { path: 'ai_prompt_documentation.md', purpose: 'AI-assisted architecture walkthrough grounded in the workflow evidence.' },
+      ],
+    }),
   }),
   documentation: Object.freeze({
     name: 'documentation',
@@ -42,6 +74,36 @@ const WORKFLOW_MODE_REGISTRY = Object.freeze({
       'report.md',
       'ai_prompt_documentation.md',
     ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'New engineers',
+        'Technical writers',
+        'Maintainers assembling onboarding or system orientation notes',
+      ],
+      keyQuestionsAnswered: [
+        'What does the program do at a high level?',
+        'Which tables, calls, and source-backed evidence matter most for onboarding?',
+        'Which generated artifacts are most useful for documentation handoff?',
+      ],
+      expectedDecisions: [
+        'Decide whether the generated documentation is sufficient for onboarding or needs deeper analysis.',
+        'Choose the next artifact or subsystem to document in more detail.',
+      ],
+      interpretationGuidance: [
+        'Prefer ai_prompt_documentation.md for narrative synthesis and use report.md or ai-knowledge.json to verify claims.',
+        'Treat missing evidence highlights as a sign that the workflow is broad orientation, not a complete design review.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and selected root program.',
+        'Prompt-ready AI knowledge projection with documentation workflow evidence.',
+        'Report and prompt artifacts for narrative handoff.',
+      ],
+      recommendedOutputs: [
+        { path: 'report.md', purpose: 'Broad run summary with source-backed counts and notes.' },
+        { path: 'ai_prompt_documentation.md', purpose: 'Documentation-first prompt for onboarding or explanation.' },
+        { path: 'ai-knowledge.json', purpose: 'Prompt-ready evidence projection for follow-up AI tasks.' },
+      ],
+    }),
   }),
   'error-analysis': Object.freeze({
     name: 'error-analysis',
@@ -55,6 +117,36 @@ const WORKFLOW_MODE_REGISTRY = Object.freeze({
       'report.md',
       'ai_prompt_error_analysis.md',
     ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'Incident responders',
+        'Support engineers',
+        'Developers triaging risky runtime behavior',
+      ],
+      keyQuestionsAnswered: [
+        'Where are the highest-risk SQL, error-path, and evidence hotspots?',
+        'Which uncertainty markers or weak handling paths need manual validation first?',
+        'Which artifacts best support troubleshooting discussion?',
+      ],
+      expectedDecisions: [
+        'Choose the highest-priority failure hypothesis to verify.',
+        'Decide whether additional runtime evidence or DB2 context is needed before root-cause work.',
+      ],
+      interpretationGuidance: [
+        'Start with the highest-ranked evidence highlights, then validate against canonical-analysis.json before concluding root cause.',
+        'Treat dynamic or unresolved SQL markers as risk multipliers until verified against source or catalog evidence.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and selected root program.',
+        'AI knowledge projection with errorAnalysis workflow evidence.',
+        'Risk markers, SQL semantics, and ranked evidence highlights.',
+      ],
+      recommendedOutputs: [
+        { path: 'ai_prompt_error_analysis.md', purpose: 'Prompt for structured troubleshooting and risk review.' },
+        { path: 'report.md', purpose: 'Human-readable summary of analysis notes and operational risk signals.' },
+        { path: 'ai-knowledge.json', purpose: 'Workflow-specific evidence used by error analysis prompts.' },
+      ],
+    }),
   }),
   'defect-analysis': Object.freeze({
     name: 'defect-analysis',
@@ -69,6 +161,36 @@ const WORKFLOW_MODE_REGISTRY = Object.freeze({
       'ai_prompt_error_analysis.md',
       'ai_prompt_defect_analysis.md',
     ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'Developers preparing a dependency or defect risk review',
+        'Release owners',
+        'Technical leads validating blast radius before change',
+      ],
+      keyQuestionsAnswered: [
+        'Which defects or dependency paths are most likely to cause downstream impact?',
+        'What source-backed evidence supports each risk hypothesis?',
+        'Which artifacts should be shared with reviewers before a change decision?',
+      ],
+      expectedDecisions: [
+        'Decide whether the change can proceed with current controls or needs more investigation.',
+        'Choose the next verification step for the highest-risk dependency or defect path.',
+      ],
+      interpretationGuidance: [
+        'Use error-analysis and defect-analysis prompts together; one surfaces risk signals and the other organizes decision-oriented hypotheses.',
+        'Treat program-call and table dependencies as review inputs, not proof of production impact, until source evidence is checked.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and selected root program.',
+        'AI knowledge projection with risk markers, SQL semantics, and ranked evidence.',
+        'Dependency graph and program-call-tree artifacts for blast-radius review.',
+      ],
+      recommendedOutputs: [
+        { path: 'ai_prompt_error_analysis.md', purpose: 'Evidence-oriented risk prompt for suspicious behavior and hotspots.' },
+        { path: 'ai_prompt_defect_analysis.md', purpose: 'Decision-oriented defect and dependency risk prompt.' },
+        { path: 'report.md', purpose: 'Human-readable summary to pair with prompt conclusions.' },
+      ],
+    }),
   }),
   modernization: Object.freeze({
     name: 'modernization',
@@ -83,6 +205,37 @@ const WORKFLOW_MODE_REGISTRY = Object.freeze({
       'ai_prompt_documentation.md',
       'ai_prompt_modernization.md',
     ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'Modernization leads',
+        'IBM i architects',
+        'Engineers planning extraction or refactoring work',
+      ],
+      keyQuestionsAnswered: [
+        'Which change boundaries look safest to extract or rewrite first?',
+        'What dependencies, native I/O patterns, or SQL semantics block clean modernization?',
+        'Which artifacts best support a modernization readiness review?',
+      ],
+      expectedDecisions: [
+        'Choose a pilot extraction candidate or defer until prerequisites are addressed.',
+        'Decide which blockers require architecture, data, or integration follow-up before modernization work begins.',
+      ],
+      interpretationGuidance: [
+        'Use ai_prompt_modernization.md for synthesis, then validate proposed seams against architecture-report.md and canonical-analysis.json.',
+        'Treat unresolved calls, dynamic SQL, and mutating native file usage as modernization blockers until reviewed explicitly.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and selected root program.',
+        'Canonical semantic analysis, AI knowledge projection, and modernization prompt contract.',
+        'Architecture and dependency artifacts that expose extraction boundaries and risky integrations.',
+      ],
+      recommendedOutputs: [
+        { path: 'ai_prompt_modernization.md', purpose: 'Opinionated modernization review prompt with blockers and candidates.' },
+        { path: 'architecture-report.md', purpose: 'Architecture narrative for reviewing seams and dependencies.' },
+        { path: 'canonical-analysis.json', purpose: 'Semantic source of truth for validating modernization claims.' },
+        { path: 'ai_prompt_documentation.md', purpose: 'Supporting documentation prompt for reviewer context.' },
+      ],
+    }),
   }),
   impact: Object.freeze({
     name: 'impact',
@@ -97,6 +250,35 @@ const WORKFLOW_MODE_REGISTRY = Object.freeze({
       'program-call-tree.json',
       'architecture-report.md',
     ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'Maintainers estimating blast radius',
+        'Release coordinators',
+        'Engineers preparing follow-up impact analysis',
+      ],
+      keyQuestionsAnswered: [
+        'Which generated artifacts should be reviewed before running a reverse dependency check?',
+        'What structural signals define the likely blast radius for a target change?',
+      ],
+      expectedDecisions: [
+        'Choose the impact target and next investigation command.',
+        'Decide whether the available graph evidence is sufficient for a change review.',
+      ],
+      interpretationGuidance: [
+        'Use this workflow as prework for zeus impact, not as a replacement for target-specific blast-radius analysis.',
+        'Prefer program-call-tree.json and dependency-graph.json when choosing the target for reverse lookup.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and selected root program.',
+        'Dependency graph and cross-program graph artifacts.',
+        'Canonical analysis and architecture report for context before reverse impact review.',
+      ],
+      recommendedOutputs: [
+        { path: 'dependency-graph.json', purpose: 'Machine-readable dependency structure for impact follow-up.' },
+        { path: 'program-call-tree.json', purpose: 'Cross-program graph used by zeus impact.' },
+        { path: 'architecture-report.md', purpose: 'Narrative context before selecting an impact target.' },
+      ],
+    }),
   }),
 });
 
@@ -136,6 +318,7 @@ function resolveWorkflowModeSettings(modeName) {
     promptTemplates,
     workflowKeys,
     primaryArtifacts: [...mode.primaryArtifacts],
+    reviewWorkflow: cloneReviewWorkflow(mode.reviewWorkflow),
   };
 }
 

--- a/src/workflow/workflowPresetRegistry.js
+++ b/src/workflow/workflowPresetRegistry.js
@@ -12,6 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const { resolveWorkflowModeSettings } = require('./workflowModeRegistry');
+const { cloneReviewWorkflow, freezeReviewWorkflow } = require('./reviewWorkflowMetadata');
 
 const WORKFLOW_PRESET_REGISTRY = Object.freeze({
   'architecture-review': Object.freeze({
@@ -30,6 +31,38 @@ const WORKFLOW_PRESET_REGISTRY = Object.freeze({
       'architecture.html',
       'ai_prompt_documentation.md',
     ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'IBM i architects',
+        'Platform maintainers',
+        'Reviewers who need a shareable architecture bundle',
+      ],
+      keyQuestionsAnswered: [
+        'Which structural artifacts should reviewers inspect first?',
+        'What dependencies and unresolved edges define the architecture conversation?',
+        'Which outputs are safe to share as a focused architecture packet?',
+      ],
+      expectedDecisions: [
+        'Decide whether the current dependency picture is sufficient for planned change work.',
+        'Choose the next subsystem, interface, or unresolved edge for deeper analysis.',
+      ],
+      interpretationGuidance: [
+        'Review architecture-report.md alongside dependency and call-tree artifacts; each file answers a different part of the structure question.',
+        'Treat missing local source or ambiguous call resolution as explicit limitations in the review packet.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and root program selection.',
+        'Canonical analysis, AI knowledge projection, and generated graph artifacts.',
+        'Documentation prompt output for architecture narrative support.',
+      ],
+      recommendedOutputs: [
+        { path: 'architecture-report.md', purpose: 'Primary narrative used in architecture review discussion.' },
+        { path: 'dependency-graph.md', purpose: 'Readable dependency map for the root program.' },
+        { path: 'program-call-tree.md', purpose: 'Readable cross-program dependency path summary.' },
+        { path: 'architecture.html', purpose: 'Interactive graph view for live review sessions.' },
+        { path: 'ai_prompt_documentation.md', purpose: 'AI-assisted explanation of the architecture packet.' },
+      ],
+    }),
   }),
   'modernization-review': Object.freeze({
     name: 'modernization-review',
@@ -47,6 +80,37 @@ const WORKFLOW_PRESET_REGISTRY = Object.freeze({
       'ai_prompt_documentation.md',
       'ai_prompt_modernization.md',
     ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'Modernization leads',
+        'IBM i architects',
+        'Developers planning extraction, refactoring, or migration work',
+      ],
+      keyQuestionsAnswered: [
+        'Which modernization candidates look viable now?',
+        'Which dependencies, native file behaviors, or SQL patterns block safe extraction?',
+        'Which outputs should be shared to support a modernization readiness review?',
+      ],
+      expectedDecisions: [
+        'Choose a pilot modernization target or pause until blockers are resolved.',
+        'Decide which dependency or data concerns need follow-up before committing to change.',
+      ],
+      interpretationGuidance: [
+        'Use ai_prompt_modernization.md as the synthesis layer, then verify proposed seams against canonical-analysis.json and architecture-report.md.',
+        'Treat unresolved calls, dynamic SQL, and mutating file usage as blockers until reviewed explicitly.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and root program selection.',
+        'Canonical analysis, AI knowledge projection, modernization prompt output, and architecture artifacts.',
+        'Shareable bundle outputs that preserve evidence-backed context for review.',
+      ],
+      recommendedOutputs: [
+        { path: 'ai_prompt_modernization.md', purpose: 'Primary modernization review prompt for blockers, seams, and candidates.' },
+        { path: 'architecture-report.md', purpose: 'Narrative architecture evidence for modernization discussions.' },
+        { path: 'program-call-tree.md', purpose: 'Call-chain context for change-boundary reasoning.' },
+        { path: 'ai_prompt_documentation.md', purpose: 'Supporting documentation prompt for reviewer orientation.' },
+      ],
+    }),
   }),
   onboarding: Object.freeze({
     name: 'onboarding',
@@ -62,6 +126,36 @@ const WORKFLOW_PRESET_REGISTRY = Object.freeze({
       'architecture-report.md',
       'ai_prompt_documentation.md',
     ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'New engineers',
+        'Technical leads onboarding maintainers',
+        'Reviewers who need a concise orientation bundle',
+      ],
+      keyQuestionsAnswered: [
+        'Which artifacts explain the program quickly without opening every generated file?',
+        'What business and technical context is most important for a new maintainer first?',
+        'Which outputs form a shareable onboarding packet?',
+      ],
+      expectedDecisions: [
+        'Decide whether onboarding context is sufficient or deeper architecture review is needed.',
+        'Choose the next artifact or subsystem a new maintainer should study.',
+      ],
+      interpretationGuidance: [
+        'Start with report.md and ai_prompt_documentation.md, then use architecture-report.md for structural follow-up.',
+        'Treat this bundle as orientation material, not a substitute for risk or modernization review.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and root program selection.',
+        'Documentation-oriented AI knowledge projection and human-readable reports.',
+        'A bundle targeted at fast sharing and orientation.',
+      ],
+      recommendedOutputs: [
+        { path: 'report.md', purpose: 'Broad program summary for quick reading.' },
+        { path: 'architecture-report.md', purpose: 'Architecture context for follow-up onboarding conversations.' },
+        { path: 'ai_prompt_documentation.md', purpose: 'AI-assisted onboarding and explanation prompt.' },
+      ],
+    }),
   }),
   'dependency-risk': Object.freeze({
     name: 'dependency-risk',
@@ -81,6 +175,37 @@ const WORKFLOW_PRESET_REGISTRY = Object.freeze({
       'ai_prompt_error_analysis.md',
       'ai_prompt_defect_analysis.md',
     ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'Release owners',
+        'Technical leads reviewing dependency risk',
+        'Developers assessing blast radius before change',
+      ],
+      keyQuestionsAnswered: [
+        'Which dependencies, SQL paths, or defect hypotheses represent the highest change risk?',
+        'What evidence should reviewers inspect before approving a risky change?',
+        'Which outputs make the dependency-risk review bundle shareable without extra assembly?',
+      ],
+      expectedDecisions: [
+        'Approve, defer, or further investigate a change based on dependency risk.',
+        'Choose the next validation step for the highest-risk dependency path or defect hypothesis.',
+      ],
+      interpretationGuidance: [
+        'Use ai_prompt_defect_analysis.md for decision framing and ai_prompt_error_analysis.md for the supporting evidence trail.',
+        'Treat dependency graphs as blast-radius indicators that still need source-backed validation for production decisions.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and root program selection.',
+        'Risk-oriented AI knowledge projection, prompt outputs, and dependency graph artifacts.',
+        'A shareable bundle that keeps risk evidence and graph context together.',
+      ],
+      recommendedOutputs: [
+        { path: 'ai_prompt_defect_analysis.md', purpose: 'Primary dependency-risk review prompt with hypotheses and decisions.' },
+        { path: 'ai_prompt_error_analysis.md', purpose: 'Supporting risk evidence prompt for suspicious SQL and error paths.' },
+        { path: 'dependency-graph.md', purpose: 'Readable dependency structure for review discussion.' },
+        { path: 'program-call-tree.md', purpose: 'Readable cross-program blast-radius context.' },
+      ],
+    }),
   }),
 });
 
@@ -120,6 +245,7 @@ function resolveWorkflowPresetSettings(presetName) {
     autoOptimizeContext: Boolean(guidedMode.autoOptimizeContext),
     bundleArtifacts: [...preset.bundleArtifacts],
     bundleFileName: `${preset.name}-bundle.zip`,
+    reviewWorkflow: cloneReviewWorkflow(preset.reviewWorkflow),
   };
 }
 

--- a/src/workflow/workflowRunManifest.js
+++ b/src/workflow/workflowRunManifest.js
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const fs = require('fs');
 const path = require('path');
+const { cloneReviewWorkflow } = require('./reviewWorkflowMetadata');
 
 const WORKFLOW_RUN_MANIFEST_FILE = 'workflow-run-manifest.json';
 const WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION = 1;
@@ -31,6 +32,7 @@ function buildWorkflowRunManifest({ preset, analyzeManifest, bundleManifest, bun
       promptTemplates: [...(preset.promptTemplates || [])],
       workflowKeys: [...(preset.workflowKeys || [])],
       bundleArtifacts: [...(preset.bundleArtifacts || [])],
+      reviewWorkflow: cloneReviewWorkflow(preset.reviewWorkflow),
     } : null,
     analyzeRun: analyzeManifest ? {
       manifestFile: 'analyze-run-manifest.json',

--- a/tests/analyze-run-manifest.test.js
+++ b/tests/analyze-run-manifest.test.js
@@ -50,6 +50,34 @@ test('buildAnalyzeRunManifest creates a stable success manifest with artifact me
           name: 'modernization',
           promptTemplates: ['documentation', 'modernization'],
           effectiveOptimizeContext: true,
+          reviewWorkflow: {
+            intendedAudience: ['Modernization leads'],
+            keyQuestionsAnswered: ['Which change boundaries look safest to extract or rewrite first?'],
+            expectedDecisions: ['Choose a pilot modernization target.'],
+            interpretationGuidance: ['Validate proposed seams against semantic evidence.'],
+            requiredInputs: ['Canonical analysis and modernization prompts.'],
+            recommendedOutputs: [
+              { path: 'ai_prompt_modernization.md', purpose: 'Modernization review prompt.' },
+            ],
+          },
+        },
+        workflowPreset: {
+          name: 'modernization-review',
+          title: 'Modernization Review',
+          analyzeMode: 'modernization',
+          promptTemplates: ['documentation', 'modernization'],
+          workflowKeys: ['documentation'],
+          bundleArtifacts: ['analyze-run-manifest.json', 'ai_prompt_modernization.md'],
+          reviewWorkflow: {
+            intendedAudience: ['Modernization leads'],
+            keyQuestionsAnswered: ['Which outputs should be shared for modernization readiness?'],
+            expectedDecisions: ['Choose whether to proceed with a pilot change.'],
+            interpretationGuidance: ['Treat unresolved calls as blockers.'],
+            requiredInputs: ['Shareable bundle artifacts.'],
+            recommendedOutputs: [
+              { path: 'ai_prompt_modernization.md', purpose: 'Primary modernization bundle output.' },
+            ],
+          },
         },
       },
       result: {
@@ -100,6 +128,9 @@ test('buildAnalyzeRunManifest creates a stable success manifest with artifact me
     assert.equal(manifest.summary.warningCount, 1);
     assert.equal(manifest.inputs.options.guidedMode.name, 'modernization');
     assert.deepEqual(manifest.inputs.options.guidedMode.promptTemplates, ['documentation', 'modernization']);
+    assert.match(manifest.inputs.options.guidedMode.reviewWorkflow.intendedAudience.join('\n'), /Modernization leads/);
+    assert.equal(manifest.inputs.options.workflowPreset.name, 'modernization-review');
+    assert.match(manifest.inputs.options.workflowPreset.reviewWorkflow.expectedDecisions.join('\n'), /pilot change/i);
     assert.equal(manifest.artifacts.length, 2);
     assert.equal(manifest.artifacts[0].exists, true);
     assert.ok(typeof manifest.artifacts[0].sha256 === 'string' && manifest.artifacts[0].sha256.length > 0);
@@ -135,6 +166,16 @@ test('buildAnalyzeRunManifest includes failure details for failed runs', () => {
           name: 'impact',
           promptTemplates: [],
           effectiveOptimizeContext: false,
+          reviewWorkflow: {
+            intendedAudience: ['Release coordinators'],
+            keyQuestionsAnswered: ['Which artifacts should be reviewed before impact analysis?'],
+            expectedDecisions: ['Choose the impact target.'],
+            interpretationGuidance: ['Use this workflow before zeus impact.'],
+            requiredInputs: ['Dependency graph artifacts.'],
+            recommendedOutputs: [
+              { path: 'dependency-graph.json', purpose: 'Impact follow-up graph.' },
+            ],
+          },
         },
       },
       error: {
@@ -165,6 +206,7 @@ test('buildAnalyzeRunManifest includes failure details for failed runs', () => {
     assert.equal(manifest.summary.errorCount, 1);
     assert.equal(manifest.diagnostics.length, 1);
     assert.equal(manifest.inputs.options.guidedMode.name, 'impact');
+    assert.match(manifest.inputs.options.guidedMode.reviewWorkflow.expectedDecisions.join('\n'), /impact target/i);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/tests/bundle-manifest.test.js
+++ b/tests/bundle-manifest.test.js
@@ -114,6 +114,16 @@ test('buildOutputBundle can package explicit workflow preset artifacts with pres
             promptTemplates: ['documentation'],
             workflowKeys: ['documentation'],
             bundleArtifacts: ['analyze-run-manifest.json', 'analysis-index.json', 'report.md'],
+            reviewWorkflow: {
+              intendedAudience: ['New engineers'],
+              keyQuestionsAnswered: ['Which artifacts explain the program quickly?'],
+              expectedDecisions: ['Decide whether deeper architecture review is needed.'],
+              interpretationGuidance: ['Start with report.md before deeper review.'],
+              requiredInputs: ['Prompt-ready documentation artifacts.'],
+              recommendedOutputs: [
+                { path: 'report.md', purpose: 'Quick orientation summary.' },
+              ],
+            },
           },
         },
         sourceSnapshot: {
@@ -142,6 +152,7 @@ test('buildOutputBundle can package explicit workflow preset artifacts with pres
     ]);
     assert.equal(result.manifest.workflowPreset.name, 'onboarding');
     assert.deepEqual(result.manifest.workflowPreset.promptTemplates, ['documentation']);
+    assert.match(result.manifest.workflowPreset.reviewWorkflow.intendedAudience.join('\n'), /New engineers/);
     assert.equal(path.basename(result.zipPath), 'ORDERPGM-onboarding-bundle.zip');
 
     const zip = new AdmZip(result.zipPath);
@@ -153,6 +164,10 @@ test('buildOutputBundle can package explicit workflow preset artifacts with pres
       'manifest.json',
       'report.md',
     ]);
+    const readme = zip.readAsText('README.txt');
+    assert.match(readme, /Workflow preset: onboarding/);
+    assert.match(readme, /Expected decisions:/);
+    assert.match(readme, /report\.md: Quick orientation summary\./);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/tests/task-oriented-analysis-index.test.js
+++ b/tests/task-oriented-analysis-index.test.js
@@ -27,6 +27,8 @@ test('analyze --list-modes exposes guided workflow presets', () => {
   assert.match(output, /- architecture:/);
   assert.match(output, /- modernization:/);
   assert.match(output, /- impact:/);
+  assert.match(output, /intended audience:/);
+  assert.match(output, /expected decisions:/);
 });
 
 test('guided analyze mode writes task index, selected mode metadata, and mode-specific prompts', () => {
@@ -58,17 +60,24 @@ test('guided analyze mode writes task index, selected mode metadata, and mode-sp
 
     const analysisIndex = readJson(path.join(programOutputDir, 'analysis-index.json'));
     assert.equal(analysisIndex.selectedMode, 'modernization');
+    assert.equal(analysisIndex.selectedPreset, null);
     assert.equal(analysisIndex.summary.selectedTaskCount, 1);
+    assert.equal(analysisIndex.summary.selectedPresetCount, 0);
     assert.ok(analysisIndex.guidedModes.some((entry) => entry.name === 'modernization' && entry.selected === true));
     const modernizationTask = analysisIndex.tasks.find((entry) => entry.id === 'modernization');
     assert.ok(modernizationTask);
     assert.equal(modernizationTask.selected, true);
     assert.ok(modernizationTask.prompts.some((entry) => entry.name === 'modernization' && entry.generated === true));
+    assert.ok(Array.isArray(modernizationTask.reviewWorkflow.intendedAudience));
+    assert.match(modernizationTask.reviewWorkflow.intendedAudience.join('\n'), /Modernization leads/);
+    assert.match(modernizationTask.reviewWorkflow.keyQuestionsAnswered.join('\n'), /extract or rewrite first/i);
+    assert.ok(Array.isArray(analysisIndex.derivedModeSettings.reviewWorkflow.expectedDecisions));
 
     const manifest = readJson(path.join(programOutputDir, 'analyze-run-manifest.json'));
     assert.equal(manifest.inputs.options.guidedMode.name, 'modernization');
     assert.deepEqual(manifest.inputs.options.guidedMode.promptTemplates, ['documentation', 'modernization']);
     assert.equal(manifest.inputs.options.guidedMode.effectiveOptimizeContext, true);
+    assert.match(manifest.inputs.options.guidedMode.reviewWorkflow.expectedDecisions.join('\n'), /pilot extraction candidate/i);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/tests/v1-smoke.test.js
+++ b/tests/v1-smoke.test.js
@@ -124,9 +124,12 @@ test('V1 smoke flow generates analysis artifacts and bundle outputs', () => {
     assert.equal(analysisIndex.kind, 'analysis-task-index');
     assert.equal(analysisIndex.program, 'ORDERPGM');
     assert.equal(analysisIndex.selectedMode, null);
+    assert.equal(analysisIndex.selectedPreset, null);
+    assert.equal(analysisIndex.summary.selectedPresetCount, 0);
     assert.ok(Array.isArray(analysisIndex.guidedModes));
     assert.ok(analysisIndex.tasks.some((task) => task.id === 'modernization'));
     assert.ok(analysisIndex.tasks.some((task) => task.id === 'impact'));
+    assert.ok(analysisIndex.tasks.every((task) => task.reviewWorkflow));
 
     const report = fs.readFileSync(path.join(programOutputDir, 'report.md'), 'utf8');
     assert.match(report, /## Native File I\/O/);

--- a/tests/workflow-presets.test.js
+++ b/tests/workflow-presets.test.js
@@ -29,6 +29,8 @@ test('workflow --list-presets exposes named guided workflow bundles', () => {
   assert.match(output, /- modernization-review:/);
   assert.match(output, /- onboarding:/);
   assert.match(output, /- dependency-risk:/);
+  assert.match(output, /intended audience:/);
+  assert.match(output, /expected decisions:/);
 });
 
 test('workflow preset runs analyze plus bundle and records preset metadata in manifests', () => {
@@ -56,6 +58,7 @@ test('workflow preset runs analyze plus bundle and records preset metadata in ma
 
     const programOutputDir = path.join(outputRoot, 'ORDERPGM');
     const analyzeManifest = readJson(path.join(programOutputDir, 'analyze-run-manifest.json'));
+    const analysisIndex = readJson(path.join(programOutputDir, 'analysis-index.json'));
     const workflowManifest = readJson(path.join(programOutputDir, 'workflow-run-manifest.json'));
     const bundleManifest = readJson(path.join(programOutputDir, 'bundle-manifest.json'));
     const bundlePath = path.join(bundleRoot, 'ORDERPGM-modernization-review-bundle.zip');
@@ -66,14 +69,24 @@ test('workflow preset runs analyze plus bundle and records preset metadata in ma
       analyzeManifest.inputs.options.workflowPreset.promptTemplates,
       ['documentation', 'modernization'],
     );
+    assert.match(
+      analyzeManifest.inputs.options.workflowPreset.reviewWorkflow.expectedDecisions.join('\n'),
+      /pilot modernization target/i,
+    );
+
+    assert.equal(analysisIndex.selectedPreset.name, 'modernization-review');
+    assert.equal(analysisIndex.selectedPreset.analyzeMode, 'modernization');
+    assert.match(analysisIndex.selectedPreset.reviewWorkflow.intendedAudience.join('\n'), /Modernization leads/);
 
     assert.equal(workflowManifest.kind, 'workflow-run-manifest');
     assert.equal(workflowManifest.preset.name, 'modernization-review');
     assert.equal(workflowManifest.preset.analyzeMode, 'modernization');
+    assert.match(workflowManifest.preset.reviewWorkflow.keyQuestionsAnswered.join('\n'), /modernization candidates/i);
     assert.equal(workflowManifest.bundle.zipPath, 'ORDERPGM-modernization-review-bundle.zip');
 
     assert.equal(bundleManifest.workflowPreset.name, 'modernization-review');
     assert.equal(bundleManifest.workflowPreset.analyzeMode, 'modernization');
+    assert.match(bundleManifest.workflowPreset.reviewWorkflow.expectedDecisions.join('\n'), /pilot modernization target/i);
     assert.ok(bundleManifest.files.includes('ai_prompt_modernization.md'));
     assert.ok(bundleManifest.files.includes('architecture-report.md'));
     assert.equal(bundleManifest.files.includes('context.json'), false);
@@ -84,6 +97,10 @@ test('workflow preset runs analyze plus bundle and records preset metadata in ma
     assert.ok(entryNames.includes('ai_prompt_modernization.md'));
     assert.ok(entryNames.includes('architecture-report.md'));
     assert.equal(entryNames.includes('context.json'), false);
+    const readme = zip.readAsText('README.txt');
+    assert.match(readme, /Workflow preset: modernization-review/);
+    assert.match(readme, /Expected decisions:/);
+    assert.match(readme, /ai_prompt_modernization\.md:/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary\n- add opinionated review metadata to guided analyze modes and workflow presets\n- propagate intended audience, key questions, expected decisions, interpretation guidance, and recommended outputs through analysis indexes, manifests, and bundle README files\n- update CLI listings and regression coverage for review-oriented workflow bundles\n\n## Testing\n- node --test tests/task-oriented-analysis-index.test.js\n- node --test tests/workflow-presets.test.js\n- node --test tests/bundle-manifest.test.js\n- node --test tests/analyze-run-manifest.test.js\n- node --test tests/v1-smoke.test.js\n- npm test\n- node cli/zeus.js analyze --list-modes\n- node cli/zeus.js workflow --list-presets\n\nCloses #51