### PR TITLE
Add reproducible output mode with stable timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ npm test
 Command syntax:
 
 ```bash
-zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--safe-sharing] [--test-data-limit <n>] [--skip-test-data] [--verbose]
+zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]
 ```
 
 Workflow command syntax:
 
 ```bash
-zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--list-presets] [--safe-sharing] [--test-data-limit <n>] [--skip-test-data] [--verbose]
+zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--list-presets] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]
 ```
 
 Guided analyze modes:
@@ -115,6 +115,7 @@ Guided analyze modes:
 When a guided mode is selected, Zeus records the mode and derived behavior in `analyze-run-manifest.json`, writes `analysis-index.json`, and may auto-enable context optimization for prompt-heavy workflows.
 
 Use `--safe-sharing` when you need a redacted sharing packet. Zeus writes a parallel `safe-sharing/` artifact set with deterministic placeholders for identifiers, source paths, and extracted values.
+Use `--reproducible` when you need stable timestamps and content fingerprints for repeated analyze, impact, workflow, and bundle runs.
 
 Named workflow presets build on top of those guided modes and package a shareable bundle in one step:
 
@@ -138,13 +139,13 @@ Guided modes and workflow presets now also expose opinionated review metadata:
 Bundle command syntax:
 
 ```bash
-zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--safe-sharing] [--profile <name>] [--verbose]
+zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--safe-sharing] [--reproducible] [--profile <name>] [--verbose]
 ```
 
 Impact command syntax:
 
 ```bash
-zeus impact --target <name> [--program <name>] [--out <path>] [--profile <name>] [--source <path>] [--verbose]
+zeus impact --target <name> [--program <name>] [--out <path>] [--profile <name>] [--source <path>] [--reproducible] [--verbose]
 ```
 
 Fetch source syntax:
@@ -285,6 +286,7 @@ The safe-sharing directory reuses the same artifact filenames where possible, bu
 `workflow-run-manifest.json` records which named workflow preset produced the run, which guided analyze mode it resolved to, which review metadata shaped the run, and which bundle was emitted for sharing.
 
 `safe-sharing/redaction-manifest.json` records which artifacts were redacted, which placeholder categories were used, and which safe-sharing files were written. Reverse mappings are intentionally not exported.
+Analyze, bundle, workflow, and impact outputs also record reproducibility metadata when repeated-run verification is required.
 
 `canonical-analysis.json` is now the semantic source of truth for the analyze pipeline.
 
@@ -800,6 +802,7 @@ zeus bundle --program ORDERPGM --source-output-root ./output --safe-sharing
 
 See [docs/safe-sharing.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/safe-sharing.md) for the safe-sharing rules for reports, prompts, bundles, fixtures, and issue text.
 See [docs/fixture-sanitization.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/fixture-sanitization.md) for the shared sanitized fixture corpus rules and review checklist.
+See [docs/reproducible-output-mode.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/reproducible-output-mode.md) for the reproducible output contract and stable-timestamp mode.
 
 ## Notes
 

