### PR TITLE
Add safe-sharing redaction mode for prompts, reports, and bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ npm test
 Command syntax:
 
 ```bash
-zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--test-data-limit <n>] [--skip-test-data] [--verbose]
+zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--safe-sharing] [--test-data-limit <n>] [--skip-test-data] [--verbose]
 ```
 
 Workflow command syntax:
 
 ```bash
-zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--list-presets] [--test-data-limit <n>] [--skip-test-data] [--verbose]
+zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--list-presets] [--safe-sharing] [--test-data-limit <n>] [--skip-test-data] [--verbose]
 ```
 
 Guided analyze modes:
@@ -113,6 +113,8 @@ Guided analyze modes:
 - use `--mode impact` to highlight dependency artifacts and the next `zeus impact` step
 
 When a guided mode is selected, Zeus records the mode and derived behavior in `analyze-run-manifest.json`, writes `analysis-index.json`, and may auto-enable context optimization for prompt-heavy workflows.
+
+Use `--safe-sharing` when you need a redacted sharing packet. Zeus writes a parallel `safe-sharing/` artifact set with deterministic placeholders for identifiers, source paths, and extracted values.
 
 Named workflow presets build on top of those guided modes and package a shareable bundle in one step:
 
@@ -136,7 +138,7 @@ Guided modes and workflow presets now also expose opinionated review metadata:
 Bundle command syntax:
 
 ```bash
-zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--profile <name>] [--verbose]
+zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--safe-sharing] [--profile <name>] [--verbose]
 ```
 
 Impact command syntax:
@@ -228,6 +230,7 @@ Generated files:
 - `ai-knowledge.json`
 - `analysis-index.json`
 - `workflow-run-manifest.json` (when `zeus workflow` is executed)
+- `safe-sharing/redaction-manifest.json` (when `--safe-sharing` is enabled)
 - `report.md`
 - `architecture-report.md`
 - `ai_prompt_documentation.md`
@@ -248,6 +251,12 @@ Generated files:
 - `impact-analysis.json` (when `zeus impact` is executed)
 - `impact-analysis.md` (when `zeus impact` is executed)
 - `architecture.html`
+
+When `--safe-sharing` is enabled, Zeus also writes a parallel redacted artifact set under:
+
+`output/<program>/safe-sharing/`
+
+The safe-sharing directory reuses the same artifact filenames where possible, but replaces business-specific identifiers, source paths, and extracted values with deterministic placeholders such as `PROGRAM_001`, `TABLE_001`, `SCHEMA_001`, `SOURCE_FILE_001.rpgle`, and `VALUE_001`.
 
 `context.json` contains top-level keys:
 
@@ -273,6 +282,8 @@ Generated files:
 `analysis-index.json` is a deterministic task-oriented index that maps common workflows to the relevant artifacts, prompt contracts, intended audience, expected decisions, interpretation guidance, and recommended next actions.
 
 `workflow-run-manifest.json` records which named workflow preset produced the run, which guided analyze mode it resolved to, which review metadata shaped the run, and which bundle was emitted for sharing.
+
+`safe-sharing/redaction-manifest.json` records which artifacts were redacted, which placeholder categories were used, and which safe-sharing files were written. Reverse mappings are intentionally not exported.
 
 `canonical-analysis.json` is now the semantic source of truth for the analyze pipeline.
 
@@ -632,6 +643,10 @@ Default bundle location:
 
 - `bundles/<program>-analysis-bundle.zip`
 
+When `--safe-sharing` is used, the default bundle location becomes:
+
+- `bundles/<program>-safe-sharing-bundle.zip`
+
 Included by default:
 
 - all `.json` files in `output/<program>/`
@@ -651,6 +666,8 @@ The ZIP also contains:
 - `manifest.json` with the included file list and summary counts
 - `README.txt` with a short bundle description, intended audience, expected decisions, interpretation guidance, and recommended outputs for the selected workflow preset
 
+When `--safe-sharing` is enabled, Zeus packages only the redacted `safe-sharing/` artifacts and records the redaction manifest path in the bundle metadata and README.
+
 `zeus bundle` also writes `bundle-manifest.json` to `output/<program>/` for local reference.
 
 Both bundle manifest files are versioned and include:
@@ -661,6 +678,7 @@ Both bundle manifest files are versioned and include:
 - artifact entries with `path`, `kind`, `sizeBytes`, and `sha256` when available
 - analyze-run linkage metadata when the bundle was created from an analyze manifest
 - workflow preset metadata, including intended audience, key questions answered, expected decisions, interpretation guidance, and recommended outputs, when the bundle was created from `zeus workflow` or an analyze run tagged with a workflow preset
+- safe-sharing metadata when the bundle contains only redacted artifacts
 
 Examples:
 
@@ -668,6 +686,7 @@ Examples:
 zeus bundle --program ORDERPGM
 zeus bundle --program ORDERPGM --output ./bundles --include-json
 zeus bundle --program ORDERPGM --source-output-root ./output --verbose
