### PR TITLE
Add fetch transport parity and encoding contract coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Default behavior:
 
 - `zeus fetch` exports source members as UTF-8 stream files using IBM i CCSID `1208`
 - this keeps downloaded RPG, CL, and DDS sources readable in common Windows editors and terminals without manual conversion
+- the Windows-readable local source contract is transport-independent across `sftp`, `jt400`, and `ftp`, but it is only guaranteed for `CCSID 1208`
 - `zeus fetch` writes `zeus-import-manifest.json` into the local source root to persist remote identity, transport, checksum, and validation details for imported members
 
 Imported source validation:
@@ -808,6 +809,7 @@ IBM i source export note:
 
 - fetched source members are exported as UTF-8 stream files (`CCSID 1208`) by default
 - analyzer components read local sources as UTF-8, so keeping fetch output on that contract avoids broken umlauts and Windows-side mojibake
+- non-default `--streamfile-ccsid` values remain best-effort; the guaranteed Windows-readable contract is documented in [docs/fetch-encoding-contract.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/fetch-encoding-contract.md)
 
 ## License
 

--- a/docs/fetch-encoding-contract.md
+++ b/docs/fetch-encoding-contract.md
@@ -1,0 +1,42 @@
+# Fetch Encoding Contract
+
+Zeus guarantees one local source contract for Windows-readable analysis input:
+
+- fetched source must arrive as UTF-8 stream files
+- the guaranteed IBM i export CCSID is `1208`
+- the guarantee is transport-independent across `sftp`, `jt400`, and `ftp`
+
+## Contract Summary
+
+When `zeus fetch` runs with the default `--streamfile-ccsid 1208`, Zeus guarantees that the local files written under `--out` are expected to be valid UTF-8 input for the analyze pipeline, regardless of whether the download step used:
+
+- `sftp`
+- `jt400`
+- `ftp`
+
+`zeus-import-manifest.json` records:
+
+- `transportRequested`
+- `transportUsed`
+- `streamFileCcsid`
+- `encodingPolicy`
+- per-file `utf8Valid`
+- per-file `newlineStyle`
+- per-file `validationStatus`
+- per-file `validationMessages`
+
+## Failure Semantics
+
+The fetch contract is explicit about failures:
+
+- if a preferred transport fails in `auto` mode, Zeus records the failure in `notes` and tries the next transport
+- if downloaded source is not valid UTF-8, the manifest records `utf8Valid: false` and `validationStatus: "invalid"`
+- if newline style is mixed or legacy CR-only, the manifest records a warning instead of silently normalizing it
+
+This keeps transport fallback separate from content validation. A successful download does not hide an invalid local analysis contract.
+
+## Non-Default CCSIDs
+
+Zeus allows other positive `--streamfile-ccsid` values for advanced or diagnostic workflows, but those values are not the guaranteed local analysis contract today.
+
+For end-to-end Windows-readable analysis input, treat `CCSID 1208` as the supported contract until broader multi-CCSID handling is implemented across fetch, validation, and analysis.