--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -22,10 +22,10 @@ const { runWorkflow } = require('../src/cli/commands/workflowCommand');
 
 function printHelp() {
   console.log('Usage:');
-  console.log('  zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--safe-sharing] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
-  console.log('  zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.rpg] [--list-presets] [--safe-sharing] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
-  console.log('  zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--safe-sharing] [--profile <name>] [--verbose]');
-  console.log('  zeus impact --target <name> [--program <name>] [--out <path>] [--profile <name>] [--source <path>] [--verbose]');
+  console.log('  zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
+  console.log('  zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.rpg] [--list-presets] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
+  console.log('  zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--safe-sharing] [--reproducible] [--profile <name>] [--verbose]');
+  console.log('  zeus impact --target <name> [--program <name>] [--out <path>] [--profile <name>] [--source <path>] [--reproducible] [--verbose]');
   console.log('  zeus fetch --host <hostname> --user <username> --password <password> --source-lib <lib> --ifs-dir <ifsPath> --out <localPath> [--files <list>] [--members <list>] [--replace true|false] [--streamfile-ccsid <ccsid>] [--transport auto|sftp|jt400|ftp] [--profile <name>] [--verbose]');
 }
 

--- a/docs/reproducible-output-mode.md
+++ b/docs/reproducible-output-mode.md
@@ -1,0 +1,45 @@
+# Reproducible Output Mode
+
+Use `--reproducible` when you want Zeus to emit stable artifacts for regression testing, bundle verification, or repository-local comparisons.
+
+## Commands
+
+`--reproducible` is supported on:
+
+- `zeus analyze`
+- `zeus workflow`
+- `zeus bundle`
+- `zeus impact`
+
+## Behavior
+
+When reproducible mode is enabled:
+
+- generated timestamps use the stable value `2000-01-01T00:00:00.000Z`
+- analyze stage timing is normalized to deterministic values
+- analyze comparison metadata is suppressed so repeated runs do not drift based on prior local history
+- analyze, bundle, workflow, and impact manifests include a `reproducibility` block with a content fingerprint
+- bundle ZIP entries keep deterministic timestamps
+
+## Scope
+
+Reproducible mode is intended for identical repository-local inputs and command settings.
+
+It stabilizes runtime metadata and bundle packaging behavior, but it does not claim semantic equivalence across changed source content, different selected artifacts, or different command options.
+
+## Recommended Usage
+
+Analyze and bundle reproducibly:
+
+```bash
+zeus analyze --source ./rpg_sources --program ORDERPGM --optimize-context --reproducible
+zeus bundle --program ORDERPGM --source-output-root ./output --reproducible
+```
+
+Run a workflow reproducibly:
+
+```bash
+zeus workflow --preset modernization-review --source ./rpg_sources --program ORDERPGM --reproducible
+```
+
+Impact analysis already avoids live timestamps in its Markdown output. In reproducible mode, its JSON output also records an explicit reproducibility fingerprint.

--- a/src/analyze/analyzePipeline.js
+++ b/src/analyze/analyzePipeline.js
@@ -45,6 +45,12 @@ const { readImportManifest } = require('../fetch/importManifest');
 const { validateSourceFiles } = require('../source/sourceIntegrity');
 const { buildAnalysisIndex } = require('../workflow/analysisIndex');
 const { getPromptContract } = require('../prompt/promptRegistry');
+const {
+  buildReproduciblePathReplacements,
+  normalizeReproducibilitySettings,
+  replaceExactStringsDeep,
+  resolveTimestamp,
+} = require('../reproducibility/reproducibility');
 
 function resolvePromptContext(context, optimizedContext) {
   return optimizedContext || context;
@@ -199,6 +205,7 @@ function buildContextStage(state) {
     dependencies,
     notes,
     importManifest: state.importManifest,
+    generatedAt: resolveTimestamp(state.reproducibility),
   });
   let context = buildContext({ canonicalAnalysis });
 
@@ -451,7 +458,9 @@ function writeArtifactsStage(state) {
     workflowMode,
     workflowModeSettings,
     workflowPreset,
+    reproducibility,
   } = state;
+  const reproducibilitySettings = normalizeReproducibilitySettings(reproducibility);
   const selectedPromptTemplates = resolvePromptTemplates(promptTemplates);
 
   const aiKnowledge = buildAiKnowledgeProjection({
@@ -459,41 +468,6 @@ function writeArtifactsStage(state) {
     context,
     optimizedContext,
   });
-
-  writeJsonReport(path.join(outputProgramDir, 'canonical-analysis.json'), canonicalAnalysis);
-  writeJsonReport(path.join(outputProgramDir, 'context.json'), context);
-  if (optimizedContext) {
-    writeJsonReport(path.join(outputProgramDir, 'optimized-context.json'), optimizedContext);
-  }
-  writeJsonReport(path.join(outputProgramDir, 'ai-knowledge.json'), aiKnowledge);
-
-  const programCallTreeJsonPath = path.join(outputProgramDir, 'program-call-tree.json');
-  fs.writeFileSync(path.join(outputProgramDir, 'dependency-graph.json'), renderJson(graph), 'utf8');
-  fs.writeFileSync(path.join(outputProgramDir, 'dependency-graph.mmd'), renderMermaid(graph), 'utf8');
-  fs.writeFileSync(path.join(outputProgramDir, 'dependency-graph.md'), renderMarkdown(graph), 'utf8');
-  fs.writeFileSync(programCallTreeJsonPath, renderJson(crossProgramGraph), 'utf8');
-  fs.writeFileSync(path.join(outputProgramDir, 'program-call-tree.mmd'), renderMermaid(crossProgramGraph), 'utf8');
-  fs.writeFileSync(path.join(outputProgramDir, 'program-call-tree.md'), renderCrossProgramMarkdown(crossProgramGraph), 'utf8');
-  generateArchitectureViewer({
-    graphPath: programCallTreeJsonPath,
-    outputPath: path.join(outputProgramDir, 'architecture.html'),
-  });
-
-  const reportMarkdown = generateMarkdownReport(context, optimizationReport);
-  generateArchitectureReport({
-    contextPath: path.join(outputProgramDir, 'context.json'),
-    graphPath: path.join(outputProgramDir, 'dependency-graph.json'),
-    outputPath: path.join(outputProgramDir, 'architecture-report.md'),
-    optimizedContextPath: optimizedContext ? path.join(outputProgramDir, 'optimized-context.json') : null,
-    mermaidPath: path.join(outputProgramDir, 'dependency-graph.mmd'),
-  });
-  buildPrompts({
-    aiProjection: aiKnowledge,
-    outputDir: outputProgramDir,
-    sourceSnippet,
-    templates: selectedPromptTemplates,
-  });
-  fs.writeFileSync(path.join(outputProgramDir, 'report.md'), reportMarkdown, 'utf8');
 
   const generatedPromptFiles = selectedPromptTemplates.map((templateName) => getPromptContract(templateName).outputFileName);
   const generatedDb2Files = context.db2Metadata && context.db2Metadata.status === 'exported'
@@ -536,12 +510,71 @@ function writeArtifactsStage(state) {
     derivedModeSettings: workflowModeSettings,
     selectedPreset: workflowPreset,
   });
-  writeJsonReport(path.join(outputProgramDir, 'analysis-index.json'), analysisIndex);
+  const pathReplacements = reproducibilitySettings.enabled
+    ? buildReproduciblePathReplacements({
+      cwd: process.cwd(),
+      sourceRoot: state.sourceRoot,
+      outputRoot: state.outputRoot,
+      outputProgramDir,
+      program: state.program,
+    })
+    : null;
+  const writtenCanonicalAnalysis = reproducibilitySettings.enabled
+    ? replaceExactStringsDeep(canonicalAnalysis, pathReplacements)
+    : canonicalAnalysis;
+  const writtenContext = reproducibilitySettings.enabled
+    ? replaceExactStringsDeep(context, pathReplacements)
+    : context;
+  const writtenOptimizedContext = reproducibilitySettings.enabled && optimizedContext
+    ? replaceExactStringsDeep(optimizedContext, pathReplacements)
+    : optimizedContext;
+  const writtenAiKnowledge = reproducibilitySettings.enabled
+    ? replaceExactStringsDeep(aiKnowledge, pathReplacements)
+    : aiKnowledge;
+  const writtenAnalysisIndex = reproducibilitySettings.enabled
+    ? replaceExactStringsDeep(analysisIndex, pathReplacements)
+    : analysisIndex;
+
+  writeJsonReport(path.join(outputProgramDir, 'canonical-analysis.json'), writtenCanonicalAnalysis);
+  writeJsonReport(path.join(outputProgramDir, 'context.json'), writtenContext);
+  if (writtenOptimizedContext) {
+    writeJsonReport(path.join(outputProgramDir, 'optimized-context.json'), writtenOptimizedContext);
+  }
+  writeJsonReport(path.join(outputProgramDir, 'ai-knowledge.json'), writtenAiKnowledge);
+
+  const programCallTreeJsonPath = path.join(outputProgramDir, 'program-call-tree.json');
+  fs.writeFileSync(path.join(outputProgramDir, 'dependency-graph.json'), renderJson(graph), 'utf8');
+  fs.writeFileSync(path.join(outputProgramDir, 'dependency-graph.mmd'), renderMermaid(graph), 'utf8');
+  fs.writeFileSync(path.join(outputProgramDir, 'dependency-graph.md'), renderMarkdown(graph), 'utf8');
+  fs.writeFileSync(programCallTreeJsonPath, renderJson(crossProgramGraph), 'utf8');
+  fs.writeFileSync(path.join(outputProgramDir, 'program-call-tree.mmd'), renderMermaid(crossProgramGraph), 'utf8');
+  fs.writeFileSync(path.join(outputProgramDir, 'program-call-tree.md'), renderCrossProgramMarkdown(crossProgramGraph), 'utf8');
+  generateArchitectureViewer({
+    graphPath: programCallTreeJsonPath,
+    outputPath: path.join(outputProgramDir, 'architecture.html'),
+  });
+
+  const reportMarkdown = generateMarkdownReport(writtenContext, optimizationReport);
+  generateArchitectureReport({
+    contextPath: path.join(outputProgramDir, 'context.json'),
+    graphPath: path.join(outputProgramDir, 'dependency-graph.json'),
+    outputPath: path.join(outputProgramDir, 'architecture-report.md'),
+    optimizedContextPath: writtenOptimizedContext ? path.join(outputProgramDir, 'optimized-context.json') : null,
+    mermaidPath: path.join(outputProgramDir, 'dependency-graph.mmd'),
+  });
+  buildPrompts({
+    aiProjection: writtenAiKnowledge,
+    outputDir: outputProgramDir,
+    sourceSnippet,
+    templates: selectedPromptTemplates,
+  });
+  fs.writeFileSync(path.join(outputProgramDir, 'report.md'), reportMarkdown, 'utf8');
+  writeJsonReport(path.join(outputProgramDir, 'analysis-index.json'), writtenAnalysisIndex);
 
   return {
     ...state,
     reportMarkdown,
-    analysisIndex,
+    analysisIndex: writtenAnalysisIndex,
     generatedFiles,
     stageMetadata: {
       fileCount: generatedFiles.length,

--- a/src/analyze/analyzeRunManifest.js
+++ b/src/analyze/analyzeRunManifest.js
@@ -14,6 +14,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const {
+  buildReproducibilityMetadata,
+  buildReproduciblePathReplacements,
+  hashNormalizedValue,
+  normalizeReproducibilitySettings,
+  replaceExactStringsDeep,
+} = require('../reproducibility/reproducibility');
 
 const ANALYZE_RUN_MANIFEST_FILE = 'analyze-run-manifest.json';
 const MANIFEST_SCHEMA_VERSION = 1;
@@ -71,7 +78,8 @@ function buildArtifacts(outputProgramDir, generatedFiles) {
   });
 }
 
-function buildSourceSnapshot(sourceRoot, sourceFiles) {
+function buildSourceSnapshot(sourceRoot, sourceFiles, reproducibility) {
+  const reproducibilitySettings = normalizeReproducibilitySettings(reproducibility);
   const normalizedRoot = sourceRoot ? path.resolve(sourceRoot) : '';
   const files = Array.isArray(sourceFiles) ? sourceFiles : [];
   const entries = files
@@ -80,18 +88,28 @@ function buildSourceSnapshot(sourceRoot, sourceFiles) {
       const absolutePath = path.resolve(filePath);
       const stats = fs.existsSync(absolutePath) ? fs.statSync(absolutePath) : null;
       const relativePath = normalizedRoot ? path.relative(normalizedRoot, absolutePath) : path.basename(absolutePath);
+      const sha256 = stats ? hashContent(fs.readFileSync(absolutePath)) : null;
       return {
         path: relativePath.split(path.sep).join('/'),
         sizeBytes: stats ? stats.size : 0,
-        mtimeMs: stats ? Math.trunc(stats.mtimeMs) : 0,
+        mtimeMs: reproducibilitySettings.enabled ? null : (stats ? Math.trunc(stats.mtimeMs) : 0),
+        sha256,
       };
     })
     .sort((a, b) => a.path.localeCompare(b.path));
 
+  const contentFingerprint = hashContent(entries
+    .map((entry) => `${entry.path}|${entry.sizeBytes}|${entry.sha256 || ''}`)
+    .join('\n'));
+  const fingerprint = reproducibilitySettings.enabled
+    ? contentFingerprint
+    : hashContent(entries.map((entry) => `${entry.path}|${entry.sizeBytes}|${entry.mtimeMs}`).join('\n'));
+
   return {
     root: normalizedRoot,
     fileCount: entries.length,
-    fingerprint: hashContent(entries.map((entry) => `${entry.path}|${entry.sizeBytes}|${entry.mtimeMs}`).join('\n')),
+    fingerprint,
+    contentFingerprint,
     files: entries,
   };
 }
@@ -109,7 +127,12 @@ function buildSummary(stageReports, diagnostics, artifacts, sourceSnapshot) {
   };
 }
 
-function buildComparison(previousManifest, currentManifest) {
+function buildComparison(previousManifest, currentManifest, reproducibility) {
+  const reproducibilitySettings = normalizeReproducibilitySettings(reproducibility);
+  if (reproducibilitySettings.enabled) {
+    return null;
+  }
+
   if (!previousManifest || typeof previousManifest !== 'object') {
     return null;
   }
@@ -146,6 +169,7 @@ function buildAnalyzeRunManifest({
   error = null,
   previousManifest = null,
 }) {
+  const reproducibility = normalizeReproducibilitySettings(context.reproducibility);
   const stageReports = Array.isArray(result && result.stageReports)
     ? result.stageReports
     : Array.isArray(error && error.stageReports) ? error.stageReports : [];
@@ -153,6 +177,7 @@ function buildAnalyzeRunManifest({
   const sourceSnapshot = buildSourceSnapshot(
     context.sourceRoot,
     result && Array.isArray(result.sourceFiles) ? result.sourceFiles : [],
+    reproducibility,
   );
   const artifacts = buildArtifacts(
     context.outputProgramDir,
@@ -172,6 +197,7 @@ function buildAnalyzeRunManifest({
       durationMs: context.durationMs,
       cwd: context.cwd,
       outputDir: context.outputProgramDir,
+      reproducible: reproducibility.enabled,
       ...(error ? {
         failure: {
           message: error.message,
@@ -189,6 +215,7 @@ function buildAnalyzeRunManifest({
         skipTestData: Boolean(context.skipTestData),
         testDataLimit: Number(context.testDataLimit) || null,
         extensions: Array.isArray(context.extensions) ? context.extensions : [],
+        reproducibleEnabled: reproducibility.enabled,
         guidedMode: context.guidedMode || null,
         workflowPreset: context.workflowPreset || null,
       },
@@ -208,8 +235,54 @@ function buildAnalyzeRunManifest({
     artifacts,
   };
 
-  manifest.comparison = buildComparison(previousManifest, manifest);
-  return manifest;
+  const pathReplacements = reproducibility.enabled
+    ? buildReproduciblePathReplacements({
+      cwd: context.cwd,
+      sourceRoot: context.sourceRoot,
+      outputRoot: context.outputRoot,
+      outputProgramDir: context.outputProgramDir,
+      program: context.program,
+    })
+    : null;
+  const fingerprintSource = {
+    tool: manifest.tool,
+    status: manifest.run.status,
+    inputs: manifest.inputs,
+    summary: manifest.summary,
+    diagnostics: manifest.diagnostics,
+    stages: manifest.stages.map((stage) => ({
+      id: stage.id,
+      status: stage.status,
+      metadata: stage.metadata,
+      diagnostics: stage.diagnostics,
+    })),
+    artifacts: manifest.artifacts.map((artifact) => ({
+      path: artifact.path,
+      kind: artifact.kind,
+      exists: artifact.exists,
+      sizeBytes: artifact.sizeBytes,
+      sha256: artifact.sha256,
+    })),
+  };
+  const contentFingerprint = hashNormalizedValue(
+    reproducibility.enabled
+      ? replaceExactStringsDeep(fingerprintSource, pathReplacements)
+      : fingerprintSource,
+  );
+  manifest.reproducibility = buildReproducibilityMetadata(reproducibility, contentFingerprint, {
+    runtimeMetadataSuppressed: reproducibility.enabled,
+    comparisonSuppressed: reproducibility.enabled,
+  });
+  manifest.comparison = buildComparison(previousManifest, manifest, reproducibility);
+
+  if (!reproducibility.enabled) {
+    return manifest;
+  }
+
+  return replaceExactStringsDeep(
+    manifest,
+    pathReplacements,
+  );
 }
 
 function readAnalyzeRunManifest(outputProgramDir) {

--- a/src/analyze/runStages.js
+++ b/src/analyze/runStages.js
@@ -11,6 +11,12 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
+const {
+  normalizeReproducibilitySettings,
+  resolveDurationMs,
+  resolveTimestamp,
+} = require('../reproducibility/reproducibility');
+
 function normalizeStageMetadata(metadata) {
   if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
     return {};
@@ -49,17 +55,18 @@ function runStages(stages, initialState) {
       throw new Error('Invalid analyze stage: missing run function');
     }
 
-    const startedAt = new Date().toISOString();
+    const reproducibility = normalizeReproducibilitySettings(state.reproducibility);
+    const startedAt = resolveTimestamp(reproducibility);
     const startedNs = process.hrtime.bigint();
 
     try {
       const result = stage.run(state);
-      const durationMs = Number((process.hrtime.bigint() - startedNs) / 1000000n);
+      const durationMs = resolveDurationMs(reproducibility, Number((process.hrtime.bigint() - startedNs) / 1000000n));
       const stageReport = {
         id: stage.id || 'anonymous-stage',
         status: 'completed',
         startedAt,
-        completedAt: new Date().toISOString(),
+        completedAt: resolveTimestamp(reproducibility),
         durationMs,
         metadata: normalizeStageMetadata(result && result.stageMetadata),
         diagnostics: normalizeStageDiagnostics(result && result.stageDiagnostics),
@@ -73,12 +80,12 @@ function runStages(stages, initialState) {
       const stageReports = [...(state.stageReports || []), stageReport];
       return finalizeStageState(nextState, stageReport, stageReports);
     } catch (error) {
-      const durationMs = Number((process.hrtime.bigint() - startedNs) / 1000000n);
+      const durationMs = resolveDurationMs(reproducibility, Number((process.hrtime.bigint() - startedNs) / 1000000n));
       const stageReport = {
         id: stage.id || 'anonymous-stage',
         status: 'failed',
         startedAt,
-        completedAt: new Date().toISOString(),
+        completedAt: resolveTimestamp(reproducibility),
         durationMs,
         metadata: {},
         diagnostics: [{

--- a/src/bundle/outputBundleBuilder.js
+++ b/src/bundle/outputBundleBuilder.js
@@ -25,6 +25,12 @@ const {
   REDACTION_MANIFEST_FILE,
   buildSafeArtifactPath,
 } = require('../sharing/safeSharingArtifactBuilder');
+const {
+  buildReproducibilityMetadata,
+  hashNormalizedValue,
+  normalizeReproducibilitySettings,
+  resolveTimestamp,
+} = require('../reproducibility/reproducibility');
 
 const MANIFEST_FILE = 'bundle-manifest.json';
 const ZIP_MANIFEST_FILE = 'manifest.json';
@@ -174,7 +180,8 @@ function buildArtifactMetadata(files, analyzeManifest) {
   });
 }
 
-function buildManifest(program, files, analyzeManifest, workflowPreset, safeSharingEnabled) {
+function buildManifest(program, files, analyzeManifest, workflowPreset, safeSharingEnabled, reproducibility) {
+  const reproducibilitySettings = normalizeReproducibilitySettings(reproducibility);
   const artifacts = buildArtifactMetadata(files, analyzeManifest);
   const manifest = {
     schemaVersion: BUNDLE_MANIFEST_SCHEMA_VERSION,
@@ -183,7 +190,7 @@ function buildManifest(program, files, analyzeManifest, workflowPreset, safeShar
       command: 'bundle',
     },
     program: normalizeProgramName(program).toUpperCase(),
-    generatedAt: new Date().toISOString(),
+    generatedAt: resolveTimestamp(reproducibilitySettings),
     files: files.map((file) => file.name),
     artifacts,
     summary: {
@@ -237,6 +244,24 @@ function buildManifest(program, files, analyzeManifest, workflowPreset, safeShar
       reviewWorkflow: cloneReviewWorkflow(effectiveWorkflowPreset.reviewWorkflow),
     };
   }
+
+  manifest.reproducibility = buildReproducibilityMetadata(
+    reproducibilitySettings,
+    hashNormalizedValue({
+      program: manifest.program,
+      files: manifest.files,
+      artifacts: manifest.artifacts.map((artifact) => ({
+        path: artifact.path,
+        kind: artifact.kind,
+        sizeBytes: artifact.sizeBytes,
+        sha256: artifact.sha256,
+      })),
+      summary: manifest.summary,
+      safeSharing: manifest.safeSharing,
+      analyzeRun: manifest.analyzeRun,
+      workflowPreset: manifest.workflowPreset,
+    }),
+  );
 
   return manifest;
 }
@@ -307,6 +332,7 @@ function buildOutputBundle({
   artifactPaths = null,
   workflowPreset = null,
   bundleFileName = null,
+  reproducibility = null,
 }) {
   const resolvedProgram = normalizeProgramName(program);
   if (!resolvedProgram) {
@@ -331,7 +357,14 @@ function buildOutputBundle({
     : safeSharingEnabled
       ? collectSafeSharingBundleFiles(programOutputDir, includeTypes)
       : collectManifestBundleFiles(programOutputDir, includeTypes, analyzeManifest);
-  const manifest = buildManifest(resolvedProgram, files, analyzeManifest, workflowPreset, safeSharingEnabled);
+  const manifest = buildManifest(
+    resolvedProgram,
+    files,
+    analyzeManifest,
+    workflowPreset,
+    safeSharingEnabled,
+    reproducibility,
+  );
   const zip = new AdmZip();
 
   for (const file of files) {

--- a/src/cli/commands/analyzeCommand.js
+++ b/src/cli/commands/analyzeCommand.js
@@ -24,6 +24,11 @@ const {
 const { buildSafeSharingArtifacts } = require('../../sharing/safeSharingArtifactBuilder');
 const { listWorkflowModes, resolveWorkflowModeSettings } = require('../../workflow/workflowModeRegistry');
 const { resolvePromptTemplates } = require('../../prompt/promptBuilder');
+const {
+  normalizeReproducibilitySettings,
+  resolveDurationMs,
+  resolveTimestamp,
+} = require('../../reproducibility/reproducibility');
 
 function parsePositiveInteger(value, fallback) {
   if (value === undefined || value === null || value === true) return fallback;
@@ -105,6 +110,7 @@ function runAnalyze(args) {
   const testDataLimit = parsePositiveInteger(args['test-data-limit'], Number(config.testData.limit) || DEFAULT_TEST_DATA_LIMIT);
   const skipTestData = Boolean(args['skip-test-data']);
   const safeSharingEnabled = Boolean(args['safe-sharing']);
+  const reproducibility = normalizeReproducibilitySettings(Boolean(args.reproducible));
 
   if (testDataLimit === null) {
     console.error('Invalid option: --test-data-limit must be a positive integer');
@@ -117,6 +123,7 @@ function runAnalyze(args) {
   logVerbose(`Extensions: ${config.extensions.join(', ')}`);
   logVerbose(`Context optimization: ${optimizeContextEnabled ? 'enabled' : 'disabled'}`);
   logVerbose(`Safe sharing: ${safeSharingEnabled ? 'enabled' : 'disabled'}`);
+  logVerbose(`Reproducible mode: ${reproducibility.enabled ? 'enabled' : 'disabled'}`);
   logVerbose(`Test data extraction: ${skipTestData ? 'disabled' : `enabled (limit ${testDataLimit})`}`);
   if (guidedMode) {
     logVerbose(`Workflow mode: ${guidedMode.name}`);
@@ -135,7 +142,7 @@ function runAnalyze(args) {
   fs.mkdirSync(outputProgramDir, { recursive: true });
   logVerbose(`Writing output to ${outputProgramDir}`);
   const previousManifest = readAnalyzeRunManifest(outputProgramDir);
-  const startedAt = new Date().toISOString();
+  const startedAt = resolveTimestamp(reproducibility);
   const startedNs = process.hrtime.bigint();
 
   let result;
@@ -154,9 +161,10 @@ function runAnalyze(args) {
       workflowModeSettings: guidedMode,
       promptTemplates,
       workflowPreset,
+      reproducibility,
       logVerbose,
     });
-    const durationMs = Number((process.hrtime.bigint() - startedNs) / 1000000n);
+    const durationMs = resolveDurationMs(reproducibility, Number((process.hrtime.bigint() - startedNs) / 1000000n));
     const manifest = buildAnalyzeRunManifest({
       status: 'succeeded',
       context: {
@@ -166,13 +174,14 @@ function runAnalyze(args) {
         outputProgramDir,
         cwd: process.cwd(),
         startedAt,
-        completedAt: new Date().toISOString(),
+        completedAt: resolveTimestamp(reproducibility),
         durationMs,
         optimizeContextEnabled,
         safeSharingEnabled,
         skipTestData,
         testDataLimit,
         extensions: config.extensions,
+        reproducibility,
         guidedMode,
         workflowPreset,
       },
@@ -184,10 +193,11 @@ function runAnalyze(args) {
       buildSafeSharingArtifacts({
         outputProgramDir,
         analyzeManifest: manifest,
+        reproducibility,
       });
     }
   } catch (error) {
-    const durationMs = Number((process.hrtime.bigint() - startedNs) / 1000000n);
+    const durationMs = resolveDurationMs(reproducibility, Number((process.hrtime.bigint() - startedNs) / 1000000n));
     const manifest = buildAnalyzeRunManifest({
       status: 'failed',
       context: {
@@ -197,13 +207,14 @@ function runAnalyze(args) {
         outputProgramDir,
         cwd: process.cwd(),
         startedAt,
-        completedAt: new Date().toISOString(),
+        completedAt: resolveTimestamp(reproducibility),
         durationMs,
         optimizeContextEnabled,
         safeSharingEnabled,
         skipTestData,
         testDataLimit,
         extensions: config.extensions,
+        reproducibility,
         guidedMode,
         workflowPreset,
       },

--- a/src/cli/commands/bundleCommand.js
+++ b/src/cli/commands/bundleCommand.js
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const { buildOutputBundle } = require('../../bundle/outputBundleBuilder');
 const { resolveBundleConfig } = require('../../config/runtimeConfig');
+const { normalizeReproducibilitySettings } = require('../../reproducibility/reproducibility');
 
 function runBundle(args) {
   const verbose = Boolean(args.verbose);
@@ -31,6 +32,7 @@ function runBundle(args) {
     includeMd: args['include-md'] === true,
     includeHtml: args['include-html'] === true,
     safeSharingEnabled: Boolean(args['safe-sharing']),
+    reproducibility: normalizeReproducibilitySettings(Boolean(args.reproducible)),
     artifactPaths: Array.isArray(args['artifact-paths']) ? args['artifact-paths'] : null,
     workflowPreset: args['workflow-preset-settings'] || null,
     bundleFileName: args['bundle-file-name'] || null,

--- a/src/cli/commands/impactCommand.js
+++ b/src/cli/commands/impactCommand.js
@@ -15,6 +15,7 @@ const path = require('path');
 const { generateImpactAnalysis, normalizeId } = require('../../impact/impactAnalyzer');
 const { resolveAnalyzeConfig } = require('../../config/runtimeConfig');
 const { findImpactGraph } = require('../helpers/impactGraphResolver');
+const { normalizeReproducibilitySettings } = require('../../reproducibility/reproducibility');
 
 function runImpact(args) {
   const verbose = Boolean(args.verbose);
@@ -46,6 +47,7 @@ function runImpact(args) {
     target: args.target,
     jsonOutputPath: path.join(resolved.outputProgramDir, 'impact-analysis.json'),
     markdownOutputPath: path.join(resolved.outputProgramDir, 'impact-analysis.md'),
+    reproducibility: normalizeReproducibilitySettings(Boolean(args.reproducible)),
   });
 
   console.log(`Impact analysis complete for target ${result.target}`);

--- a/src/cli/commands/workflowCommand.js
+++ b/src/cli/commands/workflowCommand.js
@@ -18,6 +18,7 @@ const { runBundle } = require('./bundleCommand');
 const { resolveAnalyzeConfig } = require('../../config/runtimeConfig');
 const { resolveWorkflowPresetSettings, listWorkflowPresets } = require('../../workflow/workflowPresetRegistry');
 const { buildWorkflowRunManifest, writeWorkflowRunManifest } = require('../../workflow/workflowRunManifest');
+const { normalizeReproducibilitySettings } = require('../../reproducibility/reproducibility');
 
 function printWorkflowPresets() {
   console.log('Supported workflow presets:');
@@ -61,6 +62,7 @@ function runWorkflow(args) {
   delete analyzeArgs.preset;
   delete analyzeArgs['list-presets'];
   delete analyzeArgs['bundle-output'];
+  const reproducibility = normalizeReproducibilitySettings(Boolean(args.reproducible));
 
   runAnalyze(analyzeArgs);
 
@@ -76,6 +78,7 @@ function runWorkflow(args) {
     'artifact-paths': preset.bundleArtifacts,
     'bundle-file-name': `${String(args.program || '').trim()}-${preset.bundleFileName}`,
     'workflow-preset-settings': preset,
+    reproducible: reproducibility.enabled,
     verbose: args.verbose,
   });
 
@@ -84,6 +87,7 @@ function runWorkflow(args) {
     analyzeManifest,
     bundleManifest: bundleResult.manifest,
     bundlePath: bundleResult.zipPath,
+    reproducibility,
   });
   writeWorkflowRunManifest(outputProgramDir, workflowManifest);
 

--- a/src/impact/impactAnalyzer.js
+++ b/src/impact/impactAnalyzer.js
@@ -12,6 +12,11 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const fs = require('fs');
+const {
+  buildReproducibilityMetadata,
+  hashNormalizedValue,
+  normalizeReproducibilitySettings,
+} = require('../reproducibility/reproducibility');
 
 function normalizeId(value) {
   return String(value || '').trim().toUpperCase();
@@ -184,9 +189,23 @@ function generateImpactAnalysis({
   target,
   jsonOutputPath,
   markdownOutputPath,
+  reproducibility = null,
 }) {
   const graph = loadGraph(graphPath);
+  const reproducibilitySettings = normalizeReproducibilitySettings(reproducibility);
   const result = analyzeImpactFromGraph(graph, target);
+  result.reproducibility = buildReproducibilityMetadata(
+    reproducibilitySettings,
+    hashNormalizedValue({
+      target: result.target,
+      type: result.type,
+      directPrograms: result.directPrograms || [],
+      indirectPrograms: result.indirectPrograms || [],
+      directCallers: result.directCallers || [],
+      indirectCallers: result.indirectCallers || [],
+      totalAffectedPrograms: result.totalAffectedPrograms || 0,
+    }),
+  );
 
   fs.writeFileSync(jsonOutputPath, `${JSON.stringify(result, null, 2)}\n`, 'utf8');
   fs.writeFileSync(markdownOutputPath, renderImpactMarkdown(result), 'utf8');

--- a/src/report/architectureReport.js
+++ b/src/report/architectureReport.js
@@ -260,7 +260,7 @@ function renderMermaidBlock(graph, fallbackText) {
 
 function renderArchitectureReport({ context, graph, optimizedContext, mermaidText }) {
   const program = String((context && context.program) || 'UNKNOWN');
-  const generatedAt = new Date().toISOString();
+  const generatedAt = (context && context.scannedAt) || new Date().toISOString();
   const tables = collectTables(context);
   const calls = collectProgramCalls(context);
   const copyMembers = collectCopyMembers(context);

--- a/src/reproducibility/reproducibility.js
+++ b/src/reproducibility/reproducibility.js
@@ -1,0 +1,144 @@
+const crypto = require('crypto');
+
+const REPRODUCIBLE_TIMESTAMP = '2000-01-01T00:00:00.000Z';
+
+const REPRODUCIBLE_PATHS = Object.freeze({
+  workspaceRoot: 'WORKSPACE_ROOT',
+  sourceRoot: 'SOURCE_ROOT',
+  outputRoot: 'OUTPUT_ROOT',
+});
+
+function hashContent(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function normalizeReproducibilitySettings(value) {
+  if (value === true) {
+    return {
+      enabled: true,
+      stableTimestamp: REPRODUCIBLE_TIMESTAMP,
+    };
+  }
+
+  if (!value || typeof value !== 'object') {
+    return {
+      enabled: false,
+      stableTimestamp: REPRODUCIBLE_TIMESTAMP,
+    };
+  }
+
+  return {
+    enabled: Boolean(value.enabled),
+    stableTimestamp: value.stableTimestamp || REPRODUCIBLE_TIMESTAMP,
+  };
+}
+
+function resolveTimestamp(reproducibility, fallbackValue = null) {
+  const settings = normalizeReproducibilitySettings(reproducibility);
+  if (settings.enabled) {
+    return settings.stableTimestamp;
+  }
+  return fallbackValue || new Date().toISOString();
+}
+
+function resolveDurationMs(reproducibility, actualDurationMs) {
+  const settings = normalizeReproducibilitySettings(reproducibility);
+  if (settings.enabled) {
+    return 0;
+  }
+  return Number(actualDurationMs) || 0;
+}
+
+function sortKeysDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sortKeysDeep(entry));
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.keys(value)
+    .sort((a, b) => a.localeCompare(b))
+    .reduce((acc, key) => {
+      acc[key] = sortKeysDeep(value[key]);
+      return acc;
+    }, {});
+}
+
+function hashNormalizedValue(value) {
+  return hashContent(JSON.stringify(sortKeysDeep(value)));
+}
+
+function buildReproducibilityMetadata(reproducibility, contentFingerprint, extras = {}) {
+  const settings = normalizeReproducibilitySettings(reproducibility);
+  return {
+    enabled: settings.enabled,
+    stableTimestamp: settings.enabled ? settings.stableTimestamp : null,
+    contentFingerprint: String(contentFingerprint || ''),
+    ...extras,
+  };
+}
+
+function buildReproduciblePathReplacements({ cwd, sourceRoot, outputRoot, outputProgramDir, program }) {
+  const normalizedProgram = String(program || '').trim().toUpperCase() || 'PROGRAM';
+  const replacements = new Map();
+
+  if (outputProgramDir) {
+    replacements.set(String(outputProgramDir), `${REPRODUCIBLE_PATHS.outputRoot}/${normalizedProgram}`);
+  }
+  if (outputRoot) {
+    replacements.set(String(outputRoot), REPRODUCIBLE_PATHS.outputRoot);
+  }
+  if (sourceRoot) {
+    replacements.set(String(sourceRoot), REPRODUCIBLE_PATHS.sourceRoot);
+  }
+  if (cwd) {
+    replacements.set(String(cwd), REPRODUCIBLE_PATHS.workspaceRoot);
+  }
+
+  return replacements;
+}
+
+function replaceStringWithReplacements(value, replacements) {
+  let result = String(value || '');
+  const entries = Array.from(replacements.entries())
+    .sort((a, b) => b[0].length - a[0].length || a[0].localeCompare(b[0]));
+
+  for (const [rawValue, replacement] of entries) {
+    if (!rawValue) continue;
+    result = result.split(rawValue).join(replacement);
+  }
+
+  return result;
+}
+
+function replaceExactStringsDeep(value, replacements) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => replaceExactStringsDeep(entry, replacements));
+  }
+  if (!value || typeof value !== 'object') {
+    if (typeof value === 'string') {
+      return replaceStringWithReplacements(value, replacements);
+    }
+    return value;
+  }
+
+  return Object.entries(value).reduce((acc, [key, entry]) => {
+    acc[key] = replaceExactStringsDeep(entry, replacements);
+    return acc;
+  }, {});
+}
+
+module.exports = {
+  REPRODUCIBLE_PATHS,
+  REPRODUCIBLE_TIMESTAMP,
+  buildReproducibilityMetadata,
+  buildReproduciblePathReplacements,
+  hashContent,
+  hashNormalizedValue,
+  normalizeReproducibilitySettings,
+  replaceExactStringsDeep,
+  resolveDurationMs,
+  resolveTimestamp,
+  sortKeysDeep,
+};

--- a/src/sharing/safeSharingArtifactBuilder.js
+++ b/src/sharing/safeSharingArtifactBuilder.js
@@ -22,6 +22,10 @@ const { renderHtml } = require('../viewer/architectureViewerGenerator');
 const { renderDb2MetadataMarkdown } = require('../db2/metadataExportService');
 const { renderTestDataMarkdown } = require('../db2/testDataExportService');
 const { readAnalyzeRunManifest } = require('../analyze/analyzeRunManifest');
+const {
+  normalizeReproducibilitySettings,
+  resolveTimestamp,
+} = require('../reproducibility/reproducibility');
 
 const SAFE_SHARING_DIR = 'safe-sharing';
 const REDACTION_MANIFEST_FILE = 'redaction-manifest.json';
@@ -679,7 +683,7 @@ function buildGeneratedArtifactSet(context) {
   const redactionManifest = {
     schemaVersion: REDACTION_MANIFEST_SCHEMA_VERSION,
     kind: 'safe-sharing-redaction-manifest',
-    generatedAt: new Date().toISOString(),
+    generatedAt: resolveTimestamp(context.reproducibility),
     sourceArtifactCount: context.sourceArtifactPaths.length,
     redactedArtifactCount: generated.length,
     sourceArtifacts: [...context.sourceArtifactPaths],
@@ -708,9 +712,16 @@ function buildSafeSharingArtifacts({ outputProgramDir, analyzeManifest = null })
 
   const sourceArtifactPaths = collectSourceArtifactPaths(resolvedManifest);
   const context = buildArtifactContext(outputProgramDir, sourceArtifactPaths);
+  const reproducibility = normalizeReproducibilitySettings(
+    context.analyzeManifest
+    && context.analyzeManifest.inputs
+    && context.analyzeManifest.inputs.options
+    && context.analyzeManifest.inputs.options.reproducibleEnabled,
+  );
   return buildGeneratedArtifactSet({
     ...context,
     outputProgramDir,
+    reproducibility,
   });
 }
 

--- a/src/workflow/workflowRunManifest.js
+++ b/src/workflow/workflowRunManifest.js
@@ -14,15 +14,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 const fs = require('fs');
 const path = require('path');
 const { cloneReviewWorkflow } = require('./reviewWorkflowMetadata');
+const {
+  buildReproducibilityMetadata,
+  hashNormalizedValue,
+  normalizeReproducibilitySettings,
+  resolveTimestamp,
+} = require('../reproducibility/reproducibility');
 
 const WORKFLOW_RUN_MANIFEST_FILE = 'workflow-run-manifest.json';
 const WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION = 1;
 
-function buildWorkflowRunManifest({ preset, analyzeManifest, bundleManifest, bundlePath }) {
-  return {
+function buildWorkflowRunManifest({ preset, analyzeManifest, bundleManifest, bundlePath, reproducibility = null }) {
+  const reproducibilitySettings = normalizeReproducibilitySettings(reproducibility);
+  const manifest = {
     schemaVersion: WORKFLOW_RUN_MANIFEST_SCHEMA_VERSION,
     kind: 'workflow-run-manifest',
-    generatedAt: new Date().toISOString(),
+    generatedAt: resolveTimestamp(reproducibilitySettings),
     program: analyzeManifest && analyzeManifest.inputs ? analyzeManifest.inputs.program : null,
     preset: preset ? {
       name: preset.name,
@@ -53,6 +60,17 @@ function buildWorkflowRunManifest({ preset, analyzeManifest, bundleManifest, bun
       totalSizeBytes: bundleManifest.summary ? bundleManifest.summary.totalSizeBytes : 0,
     } : null,
   };
+
+  manifest.reproducibility = buildReproducibilityMetadata(
+    reproducibilitySettings,
+    hashNormalizedValue({
+      program: manifest.program,
+      preset: manifest.preset,
+      analyzeRun: manifest.analyzeRun,
+      bundle: manifest.bundle,
+    }),
+  );
+  return manifest;
 }
 
 function writeWorkflowRunManifest(outputProgramDir, manifest) {

--- a/tests/analyze-run-manifest.test.js
+++ b/tests/analyze-run-manifest.test.js
@@ -134,6 +134,8 @@ test('buildAnalyzeRunManifest creates a stable success manifest with artifact me
     assert.equal(manifest.artifacts.length, 2);
     assert.equal(manifest.artifacts[0].exists, true);
     assert.ok(typeof manifest.artifacts[0].sha256 === 'string' && manifest.artifacts[0].sha256.length > 0);
+    assert.equal(manifest.reproducibility.enabled, false);
+    assert.ok(typeof manifest.reproducibility.contentFingerprint === 'string');
     assert.equal(manifest.comparison.previousRunStatus, 'succeeded');
     assert.equal(manifest.comparison.sourceFingerprintChanged, true);
     assert.deepEqual(manifest.comparison.addedArtifacts, ['report.md']);
@@ -205,6 +207,7 @@ test('buildAnalyzeRunManifest includes failure details for failed runs', () => {
     assert.equal(manifest.summary.failedStageCount, 1);
     assert.equal(manifest.summary.errorCount, 1);
     assert.equal(manifest.diagnostics.length, 1);
+    assert.equal(manifest.reproducibility.enabled, false);
     assert.equal(manifest.inputs.options.guidedMode.name, 'impact');
     assert.match(manifest.inputs.options.guidedMode.reviewWorkflow.expectedDecisions.join('\n'), /impact target/i);
   } finally {

--- a/tests/bundle-manifest.test.js
+++ b/tests/bundle-manifest.test.js
@@ -63,6 +63,7 @@ test('buildOutputBundle prefers analyze-run-manifest artifacts over directory sc
     assert.equal(result.manifest.analyzeRun.status, 'succeeded');
     assert.equal(result.manifest.analyzeRun.schemaVersion, null);
     assert.equal(result.manifest.analyzeRun.sourceFingerprint, 'abc123');
+    assert.equal(result.manifest.reproducibility.enabled, false);
     assert.equal(result.manifest.summary.totalFiles, 3);
     assert.ok(result.manifest.summary.totalSizeBytes > 0);
     assert.deepEqual(
@@ -150,6 +151,7 @@ test('buildOutputBundle can package explicit workflow preset artifacts with pres
       'analyze-run-manifest.json',
       'report.md',
     ]);
+    assert.equal(result.manifest.reproducibility.enabled, false);
     assert.equal(result.manifest.workflowPreset.name, 'onboarding');
     assert.deepEqual(result.manifest.workflowPreset.promptTemplates, ['documentation']);
     assert.match(result.manifest.workflowPreset.reviewWorkflow.intendedAudience.join('\n'), /New engineers/);

--- a/tests/reproducible-output.test.js
+++ b/tests/reproducible-output.test.js
@@ -1,0 +1,138 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'cli', 'zeus.js');
+const fixtureRoot = path.join(__dirname, 'fixtures', 'v1-smoke', 'src');
+const STABLE_TIMESTAMP = '2000-01-01T00:00:00.000Z';
+
+function runCli(args, cwd) {
+  return execFileSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function captureFiles(rootDir, relativePaths) {
+  const snapshot = {};
+  for (const relativePath of relativePaths) {
+    snapshot[relativePath] = fs.readFileSync(path.join(rootDir, relativePath));
+  }
+  return snapshot;
+}
+
+test('reproducible mode produces identical analyze, impact, and bundle artifacts across repeated runs', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-reproducible-output-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const outputRoot = path.join(tempRoot, 'output');
+  const bundleRoot = path.join(tempRoot, 'bundles');
+
+  fs.cpSync(fixtureRoot, sourceRoot, { recursive: true });
+
+  const programOutputDir = path.join(outputRoot, 'ORDERPGM');
+  const trackedArtifacts = [
+    'analyze-run-manifest.json',
+    'canonical-analysis.json',
+    'context.json',
+    'optimized-context.json',
+    'ai-knowledge.json',
+    'analysis-index.json',
+    'report.md',
+    'architecture-report.md',
+    'ai_prompt_documentation.md',
+    'ai_prompt_error_analysis.md',
+    'impact-analysis.json',
+    'impact-analysis.md',
+    'bundle-manifest.json',
+  ];
+
+  function executeCycle() {
+    runCli([
+      'analyze',
+      '--source',
+      sourceRoot,
+      '--program',
+      'ORDERPGM',
+      '--out',
+      outputRoot,
+      '--optimize-context',
+      '--test-data-limit',
+      '25',
+      '--reproducible',
+    ], projectRoot);
+
+    runCli([
+      'impact',
+      '--target',
+      'ORDERS',
+      '--program',
+      'ORDERPGM',
+      '--out',
+      outputRoot,
+      '--reproducible',
+    ], projectRoot);
+
+    runCli([
+      'bundle',
+      '--program',
+      'ORDERPGM',
+      '--source-output-root',
+      outputRoot,
+      '--output',
+      bundleRoot,
+      '--reproducible',
+    ], projectRoot);
+
+    const artifacts = captureFiles(programOutputDir, trackedArtifacts);
+    const bundlePath = path.join(bundleRoot, 'ORDERPGM-analysis-bundle.zip');
+    const bundleBytes = fs.readFileSync(bundlePath);
+    return { artifacts, bundleBytes };
+  }
+
+  try {
+    const firstRun = executeCycle();
+
+    const analyzeManifest = readJson(path.join(programOutputDir, 'analyze-run-manifest.json'));
+    const impactResult = readJson(path.join(programOutputDir, 'impact-analysis.json'));
+    const bundleManifest = readJson(path.join(programOutputDir, 'bundle-manifest.json'));
+
+    assert.equal(analyzeManifest.inputs.options.reproducibleEnabled, true);
+    assert.equal(analyzeManifest.run.startedAt, STABLE_TIMESTAMP);
+    assert.equal(analyzeManifest.run.completedAt, STABLE_TIMESTAMP);
+    assert.equal(analyzeManifest.run.durationMs, 0);
+    assert.equal(analyzeManifest.comparison, null);
+    assert.equal(analyzeManifest.reproducibility.enabled, true);
+    assert.equal(bundleManifest.reproducibility.enabled, true);
+    assert.equal(bundleManifest.generatedAt, STABLE_TIMESTAMP);
+    assert.equal(impactResult.reproducibility.enabled, true);
+
+    fs.rmSync(outputRoot, { recursive: true, force: true });
+    fs.rmSync(bundleRoot, { recursive: true, force: true });
+
+    const secondRun = executeCycle();
+
+    assert.deepEqual(
+      Object.keys(firstRun.artifacts).sort(),
+      Object.keys(secondRun.artifacts).sort(),
+    );
+    for (const relativePath of Object.keys(firstRun.artifacts)) {
+      assert.equal(
+        Buffer.compare(firstRun.artifacts[relativePath], secondRun.artifacts[relativePath]),
+        0,
+        `artifact changed between reproducible runs: ${relativePath}`,
+      );
+    }
+    assert.equal(Buffer.compare(firstRun.bundleBytes, secondRun.bundleBytes), 0, 'bundle zip changed between reproducible runs');
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a shared --reproducible mode for analyze, workflow, bundle, and impact
- stabilize analyze and workflow manifests, bundle manifests, stage timing, and safe-sharing redaction metadata with deterministic timestamps and content fingerprints
- add repeat-run regression coverage proving identical analyze, impact, and bundle artifacts across reproducible runs and document the mode in README and docs

## Testing
- node --test tests/analyze-run-manifest.test.js tests/bundle-manifest.test.js tests/reproducible-output.test.js tests/workflow-presets.test.js tests/v1-smoke.test.js
- npm test
- CLI help check via node cli/zeus.js

Closes #61