+zeus bundle --program ORDERPGM --source-output-root ./output --safe-sharing
 zeus workflow --preset architecture-review --source ./rpg_sources --program ORDERPGM
 ```
 
@@ -770,6 +789,15 @@ Example:
 ```bash
 zeus analyze --source ./rpg_sources --program ORDERPGM --optimize-context
 ```
+
+Safe-sharing example:
+
+```bash
+zeus analyze --source ./rpg_sources --program ORDERPGM --safe-sharing
+zeus bundle --program ORDERPGM --source-output-root ./output --safe-sharing
+```
+
+See [docs/safe-sharing.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/safe-sharing.md) for the safe-sharing rules for reports, prompts, bundles, fixtures, and issue text.
 
 ## Notes
 

--- a/V2_ROADMAP.md
+++ b/V2_ROADMAP.md
@@ -150,6 +150,7 @@ Current workflow packaging now includes:
 - named workflow presets for `architecture-review`, `modernization-review`, `onboarding`, and `dependency-risk`
 - workflow-tagged bundle manifests so shared archives can describe which preset produced them
 - review-oriented metadata on modes and presets so manifests, analysis indexes, and shared bundle README files identify intended audience, key questions, expected decisions, interpretation guidance, and recommended outputs
+- opt-in `--safe-sharing` outputs and bundles that preserve workflow structure while redacting identifiers, source paths, and extracted values with stable placeholders
 
 ### Track E: AI Knowledge Projection and Safe Sharing
 

--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -22,9 +22,9 @@ const { runWorkflow } = require('../src/cli/commands/workflowCommand');
 
 function printHelp() {
   console.log('Usage:');
-  console.log('  zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
-  console.log('  zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.rpg] [--list-presets] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
-  console.log('  zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--profile <name>] [--verbose]');
+  console.log('  zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--safe-sharing] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
+  console.log('  zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.rpg] [--list-presets] [--safe-sharing] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
+  console.log('  zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--safe-sharing] [--profile <name>] [--verbose]');
   console.log('  zeus impact --target <name> [--program <name>] [--out <path>] [--profile <name>] [--source <path>] [--verbose]');
   console.log('  zeus fetch --host <hostname> --user <username> --password <password> --source-lib <lib> --ifs-dir <ifsPath> --out <localPath> [--files <list>] [--members <list>] [--replace true|false] [--streamfile-ccsid <ccsid>] [--transport auto|sftp|jt400|ftp] [--profile <name>] [--verbose]');
 }

--- a/docs/safe-sharing.md
+++ b/docs/safe-sharing.md
@@ -1,0 +1,72 @@
+# Safe Sharing
+
+Use Zeus `--safe-sharing` mode before sharing generated artifacts outside the working repository.
+
+## Purpose
+
+Safe-sharing mode creates a parallel redacted artifact set under `output/<program>/safe-sharing/`.
+
+It preserves:
+
+- workflow structure
+- graph shape
+- evidence counts
+- file and artifact contracts
+
+It replaces:
+
+- business-specific program, table, copy-member, module, and service-program identifiers
+- source paths and imported member identity
+- DB2 schema names when they appear in exported artifacts
+- extracted data values and SQL string literals
+
+## CLI Usage
+
+Analyze with redacted variants:
+
+```bash
+zeus analyze --source ./rpg_sources --program ORDERPGM --safe-sharing
+```
+
+Create a redacted bundle:
+
+```bash
+zeus bundle --program ORDERPGM --source-output-root ./output --safe-sharing
+```
+
+Run a preset and package only safe-sharing artifacts:
+
+```bash
+zeus workflow --preset modernization-review --source ./rpg_sources --program ORDERPGM --safe-sharing
+```
+
+## Artifact Contract
+
+Safe-sharing mode writes:
+
+- `safe-sharing/context.json`
+- `safe-sharing/optimized-context.json` when available
+- `safe-sharing/ai-knowledge.json`
+- `safe-sharing/analysis-index.json`
+- `safe-sharing/report.md`
+- `safe-sharing/architecture-report.md`
+- `safe-sharing/ai_prompt_*.md`
+- `safe-sharing/dependency-graph.*`
+- `safe-sharing/program-call-tree.*`
+- `safe-sharing/architecture.html`
+- `safe-sharing/analyze-run-manifest.json`
+- `safe-sharing/redaction-manifest.json`
+
+`safe-sharing/redaction-manifest.json` is safe to share. It records placeholder counts and generated safe-sharing files, but it does not contain reverse mappings back to the original identifiers.
+
+## Repository Rules
+
+- Do not copy raw prompts, reports, DB2 extracts, or bundle contents into GitHub issues when `--safe-sharing` output is available.
+- Do not add non-redacted production-like fixture data to `tests/fixtures/`.
+- Prefer safe-sharing artifacts when drafting issue summaries, bug reports, or architecture review packets.
+- If a fixture or shared example needs data rows, use the redacted safe-sharing variant or a manually sanitized synthetic sample.
+
+## Limits
+
+- Safe-sharing mode is designed to preserve workflow usefulness, not to provide a legal or compliance certification.
+- Review the redacted output before external sharing when repository-specific confidentiality requirements are strict.

--- a/src/analyze/analyzePipeline.js
+++ b/src/analyze/analyzePipeline.js
@@ -496,6 +496,18 @@ function writeArtifactsStage(state) {
   fs.writeFileSync(path.join(outputProgramDir, 'report.md'), reportMarkdown, 'utf8');
 
   const generatedPromptFiles = selectedPromptTemplates.map((templateName) => getPromptContract(templateName).outputFileName);
+  const generatedDb2Files = context.db2Metadata && context.db2Metadata.status === 'exported'
+    ? [
+      context.db2Metadata.file || 'db2-metadata.json',
+      context.db2Metadata.markdownFile || 'db2-metadata.md',
+    ]
+    : [];
+  const generatedTestDataFiles = context.testData && context.testData.status === 'exported'
+    ? [
+      context.testData.file || 'test-data.json',
+      context.testData.markdownFile || 'test-data.md',
+    ]
+    : [];
   const generatedFiles = [
     'canonical-analysis.json',
     'context.json',
@@ -510,6 +522,8 @@ function writeArtifactsStage(state) {
     'program-call-tree.md',
     'architecture.html',
     'architecture-report.md',
+    ...generatedDb2Files,
+    ...generatedTestDataFiles,
     ...generatedPromptFiles,
     'report.md',
   ];

--- a/src/analyze/analyzeRunManifest.js
+++ b/src/analyze/analyzeRunManifest.js
@@ -185,6 +185,7 @@ function buildAnalyzeRunManifest({
       outputRoot: context.outputRoot,
       options: {
         optimizeContextEnabled: Boolean(context.optimizeContextEnabled),
+        safeSharingEnabled: Boolean(context.safeSharingEnabled),
         skipTestData: Boolean(context.skipTestData),
         testDataLimit: Number(context.testDataLimit) || null,
         extensions: Array.isArray(context.extensions) ? context.extensions : [],

--- a/src/bundle/outputBundleBuilder.js
+++ b/src/bundle/outputBundleBuilder.js
@@ -20,6 +20,11 @@ const {
   readAnalyzeRunManifest,
 } = require('../analyze/analyzeRunManifest');
 const { cloneReviewWorkflow } = require('../workflow/reviewWorkflowMetadata');
+const {
+  SAFE_SHARING_DIR,
+  REDACTION_MANIFEST_FILE,
+  buildSafeArtifactPath,
+} = require('../sharing/safeSharingArtifactBuilder');
 
 const MANIFEST_FILE = 'bundle-manifest.json';
 const ZIP_MANIFEST_FILE = 'manifest.json';
@@ -101,6 +106,21 @@ function collectLegacyBundleFiles(programOutputDir, includeTypes) {
   );
 }
 
+function collectSafeSharingBundleFiles(programOutputDir, includeTypes) {
+  const safeSharingDir = path.join(programOutputDir, SAFE_SHARING_DIR);
+  if (!fs.existsSync(safeSharingDir)) {
+    throw new Error(`Safe-sharing artifacts not found: ${safeSharingDir}. Run analyze --safe-sharing first.`);
+  }
+
+  return mapBundleFiles(
+    programOutputDir,
+    fs.readdirSync(safeSharingDir, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => path.posix.join(SAFE_SHARING_DIR, entry.name)),
+    includeTypes,
+  );
+}
+
 function collectManifestBundleFiles(programOutputDir, includeTypes, analyzeManifest) {
   if (!analyzeManifest || !Array.isArray(analyzeManifest.artifacts)) {
     return collectLegacyBundleFiles(programOutputDir, includeTypes);
@@ -154,7 +174,7 @@ function buildArtifactMetadata(files, analyzeManifest) {
   });
 }
 
-function buildManifest(program, files, analyzeManifest, workflowPreset) {
+function buildManifest(program, files, analyzeManifest, workflowPreset, safeSharingEnabled) {
   const artifacts = buildArtifactMetadata(files, analyzeManifest);
   const manifest = {
     schemaVersion: BUNDLE_MANIFEST_SCHEMA_VERSION,
@@ -169,6 +189,11 @@ function buildManifest(program, files, analyzeManifest, workflowPreset) {
     summary: {
       ...buildSummary(files),
       totalSizeBytes: artifacts.reduce((sum, artifact) => sum + artifact.sizeBytes, 0),
+    },
+    safeSharing: {
+      enabled: Boolean(safeSharingEnabled),
+      sourceDir: safeSharingEnabled ? SAFE_SHARING_DIR : null,
+      redactionManifestFile: safeSharingEnabled ? path.posix.join(SAFE_SHARING_DIR, REDACTION_MANIFEST_FILE) : null,
     },
   };
 
@@ -226,6 +251,10 @@ function buildReadmeText(program, manifest) {
   if (manifest.workflowPreset && manifest.workflowPreset.name) {
     lines.push(`Workflow preset: ${manifest.workflowPreset.name}`);
   }
+  if (manifest.safeSharing && manifest.safeSharing.enabled) {
+    lines.push('Safe sharing: enabled');
+    lines.push(`Redaction manifest: ${manifest.safeSharing.redactionManifestFile}`);
+  }
   if (manifest.workflowPreset && manifest.workflowPreset.reviewWorkflow) {
     const reviewWorkflow = manifest.workflowPreset.reviewWorkflow;
     if (reviewWorkflow.intendedAudience.length > 0) {
@@ -274,6 +303,7 @@ function buildOutputBundle({
   includeJson = false,
   includeMd = false,
   includeHtml = false,
+  safeSharingEnabled = false,
   artifactPaths = null,
   workflowPreset = null,
   bundleFileName = null,
@@ -293,10 +323,15 @@ function buildOutputBundle({
 
   const includeTypes = resolveIncludeTypes({ includeJson, includeMd, includeHtml });
   const analyzeManifest = readAnalyzeRunManifest(programOutputDir);
-  const files = Array.isArray(artifactPaths) && artifactPaths.length > 0
-    ? collectExplicitBundleFiles(programOutputDir, includeTypes, artifactPaths)
-    : collectManifestBundleFiles(programOutputDir, includeTypes, analyzeManifest);
-  const manifest = buildManifest(resolvedProgram, files, analyzeManifest, workflowPreset);
+  const selectedArtifactPaths = safeSharingEnabled && Array.isArray(artifactPaths) && artifactPaths.length > 0
+    ? artifactPaths.map((artifactPath) => buildSafeArtifactPath(artifactPath))
+    : artifactPaths;
+  const files = Array.isArray(selectedArtifactPaths) && selectedArtifactPaths.length > 0
+    ? collectExplicitBundleFiles(programOutputDir, includeTypes, selectedArtifactPaths)
+    : safeSharingEnabled
+      ? collectSafeSharingBundleFiles(programOutputDir, includeTypes)
+      : collectManifestBundleFiles(programOutputDir, includeTypes, analyzeManifest);
+  const manifest = buildManifest(resolvedProgram, files, analyzeManifest, workflowPreset, safeSharingEnabled);
   const zip = new AdmZip();
 
   for (const file of files) {
@@ -313,7 +348,7 @@ function buildOutputBundle({
     resolvedBundleRoot,
     bundleFileName && String(bundleFileName).trim()
       ? String(bundleFileName).trim()
-      : `${resolvedProgram}-analysis-bundle.zip`,
+      : `${resolvedProgram}${safeSharingEnabled ? '-safe-sharing' : '-analysis'}-bundle.zip`,
   );
   zip.writeZip(zipPath);
 

--- a/src/cli/commands/analyzeCommand.js
+++ b/src/cli/commands/analyzeCommand.js
@@ -21,6 +21,7 @@ const {
   readAnalyzeRunManifest,
   writeAnalyzeRunManifest,
 } = require('../../analyze/analyzeRunManifest');
+const { buildSafeSharingArtifacts } = require('../../sharing/safeSharingArtifactBuilder');
 const { listWorkflowModes, resolveWorkflowModeSettings } = require('../../workflow/workflowModeRegistry');
 const { resolvePromptTemplates } = require('../../prompt/promptBuilder');
 
@@ -103,6 +104,7 @@ function runAnalyze(args) {
     : resolvePromptTemplates();
   const testDataLimit = parsePositiveInteger(args['test-data-limit'], Number(config.testData.limit) || DEFAULT_TEST_DATA_LIMIT);
   const skipTestData = Boolean(args['skip-test-data']);
+  const safeSharingEnabled = Boolean(args['safe-sharing']);
 
   if (testDataLimit === null) {
     console.error('Invalid option: --test-data-limit must be a positive integer');
@@ -114,6 +116,7 @@ function runAnalyze(args) {
   logVerbose(`Output root: ${outputRoot}`);
   logVerbose(`Extensions: ${config.extensions.join(', ')}`);
   logVerbose(`Context optimization: ${optimizeContextEnabled ? 'enabled' : 'disabled'}`);
+  logVerbose(`Safe sharing: ${safeSharingEnabled ? 'enabled' : 'disabled'}`);
   logVerbose(`Test data extraction: ${skipTestData ? 'disabled' : `enabled (limit ${testDataLimit})`}`);
   if (guidedMode) {
     logVerbose(`Workflow mode: ${guidedMode.name}`);
@@ -166,6 +169,7 @@ function runAnalyze(args) {
         completedAt: new Date().toISOString(),
         durationMs,
         optimizeContextEnabled,
+        safeSharingEnabled,
         skipTestData,
         testDataLimit,
         extensions: config.extensions,
@@ -176,6 +180,12 @@ function runAnalyze(args) {
       previousManifest,
     });
     writeAnalyzeRunManifest(outputProgramDir, manifest);
+    if (safeSharingEnabled) {
+      buildSafeSharingArtifacts({
+        outputProgramDir,
+        analyzeManifest: manifest,
+      });
+    }
   } catch (error) {
     const durationMs = Number((process.hrtime.bigint() - startedNs) / 1000000n);
     const manifest = buildAnalyzeRunManifest({
@@ -190,6 +200,7 @@ function runAnalyze(args) {
         completedAt: new Date().toISOString(),
         durationMs,
         optimizeContextEnabled,
+        safeSharingEnabled,
         skipTestData,
         testDataLimit,
         extensions: config.extensions,
@@ -209,6 +220,9 @@ function runAnalyze(args) {
   }
   if (workflowPreset) {
     console.log(`Workflow preset: ${workflowPreset.name}`);
+  }
+  if (safeSharingEnabled) {
+    console.log(`Safe-sharing artifacts: ${path.join(outputProgramDir, 'safe-sharing')}`);
   }
   console.log(`Source files scanned: ${(result.scanSummary.sourceFiles || []).length}`);
   if (result.optimizationReport.enabled) {

--- a/src/cli/commands/bundleCommand.js
+++ b/src/cli/commands/bundleCommand.js
@@ -30,6 +30,7 @@ function runBundle(args) {
     includeJson: args['include-json'] === true,
     includeMd: args['include-md'] === true,
     includeHtml: args['include-html'] === true,
+    safeSharingEnabled: Boolean(args['safe-sharing']),
     artifactPaths: Array.isArray(args['artifact-paths']) ? args['artifact-paths'] : null,
     workflowPreset: args['workflow-preset-settings'] || null,
     bundleFileName: args['bundle-file-name'] || null,
@@ -41,6 +42,9 @@ function runBundle(args) {
   }
 
   console.log(`Bundle created for program ${result.program}`);
+  if (result.manifest.safeSharing && result.manifest.safeSharing.enabled) {
+    console.log('Safe-sharing bundle: enabled');
+  }
   console.log(`Files included: ${result.manifest.summary.totalFiles}`);
   console.log(`Bundle written to: ${result.zipPath}`);
   return result;

--- a/src/db2/metadataExportService.js
+++ b/src/db2/metadataExportService.js
@@ -126,7 +126,7 @@ function renderLength(column) {
   return String(column.length);
 }
 
-function renderMarkdown(program, tables) {
+function renderDb2MetadataMarkdown(program, tables) {
   const lines = [
     '# DB2 Metadata',
     '',
@@ -242,7 +242,7 @@ function exportDb2Metadata({ program, dependencies, dbConfig, outputDir, verbose
       tables: [],
       tableLinks: linkage.tableLinks,
     };
-    writeOutputs(outputDir, payload, renderMarkdown(program, []));
+    writeOutputs(outputDir, payload, renderDb2MetadataMarkdown(program, []));
     return {
       payload,
       summary: {
@@ -307,7 +307,7 @@ function exportDb2Metadata({ program, dependencies, dbConfig, outputDir, verbose
       tables: linkedTables,
       tableLinks: linkage.tableLinks,
     };
-    writeOutputs(outputDir, payload, renderMarkdown(program, linkedTables));
+    writeOutputs(outputDir, payload, renderDb2MetadataMarkdown(program, linkedTables));
 
     const unresolvedTables = linkage.unresolvedTables;
     const notes = [];
@@ -358,4 +358,5 @@ function exportDb2Metadata({ program, dependencies, dbConfig, outputDir, verbose
 
 module.exports = {
   exportDb2Metadata,
+  renderDb2MetadataMarkdown,
 };

--- a/src/db2/testDataExportService.js
+++ b/src/db2/testDataExportService.js
@@ -245,7 +245,7 @@ function renderTableMarkdown(table) {
   return lines;
 }
 
-function renderMarkdown(program, rowLimit, tables, notes) {
+function renderTestDataMarkdown(program, rowLimit, tables, notes) {
   const lines = [
     '# Test Data Extract',
     '',
@@ -368,7 +368,7 @@ function exportTestData({
       tables: [],
       notes,
     };
-    writeOutputs(outputDir, payload, renderMarkdown(program, rowLimit, [], notes));
+    writeOutputs(outputDir, payload, renderTestDataMarkdown(program, rowLimit, [], notes));
     return {
       payload,
       summary: {
@@ -491,7 +491,7 @@ function exportTestData({
     tables,
     notes: sortedNotes,
   };
-  writeOutputs(outputDir, payload, renderMarkdown(program, rowLimit, tables, sortedNotes));
+  writeOutputs(outputDir, payload, renderTestDataMarkdown(program, rowLimit, tables, sortedNotes));
 
   return {
     payload,
@@ -521,4 +521,5 @@ function exportTestData({
 module.exports = {
   exportTestData,
   DEFAULT_TEST_DATA_LIMIT,
+  renderTestDataMarkdown,
 };

--- a/src/sharing/safeSharingArtifactBuilder.js
+++ b/src/sharing/safeSharingArtifactBuilder.js
@@ -1,0 +1,723 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+const { renderJson, renderMermaid, renderMarkdown, renderCrossProgramMarkdown } = require('../dependency/graphSerializer');
+const { generateMarkdownReport } = require('../report/markdownReport');
+const { renderArchitectureReport } = require('../report/architectureReport');
+const { buildPrompts, resolvePromptTemplates } = require('../prompt/promptBuilder');
+const { getPromptContract } = require('../prompt/promptRegistry');
+const { renderHtml } = require('../viewer/architectureViewerGenerator');
+const { renderDb2MetadataMarkdown } = require('../db2/metadataExportService');
+const { renderTestDataMarkdown } = require('../db2/testDataExportService');
+const { readAnalyzeRunManifest } = require('../analyze/analyzeRunManifest');
+
+const SAFE_SHARING_DIR = 'safe-sharing';
+const REDACTION_MANIFEST_FILE = 'redaction-manifest.json';
+const REDACTION_MANIFEST_SCHEMA_VERSION = 1;
+
+const CATEGORY_PREFIX = Object.freeze({
+  PROGRAM: 'PROGRAM',
+  TABLE: 'TABLE',
+  COPY_MEMBER: 'COPY_MEMBER',
+  NATIVE_FILE: 'NATIVE_FILE',
+  PROCEDURE: 'PROCEDURE',
+  PROTOTYPE: 'PROTOTYPE',
+  MODULE: 'MODULE',
+  SERVICE_PROGRAM: 'SERVICE_PROGRAM',
+  BINDING_DIRECTORY: 'BINDING_DIRECTORY',
+  RECORD_FORMAT: 'RECORD_FORMAT',
+  SOURCE_FILE: 'SOURCE_FILE',
+  SOURCE_LIBRARY: 'SOURCE_LIBRARY',
+  SOURCE_FILE_SET: 'SOURCE_FILE_SET',
+  MEMBER: 'MEMBER',
+  SCHEMA: 'SCHEMA',
+  VALUE: 'VALUE',
+});
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function readJsonIfExists(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function readTextIfExists(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return '';
+  }
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function writeJson(filePath, value) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function writeText(filePath, value) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, value, 'utf8');
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function escapeRegExp(value) {
+  return String(value || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function uniqueSortedStrings(values) {
+  return Array.from(new Set(asArray(values).map((value) => String(value || '').trim()).filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function normalizePathString(value) {
+  return String(value || '').trim().replace(/\\/g, '/');
+}
+
+function collectSourceArtifactPaths(analyzeManifest) {
+  const artifactPaths = Array.isArray(analyzeManifest && analyzeManifest.artifacts)
+    ? analyzeManifest.artifacts.map((artifact) => artifact.path)
+    : [];
+  return uniqueSortedStrings([
+    'analyze-run-manifest.json',
+    ...artifactPaths,
+  ]);
+}
+
+function buildSafeArtifactPath(artifactPath) {
+  return `${SAFE_SHARING_DIR}/${String(artifactPath || '').replace(/\\/g, '/')}`;
+}
+
+function extractOptimizationReport(analyzeManifest) {
+  const stage = asArray(analyzeManifest && analyzeManifest.stages)
+    .find((entry) => entry.id === 'optimize-context');
+  const metadata = stage && stage.metadata ? stage.metadata : {};
+  const safeSharingEnabled = Boolean(analyzeManifest
+    && analyzeManifest.inputs
+    && analyzeManifest.inputs.options
+    && analyzeManifest.inputs.options.safeSharingEnabled);
+  return {
+    enabled: Boolean(metadata.enabled),
+    contextTokens: Number(metadata.contextTokens) || 0,
+    optimizedTokens: Number(metadata.optimizedTokens) || Number(metadata.contextTokens) || 0,
+    reductionPercent: Number(metadata.reductionPercent) || 0,
+    softTokenLimit: 0,
+    warning: false,
+    safeSharingEnabled,
+  };
+}
+
+function resolvePromptTemplatesFromManifest(analyzeManifest) {
+  const options = analyzeManifest && analyzeManifest.inputs && analyzeManifest.inputs.options
+    ? analyzeManifest.inputs.options
+    : {};
+  const presetTemplates = options.workflowPreset && Array.isArray(options.workflowPreset.promptTemplates)
+    ? options.workflowPreset.promptTemplates
+    : [];
+  const guidedTemplates = options.guidedMode && Array.isArray(options.guidedMode.promptTemplates)
+    ? options.guidedMode.promptTemplates
+    : [];
+  const selected = presetTemplates.length > 0 ? presetTemplates : guidedTemplates;
+  return resolvePromptTemplates(selected.length > 0 ? selected : null);
+}
+
+function buildArtifactContext(outputProgramDir, sourceArtifactPaths) {
+  const canonicalAnalysis = readJsonIfExists(path.join(outputProgramDir, 'canonical-analysis.json'));
+  const context = readJsonIfExists(path.join(outputProgramDir, 'context.json'));
+  const optimizedContext = readJsonIfExists(path.join(outputProgramDir, 'optimized-context.json'));
+  const aiKnowledge = readJsonIfExists(path.join(outputProgramDir, 'ai-knowledge.json'));
+  const analysisIndex = readJsonIfExists(path.join(outputProgramDir, 'analysis-index.json'));
+  const dependencyGraph = readJsonIfExists(path.join(outputProgramDir, 'dependency-graph.json'));
+  const crossProgramGraph = readJsonIfExists(path.join(outputProgramDir, 'program-call-tree.json'));
+  const db2Metadata = readJsonIfExists(path.join(outputProgramDir, 'db2-metadata.json'));
+  const testData = readJsonIfExists(path.join(outputProgramDir, 'test-data.json'));
+  const analyzeManifest = readJsonIfExists(path.join(outputProgramDir, 'analyze-run-manifest.json'));
+  const safeArtifactPaths = sourceArtifactPaths.map((artifactPath) => buildSafeArtifactPath(artifactPath));
+
+  return {
+    canonicalAnalysis,
+    context,
+    optimizedContext,
+    aiKnowledge,
+    analysisIndex,
+    dependencyGraph,
+    crossProgramGraph,
+    db2Metadata,
+    testData,
+    analyzeManifest,
+    sourceArtifactPaths,
+    safeArtifactPaths,
+  };
+}
+
+function createRedactor({ sourceArtifactPaths, safeArtifactPaths, analyzeManifest }) {
+  const replacementMap = new Map();
+  const categoryCounters = new Map();
+  const valueMap = new Map();
+  const generatedArtifactPaths = new Set([
+    ...sourceArtifactPaths,
+    ...safeArtifactPaths,
+    REDACTION_MANIFEST_FILE,
+    `${SAFE_SHARING_DIR}/${REDACTION_MANIFEST_FILE}`,
+  ]);
+  const exactFixedPaths = new Map();
+  const sourceRoot = analyzeManifest && analyzeManifest.inputs ? analyzeManifest.inputs.sourceRoot : null;
+  const outputRoot = analyzeManifest && analyzeManifest.inputs ? analyzeManifest.inputs.outputRoot : null;
+  const outputDir = analyzeManifest && analyzeManifest.run ? analyzeManifest.run.outputDir : null;
+  const cwd = analyzeManifest && analyzeManifest.run ? analyzeManifest.run.cwd : null;
+
+  if (sourceRoot) exactFixedPaths.set(String(sourceRoot), 'SAFE_SHARING_SOURCE_ROOT');
+  if (outputRoot) exactFixedPaths.set(String(outputRoot), 'SAFE_SHARING_OUTPUT_ROOT');
+  if (outputDir) exactFixedPaths.set(String(outputDir), 'SAFE_SHARING_OUTPUT_DIR');
+  if (cwd) exactFixedPaths.set(String(cwd), 'SAFE_SHARING_WORKSPACE');
+
+  function nextPlaceholder(category) {
+    const current = Number(categoryCounters.get(category) || 0) + 1;
+    categoryCounters.set(category, current);
+    return `${CATEGORY_PREFIX[category] || category}_${String(current).padStart(3, '0')}`;
+  }
+
+  function registerExactValue(rawValue, placeholder) {
+    const normalized = String(rawValue || '').trim();
+    if (!normalized || generatedArtifactPaths.has(normalized)) {
+      return;
+    }
+    if (!replacementMap.has(normalized)) {
+      replacementMap.set(normalized, placeholder);
+    }
+  }
+
+  function registerCategoryValue(category, rawValue) {
+    const normalized = String(rawValue || '').trim();
+    if (!normalized || generatedArtifactPaths.has(normalized) || replacementMap.has(normalized)) {
+      return;
+    }
+    if (category === 'SOURCE_FILE') {
+      const ext = path.extname(normalized);
+      registerExactValue(normalized, `${nextPlaceholder(category)}${ext}`);
+      return;
+    }
+    registerExactValue(normalized, nextPlaceholder(category));
+  }
+
+  function registerDataValue(rawValue) {
+    const normalized = String(rawValue || '').trim();
+    if (!normalized) {
+      return normalized;
+    }
+    if (!valueMap.has(normalized)) {
+      valueMap.set(normalized, nextPlaceholder('VALUE'));
+    }
+    return valueMap.get(normalized);
+  }
+
+  function pathEndsWith(pathValue, suffixes) {
+    return suffixes.some((suffix) => pathValue.endsWith(suffix));
+  }
+
+  function isPathFragment(pathValue, fragments) {
+    return fragments.some((fragment) => pathValue.includes(fragment));
+  }
+
+  function collectString(pathValue, rawValue) {
+    const value = String(rawValue || '').trim();
+    if (!value || generatedArtifactPaths.has(value)) {
+      return;
+    }
+
+    if (exactFixedPaths.has(value)) {
+      registerExactValue(value, exactFixedPaths.get(value));
+      return;
+    }
+
+    if (
+      pathEndsWith(pathValue, [
+        '.rootProgram',
+        '.program',
+        '.ownerProgram',
+      ])
+      || isPathFragment(pathValue, [
+        '.entities.programs.[].name',
+        '.dependencies.programCalls.[].name',
+        '.programCalls.[].name',
+        '.unresolvedPrograms.[]',
+        '.ambiguousPrograms.[]',
+        '.primaryCalls.[]',
+      ])
+    ) {
+      registerCategoryValue('PROGRAM', value);
+      return;
+    }
+
+    if (
+      isPathFragment(pathValue, [
+        '.entities.tables.[].name',
+        '.dependencies.tables.[].name',
+        '.sqlStatements.[].tables.[',
+        '.sql.statements.[].tables.[',
+        '.db2Metadata.tables.[].requestedName',
+        '.db2Metadata.tables.[].table',
+        '.db2Tables.[].requestedName',
+        '.db2Tables.[].table',
+        '.testData.tables.[].table',
+        '.tableLinks.[].requestedName',
+        '.matches.[].table',
+        '.unresolvedTables.[]',
+      ])
+    ) {
+      registerCategoryValue('TABLE', value);
+      return;
+    }
+
+    if (
+      isPathFragment(pathValue, [
+        '.entities.copyMembers.[].name',
+        '.dependencies.copyMembers.[].name',
+        '.copyMembers.[].name',
+      ])
+    ) {
+      registerCategoryValue('COPY_MEMBER', value);
+      return;
+    }
+
+    if (
+      isPathFragment(pathValue, [
+        '.entities.nativeFiles.[].name',
+        '.nativeFileUsage.files.[].name',
+        '.nativeFiles.[].name',
+      ])
+    ) {
+      registerCategoryValue('NATIVE_FILE', value);
+      return;
+    }
+
+    if (
+      isPathFragment(pathValue, [
+        '.entities.modules.[].name',
+        '.bindingAnalysis.modules.[].name',
+        '.modules.[].name',
+      ])
+    ) {
+      registerCategoryValue('MODULE', value);
+      return;
+    }
+
+    if (
+      isPathFragment(pathValue, [
+        '.entities.servicePrograms.[].name',
+        '.bindingAnalysis.servicePrograms.[].name',
+        '.servicePrograms.[].name',
+      ])
+    ) {
+      registerCategoryValue('SERVICE_PROGRAM', value);
+      return;
+    }
+
+    if (
+      isPathFragment(pathValue, [
+        '.entities.bindingDirectories.[].name',
+        '.bindingAnalysis.bindingDirectories.[].name',
+        '.bindingDirectories.[]',
+      ])
+    ) {
+      registerCategoryValue('BINDING_DIRECTORY', value);
+      return;
+    }
+
+    if (
+      isPathFragment(pathValue, [
+        '.entities.procedures.[].name',
+        '.procedureAnalysis.procedures.[].name',
+        '.calls.[].caller',
+        '.calls.[].target',
+        '.exports.[].symbol',
+        '.attributes.targetName',
+      ])
+    ) {
+      registerCategoryValue('PROCEDURE', value);
+      return;
+    }
+
+    if (
+      isPathFragment(pathValue, [
+        '.entities.prototypes.[].name',
+        '.procedureAnalysis.prototypes.[].name',
+        '.importedProcedures.[]',
+        '.externalName',
+      ])
+    ) {
+      registerCategoryValue('PROTOTYPE', value);
+      return;
+    }
+
+    if (isPathFragment(pathValue, ['.recordFormats.[].name'])) {
+      registerCategoryValue('RECORD_FORMAT', value);
+      return;
+    }
+
+    if (
+      pathEndsWith(pathValue, ['.schema', '.referencesSchema'])
+      || isPathFragment(pathValue, ['.matchedSchemas.[]'])
+    ) {
+      registerCategoryValue('SCHEMA', value);
+      return;
+    }
+
+    if (pathEndsWith(pathValue, ['.sourceLib'])) {
+      registerCategoryValue('SOURCE_LIBRARY', value);
+      return;
+    }
+
+    if (isPathFragment(pathValue, ['.provenance.import.sourceFile'])) {
+      registerCategoryValue('SOURCE_FILE_SET', value);
+      return;
+    }
+
+    if (pathEndsWith(pathValue, ['.member'])) {
+      registerCategoryValue('MEMBER', value);
+      return;
+    }
+
+    if (
+      pathEndsWith(pathValue, ['.sourceRoot', '.outputRoot', '.outputDir', '.cwd'])
+      || isPathFragment(pathValue, [
+        '.sourceFiles.[].path',
+        '.sourceSnapshot.files.[].path',
+        '.evidence.[].file',
+        '.sourceEvidence.[].file',
+      ])
+    ) {
+      registerCategoryValue('SOURCE_FILE', normalizePathString(value));
+    }
+
+    if (
+      isPathFragment(pathValue, [
+        '.sqlStatements.[].text',
+        '.sql.statements.[].text',
+        '.snippet',
+      ])
+    ) {
+      const matches = value.matchAll(/\b([A-Z][A-Z0-9_#$@]*)[/.]([A-Z][A-Z0-9_#$@]*)\b/g);
+      for (const match of matches) {
+        registerCategoryValue('SCHEMA', match[1]);
+        registerCategoryValue('TABLE', match[2]);
+      }
+    }
+  }
+
+  function collectObject(value, pathSegments = []) {
+    if (Array.isArray(value)) {
+      value.forEach((entry) => collectObject(entry, [...pathSegments, '[]']));
+      return;
+    }
+    if (!value || typeof value !== 'object') {
+      if (typeof value === 'string') {
+        collectString(pathSegments.join('.'), value);
+      }
+      return;
+    }
+    for (const [key, entry] of Object.entries(value)) {
+      collectObject(entry, [...pathSegments, key]);
+    }
+  }
+
+  function finalize() {
+    for (const [rawValue, placeholder] of exactFixedPaths.entries()) {
+      registerExactValue(rawValue, placeholder);
+    }
+  }
+
+  function redactQuotedLiterals(text) {
+    return String(text || '').replace(/'([^']*)'/g, (match, literal) => `'${registerDataValue(literal)}'`);
+  }
+
+  function redactText(text) {
+    if (text === null || text === undefined) {
+      return text;
+    }
+    const raw = String(text);
+    if (generatedArtifactPaths.has(raw)) {
+      return raw;
+    }
+
+    let redacted = redactQuotedLiterals(raw);
+    const entries = Array.from(replacementMap.entries())
+      .sort((a, b) => b[0].length - a[0].length || a[0].localeCompare(b[0]));
+    for (const [rawValue, placeholder] of entries) {
+      redacted = redacted.replace(new RegExp(escapeRegExp(rawValue), 'g'), placeholder);
+    }
+    return redacted;
+  }
+
+  function shouldRedactDataValue(pathValue) {
+    return pathValue.includes('.rows.[]');
+  }
+
+  function redactObject(value, pathSegments = []) {
+    const pathValue = pathSegments.join('.');
+    if (Array.isArray(value)) {
+      return value.map((entry) => redactObject(entry, [...pathSegments, '[]']));
+    }
+    if (!value || typeof value !== 'object') {
+      if (typeof value === 'string') {
+        const normalized = normalizePathString(value);
+        if (replacementMap.has(normalized)) {
+          return replacementMap.get(normalized);
+        }
+        if (replacementMap.has(value)) {
+          return replacementMap.get(value);
+        }
+        if (shouldRedactDataValue(pathValue)) {
+          return registerDataValue(value);
+        }
+        return redactText(value);
+      }
+      if (shouldRedactDataValue(pathValue) && (typeof value === 'number' || typeof value === 'bigint')) {
+        return registerDataValue(value);
+      }
+      return value;
+    }
+    const redacted = {};
+    for (const [key, entry] of Object.entries(value)) {
+      redacted[key] = redactObject(entry, [...pathSegments, key]);
+    }
+    return redacted;
+  }
+
+  function buildSummary() {
+    const placeholderCounts = {};
+    for (const [category, count] of categoryCounters.entries()) {
+      placeholderCounts[category] = count;
+    }
+    return {
+      placeholderCounts,
+      replacementCount: replacementMap.size,
+      dataValueCount: valueMap.size,
+    };
+  }
+
+  return {
+    collectObject,
+    finalize,
+    redactObject,
+    redactText,
+    buildSummary,
+  };
+}
+
+function buildGeneratedArtifactSet(context) {
+  const generated = [];
+  const outputProgramDir = context.outputProgramDir;
+  const safeDir = path.join(outputProgramDir, SAFE_SHARING_DIR);
+  ensureDir(safeDir);
+
+  const redactor = createRedactor({
+    sourceArtifactPaths: context.sourceArtifactPaths,
+    safeArtifactPaths: context.safeArtifactPaths,
+    analyzeManifest: context.analyzeManifest,
+  });
+
+  const structuredArtifacts = [
+    ['canonical', context.canonicalAnalysis],
+    ['context', context.context],
+    ['optimizedContext', context.optimizedContext],
+    ['aiKnowledge', context.aiKnowledge],
+    ['analysisIndex', context.analysisIndex],
+    ['dependencyGraph', context.dependencyGraph],
+    ['crossProgramGraph', context.crossProgramGraph],
+    ['db2Metadata', context.db2Metadata],
+    ['testData', context.testData],
+    ['analyzeManifest', context.analyzeManifest],
+  ];
+
+  for (const [label, value] of structuredArtifacts) {
+    if (value) {
+      redactor.collectObject(value, [label]);
+    }
+  }
+  redactor.finalize();
+
+  const redactedCanonical = context.canonicalAnalysis ? redactor.redactObject(context.canonicalAnalysis, ['canonical']) : null;
+  const redactedContext = context.context ? redactor.redactObject(context.context, ['context']) : null;
+  const redactedOptimizedContext = context.optimizedContext ? redactor.redactObject(context.optimizedContext, ['optimizedContext']) : null;
+  const redactedAiKnowledge = context.aiKnowledge ? redactor.redactObject(context.aiKnowledge, ['aiKnowledge']) : null;
+  const redactedAnalysisIndex = context.analysisIndex ? redactor.redactObject(context.analysisIndex, ['analysisIndex']) : null;
+  const redactedDependencyGraph = context.dependencyGraph ? redactor.redactObject(context.dependencyGraph, ['dependencyGraph']) : null;
+  const redactedCrossProgramGraph = context.crossProgramGraph ? redactor.redactObject(context.crossProgramGraph, ['crossProgramGraph']) : null;
+  const redactedDb2Metadata = context.db2Metadata ? redactor.redactObject(context.db2Metadata, ['db2Metadata']) : null;
+  const redactedTestData = context.testData ? redactor.redactObject(context.testData, ['testData']) : null;
+  const redactedAnalyzeManifest = context.analyzeManifest ? redactor.redactObject(context.analyzeManifest, ['analyzeManifest']) : null;
+
+  if (redactedCanonical) {
+    writeJson(path.join(safeDir, 'canonical-analysis.json'), redactedCanonical);
+    generated.push(buildSafeArtifactPath('canonical-analysis.json'));
+  }
+  if (redactedContext) {
+    writeJson(path.join(safeDir, 'context.json'), redactedContext);
+    generated.push(buildSafeArtifactPath('context.json'));
+  }
+  if (redactedOptimizedContext) {
+    writeJson(path.join(safeDir, 'optimized-context.json'), redactedOptimizedContext);
+    generated.push(buildSafeArtifactPath('optimized-context.json'));
+  }
+  if (redactedAiKnowledge) {
+    writeJson(path.join(safeDir, 'ai-knowledge.json'), redactedAiKnowledge);
+    generated.push(buildSafeArtifactPath('ai-knowledge.json'));
+  }
+  if (redactedAnalysisIndex) {
+    writeJson(path.join(safeDir, 'analysis-index.json'), redactedAnalysisIndex);
+    generated.push(buildSafeArtifactPath('analysis-index.json'));
+  }
+  if (redactedDependencyGraph) {
+    writeText(path.join(safeDir, 'dependency-graph.json'), renderJson(redactedDependencyGraph));
+    writeText(path.join(safeDir, 'dependency-graph.mmd'), renderMermaid(redactedDependencyGraph));
+    writeText(path.join(safeDir, 'dependency-graph.md'), renderMarkdown(redactedDependencyGraph));
+    generated.push(
+      buildSafeArtifactPath('dependency-graph.json'),
+      buildSafeArtifactPath('dependency-graph.mmd'),
+      buildSafeArtifactPath('dependency-graph.md'),
+    );
+  }
+  if (redactedCrossProgramGraph) {
+    writeText(path.join(safeDir, 'program-call-tree.json'), renderJson(redactedCrossProgramGraph));
+    writeText(path.join(safeDir, 'program-call-tree.mmd'), renderMermaid(redactedCrossProgramGraph));
+    writeText(path.join(safeDir, 'program-call-tree.md'), renderCrossProgramMarkdown(redactedCrossProgramGraph));
+    writeText(path.join(safeDir, 'architecture.html'), renderHtml(redactedCrossProgramGraph));
+    generated.push(
+      buildSafeArtifactPath('program-call-tree.json'),
+      buildSafeArtifactPath('program-call-tree.mmd'),
+      buildSafeArtifactPath('program-call-tree.md'),
+      buildSafeArtifactPath('architecture.html'),
+    );
+  }
+  if (redactedContext) {
+    const reportMarkdown = generateMarkdownReport(redactedContext, extractOptimizationReport(context.analyzeManifest));
+    writeText(path.join(safeDir, 'report.md'), reportMarkdown);
+    generated.push(buildSafeArtifactPath('report.md'));
+  }
+  if (redactedContext && redactedDependencyGraph) {
+    const architectureReport = renderArchitectureReport({
+      context: redactedContext,
+      graph: redactedDependencyGraph,
+      optimizedContext: redactedOptimizedContext,
+      mermaidText: '',
+    });
+    writeText(path.join(safeDir, 'architecture-report.md'), architectureReport);
+    generated.push(buildSafeArtifactPath('architecture-report.md'));
+  }
+  if (redactedAiKnowledge) {
+    const promptTemplates = resolvePromptTemplatesFromManifest(context.analyzeManifest);
+    buildPrompts({
+      aiProjection: redactedAiKnowledge,
+      outputDir: safeDir,
+      templates: promptTemplates,
+    });
+    for (const templateName of promptTemplates) {
+      generated.push(buildSafeArtifactPath(getPromptContract(templateName).outputFileName));
+    }
+  }
+  if (redactedDb2Metadata) {
+    writeJson(path.join(safeDir, 'db2-metadata.json'), redactedDb2Metadata);
+    writeText(
+      path.join(safeDir, 'db2-metadata.md'),
+      renderDb2MetadataMarkdown(redactedDb2Metadata.program, redactedDb2Metadata.tables || []),
+    );
+    generated.push(buildSafeArtifactPath('db2-metadata.json'), buildSafeArtifactPath('db2-metadata.md'));
+  }
+  if (redactedTestData) {
+    writeJson(path.join(safeDir, 'test-data.json'), redactedTestData);
+    writeText(
+      path.join(safeDir, 'test-data.md'),
+      renderTestDataMarkdown(
+        redactedTestData.program,
+        redactedTestData.rowLimit,
+        redactedTestData.tables || [],
+        redactedTestData.notes || [],
+      ),
+    );
+    generated.push(buildSafeArtifactPath('test-data.json'), buildSafeArtifactPath('test-data.md'));
+  }
+  if (redactedAnalyzeManifest) {
+    writeJson(path.join(safeDir, 'analyze-run-manifest.json'), redactedAnalyzeManifest);
+    generated.push(buildSafeArtifactPath('analyze-run-manifest.json'));
+  }
+
+  const regenerated = new Set(generated);
+  for (const artifactPath of context.sourceArtifactPaths) {
+    const sourcePath = path.join(outputProgramDir, artifactPath);
+    const safePath = path.join(safeDir, artifactPath);
+    if (!fs.existsSync(sourcePath) || regenerated.has(buildSafeArtifactPath(artifactPath))) {
+      continue;
+    }
+    const ext = path.extname(artifactPath).toLowerCase();
+    if (ext === '.md' || ext === '.mmd' || ext === '.html') {
+      writeText(safePath, redactor.redactText(readTextIfExists(sourcePath)));
+      generated.push(buildSafeArtifactPath(artifactPath));
+    } else if (ext === '.json') {
+      writeJson(safePath, redactor.redactObject(readJsonIfExists(sourcePath), ['artifact', artifactPath]));
+      generated.push(buildSafeArtifactPath(artifactPath));
+    }
+  }
+
+  const redactionManifest = {
+    schemaVersion: REDACTION_MANIFEST_SCHEMA_VERSION,
+    kind: 'safe-sharing-redaction-manifest',
+    generatedAt: new Date().toISOString(),
+    sourceArtifactCount: context.sourceArtifactPaths.length,
+    redactedArtifactCount: generated.length,
+    sourceArtifacts: [...context.sourceArtifactPaths],
+    redactedArtifacts: [...generated].sort((a, b) => a.localeCompare(b)),
+    safeSharingDirectory: SAFE_SHARING_DIR,
+    summary: redactor.buildSummary(),
+    notes: [
+      'Reverse placeholder mappings are intentionally not exported.',
+      'Redacted artifacts preserve workflow structure but replace sensitive identifiers and extracted values.',
+    ],
+  };
+  writeJson(path.join(safeDir, REDACTION_MANIFEST_FILE), redactionManifest);
+  generated.push(buildSafeArtifactPath(REDACTION_MANIFEST_FILE));
+
+  return {
+    generatedFiles: uniqueSortedStrings(generated),
+    redactionManifest,
+  };
+}
+
+function buildSafeSharingArtifacts({ outputProgramDir, analyzeManifest = null }) {
+  const resolvedManifest = analyzeManifest || readAnalyzeRunManifest(outputProgramDir);
+  if (!resolvedManifest) {
+    throw new Error(`Analyze manifest not found for safe-sharing artifacts: ${outputProgramDir}`);
+  }
+
+  const sourceArtifactPaths = collectSourceArtifactPaths(resolvedManifest);
+  const context = buildArtifactContext(outputProgramDir, sourceArtifactPaths);
+  return buildGeneratedArtifactSet({
+    ...context,
+    outputProgramDir,
+  });
+}
+
+module.exports = {
+  SAFE_SHARING_DIR,
+  REDACTION_MANIFEST_FILE,
+  REDACTION_MANIFEST_SCHEMA_VERSION,
+  buildSafeArtifactPath,
+  buildSafeSharingArtifacts,
+};

--- a/src/viewer/architectureViewerGenerator.js
+++ b/src/viewer/architectureViewerGenerator.js
@@ -299,4 +299,5 @@ function generateArchitectureViewer({ graphPath, outputPath }) {
 
 module.exports = {
   generateArchitectureViewer,
+  renderHtml,
 };

--- a/src/workflow/workflowRunManifest.js
+++ b/src/workflow/workflowRunManifest.js
@@ -39,6 +39,9 @@ function buildWorkflowRunManifest({ preset, analyzeManifest, bundleManifest, bun
       status: analyzeManifest.run ? analyzeManifest.run.status : null,
       completedAt: analyzeManifest.run ? analyzeManifest.run.completedAt : null,
       generatedArtifactCount: analyzeManifest.summary ? analyzeManifest.summary.generatedArtifactCount : 0,
+      safeSharingEnabled: analyzeManifest.inputs && analyzeManifest.inputs.options
+        ? Boolean(analyzeManifest.inputs.options.safeSharingEnabled)
+        : false,
       guidedMode: analyzeManifest.inputs && analyzeManifest.inputs.options
         ? analyzeManifest.inputs.options.guidedMode
         : null,

--- a/tests/safe-sharing.test.js
+++ b/tests/safe-sharing.test.js
@@ -1,0 +1,127 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const AdmZip = require('adm-zip');
+
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'cli', 'zeus.js');
+const fixtureRoot = path.join(__dirname, 'fixtures', 'v1-smoke', 'src');
+
+function runCli(args, cwd) {
+  return execFileSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('analyze --safe-sharing writes redacted variants with stable placeholders', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-safe-sharing-analyze-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const outputRoot = path.join(tempRoot, 'output');
+
+  fs.cpSync(fixtureRoot, sourceRoot, { recursive: true });
+
+  try {
+    runCli([
+      'analyze',
+      '--source',
+      sourceRoot,
+      '--program',
+      'ORDERPGM',
+      '--out',
+      outputRoot,
+      '--safe-sharing',
+      '--mode',
+      'modernization',
+    ], projectRoot);
+
+    const safeDir = path.join(outputRoot, 'ORDERPGM', 'safe-sharing');
+    assert.equal(fs.existsSync(path.join(safeDir, 'context.json')), true);
+    assert.equal(fs.existsSync(path.join(safeDir, 'ai-knowledge.json')), true);
+    assert.equal(fs.existsSync(path.join(safeDir, 'report.md')), true);
+    assert.equal(fs.existsSync(path.join(safeDir, 'ai_prompt_documentation.md')), true);
+    assert.equal(fs.existsSync(path.join(safeDir, 'ai_prompt_modernization.md')), true);
+    assert.equal(fs.existsSync(path.join(safeDir, 'analyze-run-manifest.json')), true);
+    assert.equal(fs.existsSync(path.join(safeDir, 'redaction-manifest.json')), true);
+
+    const safeContext = readJson(path.join(safeDir, 'context.json'));
+    const safeManifest = readJson(path.join(safeDir, 'redaction-manifest.json'));
+    const safeReport = fs.readFileSync(path.join(safeDir, 'report.md'), 'utf8');
+    const safePrompt = fs.readFileSync(path.join(safeDir, 'ai_prompt_modernization.md'), 'utf8');
+
+    assert.equal(safeContext.program, 'PROGRAM_001');
+    assert.ok(safeContext.dependencies.tables.every((entry) => /^TABLE_\d{3}$/.test(entry.name)));
+    assert.ok(safeContext.dependencies.programCalls.every((entry) => /^PROGRAM_\d{3}$/.test(entry.name)));
+    assert.match(safeReport, /PROGRAM_001/);
+    assert.match(safePrompt, /PROGRAM_001/);
+    assert.match(safePrompt, /VALUE_\d{3}/);
+    assert.doesNotMatch(safeReport, /ORDERPGM|INVPGM|CUSTOMER|ORDERS|INVOICE|MYLIB|READY|NEW/);
+    assert.doesNotMatch(safePrompt, /ORDERPGM|INVPGM|CUSTOMER|ORDERS|INVOICE|MYLIB|READY|NEW/);
+    assert.ok(safeManifest.summary.placeholderCounts.PROGRAM >= 1);
+    assert.ok(safeManifest.summary.placeholderCounts.TABLE >= 1);
+    assert.ok(safeManifest.summary.placeholderCounts.VALUE >= 1);
+    assert.ok(safeManifest.redactedArtifacts.includes('safe-sharing/report.md'));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('bundle --safe-sharing packages only redacted shareable artifacts', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-safe-sharing-bundle-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const outputRoot = path.join(tempRoot, 'output');
+  const bundleRoot = path.join(tempRoot, 'bundles');
+
+  fs.cpSync(fixtureRoot, sourceRoot, { recursive: true });
+
+  try {
+    runCli([
+      'analyze',
+      '--source',
+      sourceRoot,
+      '--program',
+      'ORDERPGM',
+      '--out',
+      outputRoot,
+      '--safe-sharing',
+    ], projectRoot);
+
+    runCli([
+      'bundle',
+      '--program',
+      'ORDERPGM',
+      '--source-output-root',
+      outputRoot,
+      '--output',
+      bundleRoot,
+      '--safe-sharing',
+    ], projectRoot);
+
+    const bundlePath = path.join(bundleRoot, 'ORDERPGM-safe-sharing-bundle.zip');
+    const bundleManifest = readJson(path.join(outputRoot, 'ORDERPGM', 'bundle-manifest.json'));
+    const zip = new AdmZip(bundlePath);
+    const entryNames = zip.getEntries().map((entry) => entry.entryName).sort();
+    const readme = zip.readAsText('README.txt');
+
+    assert.equal(fs.existsSync(bundlePath), true);
+    assert.equal(bundleManifest.safeSharing.enabled, true);
+    assert.ok(bundleManifest.files.every((entry) => entry.startsWith('safe-sharing/')));
+    assert.ok(entryNames.includes('safe-sharing/report.md'));
+    assert.ok(entryNames.includes('safe-sharing/context.json'));
+    assert.ok(entryNames.includes('safe-sharing/redaction-manifest.json'));
+    assert.equal(entryNames.includes('report.md'), false);
+    assert.equal(entryNames.includes('context.json'), false);
+    assert.match(readme, /Safe sharing: enabled/);
+    assert.match(readme, /safe-sharing\/redaction-manifest\.json/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary\n- add opt-in --safe-sharing support to analyze, workflow, and bundle flows\n- generate a parallel redacted safe-sharing/ artifact set with deterministic placeholders for identifiers, source paths, and extracted values\n- package only redacted artifacts with undle --safe-sharing and document safe-sharing rules for fixtures and issue text\n\n## Testing\n- node --test tests/safe-sharing.test.js\n- npm test\n- node cli/zeus.js analyze --list-modes\n- node cli/zeus.js workflow --list-presets\n\nCloses #92