--- a/tests/fetch-transport-contract.test.js
+++ b/tests/fetch-transport-contract.test.js
@@ -1,0 +1,219 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { fetchSources } = require('../src/fetch/fetchService');
+const { IMPORT_MANIFEST_FILE } = require('../src/fetch/importManifest');
+
+function buildFetchOptions(outDir, overrides = {}) {
+  return {
+    host: 'fixture.example.com',
+    user: 'FIXUSER',
+    password: 'FIXPASSWORD',
+    sourceLib: 'FIXLIB',
+    ifsDir: '/tmp/zeus_fixture/exported_source',
+    out: outDir,
+    files: ['QRPGLESRC'],
+    members: ['PROGRAM_001'],
+    replace: true,
+    transport: 'auto',
+    streamFileCcsid: 1208,
+    verbose: false,
+    ...overrides,
+  };
+}
+
+function buildExportResult() {
+  return [{
+    sourceFile: 'QRPGLESRC',
+    member: 'PROGRAM_001',
+    ok: true,
+    command: 'CPYTOSTMF ...',
+    messages: [],
+    stderr: '',
+    fallbackUsed: false,
+  }];
+}
+
+function readManifest(outDir) {
+  return JSON.parse(fs.readFileSync(path.join(outDir, IMPORT_MANIFEST_FILE), 'utf8'));
+}
+
+function writeDownloadedSource(params, content) {
+  const filePath = path.join(params.localDir, 'QRPGLESRC', 'PROGRAM_001.rpgle');
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  return { downloadedCount: 1 };
+}
+
+test('fetchSources records the direct sftp transport contract with CRLF-normalized Windows-readable output', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-fetch-sftp-contract-'));
+  const outDir = path.join(tempRoot, 'rpg_sources');
+  let sftpCalls = 0;
+  let jt400Calls = 0;
+  let ftpCalls = 0;
+
+  try {
+    const summary = await fetchSources(buildFetchOptions(outDir, { transport: 'sftp' }), {
+      exportMembersForSourceFileFn() {
+        return buildExportResult();
+      },
+      async downloadDirectoryFn(params) {
+        sftpCalls += 1;
+        return writeDownloadedSource(params, Buffer.from('**FREE\r\nDCL-F TABLE_001 DISK;\r\n', 'utf8'));
+      },
+      async downloadDirectoryViaJt400Fn() {
+        jt400Calls += 1;
+        throw new Error('jt400 should not be used');
+      },
+      async downloadDirectoryViaFtpFn() {
+        ftpCalls += 1;
+        throw new Error('ftp should not be used');
+      },
+    });
+
+    const manifest = readManifest(outDir);
+    assert.equal(summary.transportUsed, 'sftp');
+    assert.equal(summary.encodingPolicy, 'UTF-8 stream files (CCSID 1208)');
+    assert.equal(manifest.transportRequested, 'sftp');
+    assert.equal(manifest.transportUsed, 'sftp');
+    assert.equal(manifest.streamFileCcsid, 1208);
+    assert.equal(manifest.files[0].utf8Valid, true);
+    assert.equal(manifest.files[0].newlineStyle, 'CRLF');
+    assert.equal(manifest.files[0].validationStatus, 'ok');
+    assert.equal(manifest.summary.invalidFileCount, 0);
+    assert.equal(manifest.summary.warningCount, 0);
+    assert.equal(sftpCalls, 1);
+    assert.equal(jt400Calls, 0);
+    assert.equal(ftpCalls, 0);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('fetchSources falls back from sftp to jt400 and preserves the UTF-8 manifest contract', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-fetch-jt400-contract-'));
+  const outDir = path.join(tempRoot, 'rpg_sources');
+  let sftpCalls = 0;
+  let jt400Calls = 0;
+  let ftpCalls = 0;
+
+  try {
+    const summary = await fetchSources(buildFetchOptions(outDir, { transport: 'auto' }), {
+      exportMembersForSourceFileFn() {
+        return buildExportResult();
+      },
+      async downloadDirectoryFn() {
+        sftpCalls += 1;
+        throw new Error('SFTP unavailable for fixture');
+      },
+      async downloadDirectoryViaJt400Fn(params) {
+        jt400Calls += 1;
+        return writeDownloadedSource(params, Buffer.from('**FREE\nDCL-F TABLE_001 DISK;\n', 'utf8'));
+      },
+      async downloadDirectoryViaFtpFn() {
+        ftpCalls += 1;
+        throw new Error('ftp should not be used');
+      },
+    });
+
+    const manifest = readManifest(outDir);
+    assert.equal(summary.transportUsed, 'jt400');
+    assert.ok(summary.notes.some((note) => note.includes('Download via sftp failed: SFTP unavailable for fixture')));
+    assert.equal(manifest.transportRequested, 'auto');
+    assert.equal(manifest.transportUsed, 'jt400');
+    assert.equal(manifest.files[0].utf8Valid, true);
+    assert.equal(manifest.files[0].newlineStyle, 'LF');
+    assert.equal(manifest.files[0].validationStatus, 'ok');
+    assert.equal(manifest.summary.invalidFileCount, 0);
+    assert.equal(sftpCalls, 1);
+    assert.equal(jt400Calls, 1);
+    assert.equal(ftpCalls, 0);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('fetchSources falls back to ftp and records mixed newline diagnostics in the import manifest', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-fetch-ftp-contract-'));
+  const outDir = path.join(tempRoot, 'rpg_sources');
+  let sftpCalls = 0;
+  let jt400Calls = 0;
+  let ftpCalls = 0;
+
+  try {
+    const summary = await fetchSources(buildFetchOptions(outDir, { transport: 'auto' }), {
+      exportMembersForSourceFileFn() {
+        return buildExportResult();
+      },
+      async downloadDirectoryFn() {
+        sftpCalls += 1;
+        throw new Error('SFTP unavailable for fixture');
+      },
+      async downloadDirectoryViaJt400Fn() {
+        jt400Calls += 1;
+        throw new Error('JT400 unavailable for fixture');
+      },
+      async downloadDirectoryViaFtpFn(params) {
+        ftpCalls += 1;
+        return writeDownloadedSource(params, Buffer.from('**FREE\r\nDCL-F TABLE_001 DISK;\n', 'utf8'));
+      },
+    });
+
+    const manifest = readManifest(outDir);
+    assert.equal(summary.transportUsed, 'ftp');
+    assert.ok(summary.notes.some((note) => note.includes('Download via sftp failed: SFTP unavailable for fixture')));
+    assert.ok(summary.notes.some((note) => note.includes('Download via jt400 failed: JT400 unavailable for fixture')));
+    assert.equal(manifest.transportUsed, 'ftp');
+    assert.equal(manifest.files[0].utf8Valid, true);
+    assert.equal(manifest.files[0].newlineStyle, 'MIXED');
+    assert.equal(manifest.files[0].validationStatus, 'warning');
+    assert.match(manifest.files[0].validationMessages.join('\n'), /Mixed newline styles detected/);
+    assert.equal(manifest.summary.invalidFileCount, 0);
+    assert.equal(manifest.summary.warningCount, 1);
+    assert.equal(sftpCalls, 1);
+    assert.equal(jt400Calls, 1);
+    assert.equal(ftpCalls, 1);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('fetchSources records invalid UTF-8 output as an invalid imported source contract', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-fetch-invalid-utf8-'));
+  const outDir = path.join(tempRoot, 'rpg_sources');
+  let jt400Calls = 0;
+
+  try {
+    const summary = await fetchSources(buildFetchOptions(outDir, { transport: 'jt400' }), {
+      exportMembersForSourceFileFn() {
+        return buildExportResult();
+      },
+      async downloadDirectoryFn() {
+        throw new Error('sftp should not be used');
+      },
+      async downloadDirectoryViaJt400Fn(params) {
+        jt400Calls += 1;
+        return writeDownloadedSource(params, Buffer.from([0xc3, 0x28]));
+      },
+      async downloadDirectoryViaFtpFn() {
+        throw new Error('ftp should not be used');
+      },
+    });
+
+    const manifest = readManifest(outDir);
+    assert.equal(summary.transportUsed, 'jt400');
+    assert.equal(manifest.transportRequested, 'jt400');
+    assert.equal(manifest.transportUsed, 'jt400');
+    assert.equal(manifest.files[0].utf8Valid, false);
+    assert.equal(manifest.files[0].newlineStyle, 'UNKNOWN');
+    assert.equal(manifest.files[0].validationStatus, 'invalid');
+    assert.match(manifest.files[0].validationMessages.join('\n'), /Invalid UTF-8 source encoding detected/);
+    assert.equal(manifest.summary.invalidFileCount, 1);
+    assert.equal(jt400Calls, 1);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add service-contract tests for fetch transport parity across sftp, jt400, and ftp
- cover auto fallback behavior, manifest transport fields, UTF-8 validity, and newline diagnostics
- document the guaranteed Windows-readable local source contract for CCSID 1208 across transports

## Testing
- node --test tests/fetch-transport-contract.test.js tests/fetch-import-manifest.test.js tests/source-integrity.test.js tests/runtime-config.test.js
- npm test

Closes #93