### PR TITLE
Persist imported source provenance and fetch metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ Default behavior:
 - `zeus fetch` exports source members as UTF-8 stream files using IBM i CCSID `1208`
 - this keeps downloaded RPG, CL, and DDS sources readable in common Windows editors and terminals without manual conversion
 - the Windows-readable local source contract is transport-independent across `sftp`, `jt400`, and `ftp`, but it is only guaranteed for `CCSID 1208`
-- `zeus fetch` writes `zeus-import-manifest.json` into the local source root to persist remote identity, transport, checksum, and validation details for imported members
+- `zeus fetch` writes `zeus-import-manifest.json` into the local source root to persist source member origin, member path, transport, checksum, encoding policy, normalization policy, and validation details for imported members
+- `analyze-run-manifest.json` and `bundle-manifest.json` reuse that provenance summary so downstream review flows can reference imported-member identity without re-deriving it from file names
 
 Imported source validation:
 
@@ -803,6 +804,7 @@ zeus bundle --program ORDERPGM --source-output-root ./output --safe-sharing
 See [docs/safe-sharing.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/safe-sharing.md) for the safe-sharing rules for reports, prompts, bundles, fixtures, and issue text.
 See [docs/fixture-sanitization.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/fixture-sanitization.md) for the shared sanitized fixture corpus rules and review checklist.
 See [docs/reproducible-output-mode.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/reproducible-output-mode.md) for the reproducible output contract and stable-timestamp mode.
+See [docs/import-manifest-contract.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/import-manifest-contract.md) for the public fetch provenance manifest contract.
 
 ## Notes
 
@@ -813,6 +815,7 @@ IBM i source export note:
 - fetched source members are exported as UTF-8 stream files (`CCSID 1208`) by default
 - analyzer components read local sources as UTF-8, so keeping fetch output on that contract avoids broken umlauts and Windows-side mojibake
 - non-default `--streamfile-ccsid` values remain best-effort; the guaranteed Windows-readable contract is documented in [docs/fetch-encoding-contract.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/fetch-encoding-contract.md)
+- imported-member provenance and export diagnostics are documented in [docs/import-manifest-contract.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/import-manifest-contract.md)
 
 ## License
 

--- a/docs/canonical-analysis-model.md
+++ b/docs/canonical-analysis-model.md
@@ -91,10 +91,32 @@ Imported provenance currently carries:
 - `sourceLib`
 - `sourceFile`
 - `member`
+- `memberPath`
 - `remotePath`
+- `localPath`
+- `sourceType`
 - `sha256`
+- `transportRequested`
 - `transportUsed`
 - `fetchedAt`
+- `encodingPolicy`
+- `normalizationPolicy`
+- `exportStatus`
+- `validationStatus`
+
+Top-level `provenance.importManifest` also summarizes the import contract when present, including:
+
+- `schemaVersion`
+- `transportRequested`
+- `transportUsed`
+- `streamFileCcsid`
+- `encodingPolicy`
+- `normalizationPolicy`
+- `fileCount`
+- `exportedFileCount`
+- `failedFileCount`
+- `invalidFileCount`
+- `traceableFileCount`
 
 ## Enrichments
 

--- a/docs/fetch-encoding-contract.md
+++ b/docs/fetch-encoding-contract.md
@@ -20,10 +20,16 @@ When `zeus fetch` runs with the default `--streamfile-ccsid 1208`, Zeus guarante
 - `transportUsed`
 - `streamFileCcsid`
 - `encodingPolicy`
+- `normalizationPolicy`
+- per-file `origin.memberPath`
+- per-file `export.status`
+- per-file `export.transportUsed`
 - per-file `utf8Valid`
 - per-file `newlineStyle`
 - per-file `validationStatus`
 - per-file `validationMessages`
+
+See [docs/import-manifest-contract.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/import-manifest-contract.md) for the full public fetch manifest schema.
 
 ## Failure Semantics
 

--- a/docs/import-manifest-contract.md
+++ b/docs/import-manifest-contract.md
@@ -1,0 +1,79 @@
+# Import Manifest Contract
+
+`zeus fetch` writes `zeus-import-manifest.json` into the local fetch root.
+
+This file is the public machine-readable provenance contract for imported IBM i source members.
+
+## Schema
+
+Current schema version: `2`
+
+Top-level fields:
+
+- `schemaVersion`
+- `tool`
+- `fetchedAt`
+- `remote`
+- `request`
+- `localDestination`
+- `transportRequested`
+- `transportUsed`
+- `streamFileCcsid`
+- `encodingPolicy`
+- `normalizationPolicy`
+- `summary`
+- `files`
+- `notes`
+
+## File Records
+
+Each `files[]` entry represents one attempted member export.
+
+Stable provenance fields:
+
+- `sourceLib`
+- `sourceFile`
+- `member`
+- `memberPath`
+- `remotePath`
+- `localPath`
+- `sourceType`
+
+Nested provenance blocks:
+
+- `origin`
+  - canonical imported-member identity and paths
+- `export`
+  - export status, requested/used transport, fallback usage, command, CCSID, encoding policy, normalization policy, and export diagnostics
+- `validation`
+  - local file existence, checksum, UTF-8 validity, newline style, validation status, and validation messages
+
+Backward-compatible flat aliases remain on each file record for the core identity, export, and validation fields.
+
+## Summary Semantics
+
+`summary` includes:
+
+- `exportedSuccess`
+- `exportedFailed`
+- `exportedTotal`
+- `downloadedCount`
+- `fileCount`
+- `exportedFileCount`
+- `failedFileCount`
+- `invalidFileCount`
+- `warningCount`
+
+`failedFileCount` tracks member exports that produced a manifest entry but did not complete successfully.
+
+## Downstream Usage
+
+`zeus analyze` reads this manifest to:
+
+- validate imported source files before scanning
+- attach imported-member provenance to `canonical-analysis.json`
+- expose import-manifest summary metadata in `analyze-run-manifest.json`
+
+`zeus bundle` reuses the analyze-run summary to surface source provenance in `bundle-manifest.json` and `README.txt`.
+
+This keeps later stages tied to the original imported-member identity without re-deriving it from basenames alone.

--- a/src/analyze/analyzePipeline.js
+++ b/src/analyze/analyzePipeline.js
@@ -144,6 +144,7 @@ function collectAndScanStage(state) {
     sourceFiles,
     scannableSourceFiles: validation.validFiles,
     importManifest: importManifestResult.manifest,
+    importManifestPath: importManifestResult.manifestPath,
     scanSummary,
     notes,
     dependencies: {

--- a/src/analyze/analyzeRunManifest.js
+++ b/src/analyze/analyzeRunManifest.js
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const { summarizeImportManifest } = require('../fetch/importManifest');
 const {
   buildReproducibilityMetadata,
   buildReproduciblePathReplacements,
@@ -179,6 +180,12 @@ function buildAnalyzeRunManifest({
     result && Array.isArray(result.sourceFiles) ? result.sourceFiles : [],
     reproducibility,
   );
+  const importManifestSummary = summarizeImportManifest(
+    result && result.importManifest ? result.importManifest : null,
+    {
+      manifestPath: result && result.importManifestPath ? result.importManifestPath : null,
+    },
+  );
   const artifacts = buildArtifacts(
     context.outputProgramDir,
     result && Array.isArray(result.generatedFiles) ? result.generatedFiles : null,
@@ -220,6 +227,7 @@ function buildAnalyzeRunManifest({
         workflowPreset: context.workflowPreset || null,
       },
       sourceSnapshot,
+      importManifest: importManifestSummary,
     },
     summary: buildSummary(stageReports, diagnostics, artifacts, sourceSnapshot),
     diagnostics,

--- a/src/bundle/outputBundleBuilder.js
+++ b/src/bundle/outputBundleBuilder.js
@@ -217,6 +217,20 @@ function buildManifest(program, files, analyzeManifest, workflowPreset, safeShar
         : null,
       artifactCount: Array.isArray(analyzeManifest.artifacts) ? analyzeManifest.artifacts.length : 0,
     };
+    manifest.sourceProvenance = analyzeManifest.inputs && analyzeManifest.inputs.importManifest
+      ? {
+        manifestFile: analyzeManifest.inputs.importManifest.manifestFile || null,
+        schemaVersion: analyzeManifest.inputs.importManifest.schemaVersion || null,
+        fetchedAt: analyzeManifest.inputs.importManifest.fetchedAt || null,
+        sourceLib: analyzeManifest.inputs.importManifest.sourceLib || null,
+        transportUsed: analyzeManifest.inputs.importManifest.transportUsed || null,
+        encodingPolicy: analyzeManifest.inputs.importManifest.encodingPolicy || null,
+        fileCount: Number(analyzeManifest.inputs.importManifest.fileCount) || 0,
+        exportedFileCount: Number(analyzeManifest.inputs.importManifest.exportedFileCount) || 0,
+        failedFileCount: Number(analyzeManifest.inputs.importManifest.failedFileCount) || 0,
+        traceableFileCount: Number(analyzeManifest.inputs.importManifest.traceableFileCount) || 0,
+      }
+      : null;
   }
 
   const effectiveWorkflowPreset = workflowPreset
@@ -259,6 +273,7 @@ function buildManifest(program, files, analyzeManifest, workflowPreset, safeShar
       summary: manifest.summary,
       safeSharing: manifest.safeSharing,
       analyzeRun: manifest.analyzeRun,
+      sourceProvenance: manifest.sourceProvenance,
       workflowPreset: manifest.workflowPreset,
     }),
   );
@@ -279,6 +294,16 @@ function buildReadmeText(program, manifest) {
   if (manifest.safeSharing && manifest.safeSharing.enabled) {
     lines.push('Safe sharing: enabled');
     lines.push(`Redaction manifest: ${manifest.safeSharing.redactionManifestFile}`);
+  }
+  if (manifest.sourceProvenance) {
+    lines.push(`Source provenance manifest: ${manifest.sourceProvenance.manifestFile || 'zeus-import-manifest.json'}`);
+    lines.push(`Imported members: ${manifest.sourceProvenance.exportedFileCount}/${manifest.sourceProvenance.fileCount}`);
+    if (manifest.sourceProvenance.sourceLib) {
+      lines.push(`Source library: ${manifest.sourceProvenance.sourceLib}`);
+    }
+    if (manifest.sourceProvenance.transportUsed) {
+      lines.push(`Import transport: ${manifest.sourceProvenance.transportUsed}`);
+    }
   }
   if (manifest.workflowPreset && manifest.workflowPreset.reviewWorkflow) {
     const reviewWorkflow = manifest.workflowPreset.reviewWorkflow;

--- a/src/context/canonicalAnalysisModel.js
+++ b/src/context/canonicalAnalysisModel.js
@@ -12,6 +12,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const path = require('path');
+const {
+  getImportManifestEntryExport,
+  getImportManifestEntryOrigin,
+  getImportManifestEntryValidation,
+  summarizeImportManifest,
+} = require('../fetch/importManifest');
 const { normalizeRelativePath } = require('../source/sourceIntegrity');
 
 const CANONICAL_ANALYSIS_SCHEMA_VERSION = 1;
@@ -321,7 +327,8 @@ function createManifestIndex(importManifest) {
   }
 
   for (const entry of importManifest.files) {
-    const localPath = String(entry && entry.localPath ? entry.localPath : '').trim().replace(/\\/g, '/');
+    const origin = getImportManifestEntryOrigin(entry);
+    const localPath = String(origin.localPath || '').trim().replace(/\\/g, '/');
     if (localPath) {
       map.set(localPath, entry);
     }
@@ -339,6 +346,9 @@ function normalizeSourceFiles(sourceFiles, sourceRoot, importManifest) {
         ? normalizeRelativePath(sourceRoot, absolutePath)
         : absolutePath;
       const manifestEntry = manifestIndex.get(relPath) || null;
+      const manifestOrigin = manifestEntry ? getImportManifestEntryOrigin(manifestEntry) : null;
+      const manifestExport = manifestEntry ? getImportManifestEntryExport(manifestEntry, importManifest) : null;
+      const manifestValidation = manifestEntry ? getImportManifestEntryValidation(manifestEntry) : null;
 
       return {
         id: `FILE:${relPath}`,
@@ -348,13 +358,21 @@ function normalizeSourceFiles(sourceFiles, sourceRoot, importManifest) {
         provenance: {
           origin: manifestEntry ? 'imported' : 'local',
           import: manifestEntry ? {
-            sourceLib: normalizeName(manifestEntry.sourceLib),
-            sourceFile: normalizeName(manifestEntry.sourceFile),
-            member: normalizeName(manifestEntry.member),
-            remotePath: manifestEntry.remotePath || '',
-            sha256: manifestEntry.sha256 || null,
-            transportUsed: importManifest && importManifest.transportUsed ? String(importManifest.transportUsed) : null,
+            sourceLib: normalizeName(manifestOrigin.sourceLib),
+            sourceFile: normalizeName(manifestOrigin.sourceFile),
+            member: normalizeName(manifestOrigin.member),
+            memberPath: manifestOrigin.memberPath || '',
+            remotePath: manifestOrigin.remotePath || '',
+            localPath: manifestOrigin.localPath || relPath || absolutePath,
+            sourceType: normalizeName(manifestOrigin.sourceType),
+            sha256: manifestValidation.sha256 || null,
+            transportRequested: manifestExport.transportRequested || null,
+            transportUsed: manifestExport.transportUsed || null,
             fetchedAt: importManifest && importManifest.fetchedAt ? importManifest.fetchedAt : null,
+            encodingPolicy: manifestExport.encodingPolicy || null,
+            normalizationPolicy: manifestExport.normalizationPolicy || null,
+            exportStatus: manifestExport.status || null,
+            validationStatus: manifestValidation.status || null,
           } : null,
         },
       };
@@ -1343,6 +1361,7 @@ function buildCanonicalAnalysisModel({
       id: createEntityId('TABLE', table.name),
     }));
   const procedureReferences = buildProcedureReferenceEntities(procedureCalls);
+  const importManifestSummary = summarizeImportManifest(importManifest);
 
   const dependencyBlock = {
     tables: mergedTables,
@@ -1365,14 +1384,20 @@ function buildCanonicalAnalysisModel({
     rootProgram: normalizedProgram,
     sourceRoot: normalizedSourceRoot,
     provenance: {
-      importManifest: importManifest ? {
-        file: 'zeus-import-manifest.json',
-        schemaVersion: Number(importManifest.schemaVersion) || null,
-        fetchedAt: importManifest.fetchedAt || null,
-        transportUsed: importManifest.transportUsed || null,
-        fileCount: importManifest.summary && Number.isFinite(Number(importManifest.summary.fileCount))
-          ? Number(importManifest.summary.fileCount)
-          : Array.isArray(importManifest.files) ? importManifest.files.length : 0,
+      importManifest: importManifestSummary ? {
+        file: importManifestSummary.manifestFile,
+        schemaVersion: importManifestSummary.schemaVersion,
+        fetchedAt: importManifestSummary.fetchedAt,
+        transportRequested: importManifestSummary.transportRequested,
+        transportUsed: importManifestSummary.transportUsed,
+        streamFileCcsid: importManifestSummary.streamFileCcsid,
+        encodingPolicy: importManifestSummary.encodingPolicy,
+        normalizationPolicy: importManifestSummary.normalizationPolicy,
+        fileCount: importManifestSummary.fileCount,
+        exportedFileCount: importManifestSummary.exportedFileCount,
+        failedFileCount: importManifestSummary.failedFileCount,
+        invalidFileCount: importManifestSummary.invalidFileCount,
+        traceableFileCount: importManifestSummary.traceableFileCount,
       } : null,
     },
     sourceFiles: normalizedSourceFiles,

--- a/src/fetch/importManifest.js
+++ b/src/fetch/importManifest.js
@@ -14,9 +14,198 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 const fs = require('fs');
 const path = require('path');
 const { validateSourceFiles, normalizeRelativePath } = require('../source/sourceIntegrity');
+const { memberToExtension } = require('./ifsExporter');
 
 const IMPORT_MANIFEST_FILE = 'zeus-import-manifest.json';
-const IMPORT_MANIFEST_SCHEMA_VERSION = 1;
+const IMPORT_MANIFEST_SCHEMA_VERSION = 2;
+const DEFAULT_NORMALIZATION_POLICY = Object.freeze({
+  contentBytes: 'preserve',
+  lineEndings: 'preserve',
+  localPathFormat: 'relative-forward-slash',
+  checksumAlgorithm: 'sha256',
+});
+
+function normalizeName(value) {
+  return String(value || '').trim().toUpperCase();
+}
+
+function normalizePathValue(value) {
+  return String(value || '').trim().replace(/\\/g, '/');
+}
+
+function buildMemberPath(sourceLib, sourceFile, member) {
+  const lib = normalizeName(sourceLib);
+  const file = normalizeName(sourceFile);
+  const memberName = normalizeName(member);
+  if (!lib || !file || !memberName) {
+    return '';
+  }
+  return `/QSYS.LIB/${lib}.LIB/${file}.FILE/${memberName}.MBR`;
+}
+
+function inferSourceType(sourceFile) {
+  const ext = memberToExtension(sourceFile);
+  return normalizeName(ext.startsWith('.') ? ext.slice(1) : ext) || 'SRC';
+}
+
+function createNormalizationPolicy(policy = null) {
+  const source = policy && typeof policy === 'object' ? policy : DEFAULT_NORMALIZATION_POLICY;
+  return {
+    contentBytes: String(source.contentBytes || DEFAULT_NORMALIZATION_POLICY.contentBytes),
+    lineEndings: String(source.lineEndings || DEFAULT_NORMALIZATION_POLICY.lineEndings),
+    localPathFormat: String(source.localPathFormat || DEFAULT_NORMALIZATION_POLICY.localPathFormat),
+    checksumAlgorithm: String(source.checksumAlgorithm || DEFAULT_NORMALIZATION_POLICY.checksumAlgorithm),
+  };
+}
+
+function buildOriginRecord(record, localDestination) {
+  const sourceLib = normalizeName(record.sourceLib);
+  const sourceFile = normalizeName(record.sourceFile);
+  const member = normalizeName(record.member);
+  const localPath = normalizeRelativePath(localDestination, record.localPath);
+
+  return {
+    sourceLib,
+    sourceFile,
+    member,
+    memberPath: buildMemberPath(sourceLib, sourceFile, member),
+    remotePath: record.remotePath || '',
+    localPath,
+    sourceType: inferSourceType(sourceFile),
+  };
+}
+
+function buildExportRecord(record, summary, options, normalizationPolicy) {
+  return {
+    status: record.ok ? 'exported' : 'failed',
+    transportRequested: normalizePathValue(options.transport).toLowerCase(),
+    transportUsed: summary.transportUsed || null,
+    fallbackUsed: Boolean(record.fallbackUsed),
+    command: record.command || '',
+    streamFileCcsid: Number(options.streamFileCcsid) || null,
+    encodingPolicy: summary.encodingPolicy || null,
+    normalizationPolicy,
+    messages: Array.isArray(record.messages) ? record.messages : [],
+    stderr: record.stderr || '',
+  };
+}
+
+function buildValidationRecord(validationResult) {
+  return {
+    exists: Boolean(validationResult && validationResult.exists),
+    sizeBytes: validationResult ? validationResult.sizeBytes : 0,
+    sha256: validationResult ? validationResult.sha256 : null,
+    utf8Valid: Boolean(validationResult && validationResult.utf8Valid),
+    newlineStyle: validationResult ? validationResult.newlineStyle : 'UNKNOWN',
+    status: validationResult ? validationResult.status : 'invalid',
+    messages: validationResult ? validationResult.issues.map((issue) => issue.message) : [],
+  };
+}
+
+function getImportManifestEntryOrigin(entry) {
+  const origin = entry && entry.origin && typeof entry.origin === 'object'
+    ? entry.origin
+    : entry || {};
+
+  return {
+    sourceLib: normalizeName(origin.sourceLib),
+    sourceFile: normalizeName(origin.sourceFile),
+    member: normalizeName(origin.member),
+    memberPath: origin.memberPath || buildMemberPath(origin.sourceLib, origin.sourceFile, origin.member),
+    remotePath: origin.remotePath || '',
+    localPath: normalizePathValue(origin.localPath || entry && entry.localPath),
+    sourceType: normalizeName(origin.sourceType || inferSourceType(origin.sourceFile)),
+  };
+}
+
+function getImportManifestEntryExport(entry, importManifest = null) {
+  const exportRecord = entry && entry.export && typeof entry.export === 'object'
+    ? entry.export
+    : entry || {};
+  return {
+    status: exportRecord.status || (entry && entry.exported === false ? 'failed' : 'exported'),
+    transportRequested: exportRecord.transportRequested || (importManifest && importManifest.transportRequested) || null,
+    transportUsed: exportRecord.transportUsed || (entry && entry.transportUsed) || (importManifest && importManifest.transportUsed) || null,
+    fallbackUsed: Boolean(exportRecord.fallbackUsed || (entry && entry.fallbackUsed)),
+    command: exportRecord.command || (entry && entry.command) || '',
+    streamFileCcsid: Number(exportRecord.streamFileCcsid || (entry && entry.streamFileCcsid) || (importManifest && importManifest.streamFileCcsid)) || null,
+    encodingPolicy: exportRecord.encodingPolicy || (entry && entry.encodingPolicy) || (importManifest && importManifest.encodingPolicy) || null,
+    normalizationPolicy: createNormalizationPolicy(
+      exportRecord.normalizationPolicy
+      || (entry && entry.normalizationPolicy)
+      || (importManifest && importManifest.normalizationPolicy)
+      || null,
+    ),
+    messages: Array.isArray(exportRecord.messages) ? exportRecord.messages : Array.isArray(entry && entry.messages) ? entry.messages : [],
+    stderr: exportRecord.stderr || (entry && entry.stderr) || '',
+  };
+}
+
+function getImportManifestEntryValidation(entry) {
+  const validation = entry && entry.validation && typeof entry.validation === 'object'
+    ? entry.validation
+    : entry || {};
+
+  return {
+    exists: Boolean(validation.exists),
+    sizeBytes: Number(validation.sizeBytes) || 0,
+    sha256: validation.sha256 || null,
+    utf8Valid: Boolean(validation.utf8Valid),
+    newlineStyle: validation.newlineStyle || 'UNKNOWN',
+    status: validation.status || validation.validationStatus || (entry && entry.validationStatus) || 'invalid',
+    messages: Array.isArray(validation.messages)
+      ? validation.messages
+      : Array.isArray(validation.validationMessages)
+        ? validation.validationMessages
+        : Array.isArray(entry && entry.validationMessages)
+          ? entry.validationMessages
+          : [],
+  };
+}
+
+function summarizeImportManifest(importManifest, options = {}) {
+  const manifestPath = options.manifestPath || null;
+  if (!importManifest || !Array.isArray(importManifest.files)) {
+    return null;
+  }
+
+  const traceableFiles = importManifest.files.filter((entry) => {
+    const origin = getImportManifestEntryOrigin(entry);
+    return origin.sourceLib && origin.sourceFile && origin.member && origin.localPath;
+  });
+  const exportedFileCount = importManifest.files.filter((entry) => getImportManifestEntryExport(entry, importManifest).status === 'exported').length;
+  const failedFileCount = importManifest.files.length - exportedFileCount;
+
+  return {
+    present: true,
+    manifestFile: IMPORT_MANIFEST_FILE,
+    manifestPath,
+    schemaVersion: Number(importManifest.schemaVersion) || null,
+    fetchedAt: importManifest.fetchedAt || null,
+    sourceLib: importManifest.remote && importManifest.remote.sourceLib ? normalizeName(importManifest.remote.sourceLib) : null,
+    transportRequested: importManifest.transportRequested || null,
+    transportUsed: importManifest.transportUsed || null,
+    streamFileCcsid: Number(importManifest.streamFileCcsid) || null,
+    encodingPolicy: importManifest.encodingPolicy || null,
+    normalizationPolicy: createNormalizationPolicy(importManifest.normalizationPolicy),
+    fileCount: importManifest.summary && Number.isFinite(Number(importManifest.summary.fileCount))
+      ? Number(importManifest.summary.fileCount)
+      : importManifest.files.length,
+    exportedFileCount: importManifest.summary && Number.isFinite(Number(importManifest.summary.exportedFileCount))
+      ? Number(importManifest.summary.exportedFileCount)
+      : exportedFileCount,
+    failedFileCount: importManifest.summary && Number.isFinite(Number(importManifest.summary.failedFileCount))
+      ? Number(importManifest.summary.failedFileCount)
+      : failedFileCount,
+    invalidFileCount: importManifest.summary && Number.isFinite(Number(importManifest.summary.invalidFileCount))
+      ? Number(importManifest.summary.invalidFileCount)
+      : 0,
+    warningCount: importManifest.summary && Number.isFinite(Number(importManifest.summary.warningCount))
+      ? Number(importManifest.summary.warningCount)
+      : 0,
+    traceableFileCount: traceableFiles.length,
+  };
+}
 
 function writeImportManifest(localDestination, manifest) {
   fs.mkdirSync(localDestination, { recursive: true });
@@ -56,6 +245,7 @@ function buildImportManifest({
   exportRecords,
   localDestination,
 }) {
+  const normalizationPolicy = createNormalizationPolicy();
   const validation = validateSourceFiles(
     exportRecords
       .map((record) => record.localPath)
@@ -66,23 +256,37 @@ function buildImportManifest({
 
   const files = exportRecords.map((record) => {
     const validationResult = validationByPath.get(record.localPath) || null;
+    const origin = buildOriginRecord(record, localDestination);
+    const exportDetails = buildExportRecord(record, summary, options, normalizationPolicy);
+    const validationDetails = buildValidationRecord(validationResult);
+
     return {
-      sourceLib: String(record.sourceLib || '').trim().toUpperCase(),
-      sourceFile: String(record.sourceFile || '').trim().toUpperCase(),
-      member: String(record.member || '').trim().toUpperCase(),
-      remotePath: record.remotePath,
-      localPath: normalizeRelativePath(localDestination, record.localPath),
-      exported: Boolean(record.ok),
-      fallbackUsed: Boolean(record.fallbackUsed),
-      messages: Array.isArray(record.messages) ? record.messages : [],
-      stderr: record.stderr || '',
-      exists: Boolean(validationResult && validationResult.exists),
-      sizeBytes: validationResult ? validationResult.sizeBytes : 0,
-      sha256: validationResult ? validationResult.sha256 : null,
-      utf8Valid: validationResult ? validationResult.utf8Valid : false,
-      newlineStyle: validationResult ? validationResult.newlineStyle : 'UNKNOWN',
-      validationStatus: validationResult ? validationResult.status : 'invalid',
-      validationMessages: validationResult ? validationResult.issues.map((issue) => issue.message) : [],
+      sourceLib: origin.sourceLib,
+      sourceFile: origin.sourceFile,
+      member: origin.member,
+      memberPath: origin.memberPath,
+      remotePath: origin.remotePath,
+      localPath: origin.localPath,
+      sourceType: origin.sourceType,
+      exported: exportDetails.status === 'exported',
+      transportUsed: exportDetails.transportUsed,
+      fallbackUsed: exportDetails.fallbackUsed,
+      command: exportDetails.command,
+      streamFileCcsid: exportDetails.streamFileCcsid,
+      encodingPolicy: exportDetails.encodingPolicy,
+      normalizationPolicy: exportDetails.normalizationPolicy,
+      messages: exportDetails.messages,
+      stderr: exportDetails.stderr,
+      exists: validationDetails.exists,
+      sizeBytes: validationDetails.sizeBytes,
+      sha256: validationDetails.sha256,
+      utf8Valid: validationDetails.utf8Valid,
+      newlineStyle: validationDetails.newlineStyle,
+      validationStatus: validationDetails.status,
+      validationMessages: validationDetails.messages,
+      origin,
+      export: exportDetails,
+      validation: validationDetails,
     };
   });
 
@@ -95,19 +299,28 @@ function buildImportManifest({
     fetchedAt: new Date().toISOString(),
     remote: {
       host: options.host,
-      sourceLib: String(options.sourceLib || '').trim().toUpperCase(),
+      sourceLib: normalizeName(options.sourceLib),
       ifsDir: options.ifsDir,
+    },
+    request: {
+      sourceFiles: Array.isArray(options.files) ? options.files.map((value) => normalizeName(value)).filter(Boolean) : [],
+      members: Array.isArray(options.members) ? options.members.map((value) => normalizeName(value)).filter(Boolean) : [],
+      replace: options.replace !== false,
     },
     localDestination,
     transportRequested: String(options.transport || '').trim().toLowerCase(),
     transportUsed: summary.transportUsed || null,
     streamFileCcsid: Number(options.streamFileCcsid) || null,
     encodingPolicy: summary.encodingPolicy,
+    normalizationPolicy,
     summary: {
       exportedSuccess: summary.exportedSuccess,
+      exportedFailed: Math.max(0, Number(summary.exportedTotal || 0) - Number(summary.exportedSuccess || 0)),
       exportedTotal: summary.exportedTotal,
       downloadedCount: summary.downloadedCount,
       fileCount: files.length,
+      exportedFileCount: files.filter((entry) => entry.exported).length,
+      failedFileCount: files.filter((entry) => !entry.exported).length,
       invalidFileCount: validation.invalidCount,
       warningCount: validation.warningCount,
     },
@@ -120,6 +333,11 @@ module.exports = {
   IMPORT_MANIFEST_FILE,
   IMPORT_MANIFEST_SCHEMA_VERSION,
   buildImportManifest,
+  createNormalizationPolicy,
+  getImportManifestEntryExport,
+  getImportManifestEntryOrigin,
+  getImportManifestEntryValidation,
+  summarizeImportManifest,
   readImportManifest,
   writeImportManifest,
 };

--- a/src/source/sourceCatalog.js
+++ b/src/source/sourceCatalog.js
@@ -12,7 +12,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const path = require('path');
-const { readImportManifest } = require('../fetch/importManifest');
+const {
+  getImportManifestEntryExport,
+  getImportManifestEntryOrigin,
+  getImportManifestEntryValidation,
+  readImportManifest,
+} = require('../fetch/importManifest');
 const { normalizeRelativePath } = require('./sourceIntegrity');
 
 function normalizeName(value) {
@@ -83,14 +88,24 @@ function buildSourceCatalog({
   for (const filePath of toSortedUniquePaths(sourceFiles)) {
     const relativePath = normalizeRelativePath(resolvedRoot, filePath);
     const manifestEntry = manifestEntryMap.get(relativePath) || null;
+    const manifestOrigin = manifestEntry ? getImportManifestEntryOrigin(manifestEntry) : null;
+    const manifestExport = manifestEntry ? getImportManifestEntryExport(manifestEntry, importManifestResult.manifest) : null;
+    const manifestValidation = manifestEntry ? getImportManifestEntryValidation(manifestEntry) : null;
     const entry = {
       path: path.resolve(filePath),
       relativePath,
-      memberName: normalizeName(manifestEntry && manifestEntry.member ? manifestEntry.member : inferMemberName(filePath)),
-      sourceLib: normalizeName(manifestEntry && manifestEntry.sourceLib ? manifestEntry.sourceLib : ''),
-      sourceFile: normalizeName(manifestEntry && manifestEntry.sourceFile ? manifestEntry.sourceFile : inferSourceFile(relativePath)),
-      sourceType: normalizeName(manifestEntry && manifestEntry.sourceType ? manifestEntry.sourceType : inferSourceType(filePath)),
+      memberName: normalizeName(manifestOrigin && manifestOrigin.member ? manifestOrigin.member : inferMemberName(filePath)),
+      sourceLib: normalizeName(manifestOrigin && manifestOrigin.sourceLib ? manifestOrigin.sourceLib : ''),
+      sourceFile: normalizeName(manifestOrigin && manifestOrigin.sourceFile ? manifestOrigin.sourceFile : inferSourceFile(relativePath)),
+      sourceType: normalizeName(manifestOrigin && manifestOrigin.sourceType ? manifestOrigin.sourceType : inferSourceType(filePath)),
       provenance: manifestEntry ? 'IMPORT_MANIFEST' : 'LOCAL',
+      provenanceDetails: manifestEntry ? {
+        memberPath: manifestOrigin.memberPath || '',
+        remotePath: manifestOrigin.remotePath || '',
+        localPath: manifestOrigin.localPath || relativePath,
+        exportStatus: manifestExport.status || null,
+        validationStatus: manifestValidation.status || null,
+      } : null,
     };
     entry.identity = buildIdentity(entry);
 

--- a/tests/analyze-run-manifest.test.js
+++ b/tests/analyze-run-manifest.test.js
@@ -82,6 +82,42 @@ test('buildAnalyzeRunManifest creates a stable success manifest with artifact me
       },
       result: {
         sourceFiles: [sourceFile],
+        importManifest: {
+          schemaVersion: 2,
+          fetchedAt: '2026-03-15T08:59:00.000Z',
+          remote: {
+            sourceLib: 'APPLIB',
+          },
+          transportRequested: 'sftp',
+          transportUsed: 'sftp',
+          streamFileCcsid: 1208,
+          encodingPolicy: 'UTF-8 stream files (CCSID 1208)',
+          normalizationPolicy: {
+            contentBytes: 'preserve',
+            lineEndings: 'preserve',
+            localPathFormat: 'relative-forward-slash',
+            checksumAlgorithm: 'sha256',
+          },
+          summary: {
+            fileCount: 1,
+            exportedFileCount: 1,
+            failedFileCount: 0,
+            invalidFileCount: 0,
+            warningCount: 0,
+          },
+          files: [{
+            origin: {
+              sourceLib: 'APPLIB',
+              sourceFile: 'QRPGLESRC',
+              member: 'ORDERPGM',
+              localPath: 'ORDERPGM.rpgle',
+            },
+            export: {
+              status: 'exported',
+            },
+          }],
+        },
+        importManifestPath: path.join(sourceRoot, 'zeus-import-manifest.json'),
         generatedFiles: ['context.json', 'report.md'],
         stageReports: [{
           id: 'collect-scan',
@@ -126,6 +162,9 @@ test('buildAnalyzeRunManifest creates a stable success manifest with artifact me
     assert.equal(manifest.inputs.sourceSnapshot.fileCount, 1);
     assert.equal(manifest.summary.generatedArtifactCount, 2);
     assert.equal(manifest.summary.warningCount, 1);
+    assert.equal(manifest.inputs.importManifest.schemaVersion, 2);
+    assert.equal(manifest.inputs.importManifest.sourceLib, 'APPLIB');
+    assert.equal(manifest.inputs.importManifest.traceableFileCount, 1);
     assert.equal(manifest.inputs.options.guidedMode.name, 'modernization');
     assert.deepEqual(manifest.inputs.options.guidedMode.promptTemplates, ['documentation', 'modernization']);
     assert.match(manifest.inputs.options.guidedMode.reviewWorkflow.intendedAudience.join('\n'), /Modernization leads/);

--- a/tests/bundle-manifest.test.js
+++ b/tests/bundle-manifest.test.js
@@ -37,6 +37,18 @@ test('buildOutputBundle prefers analyze-run-manifest artifacts over directory sc
         completedAt: '2026-03-16T10:00:00.000Z',
       },
       inputs: {
+        importManifest: {
+          manifestFile: 'zeus-import-manifest.json',
+          schemaVersion: 2,
+          fetchedAt: '2026-03-16T09:58:00.000Z',
+          sourceLib: 'APPLIB',
+          transportUsed: 'sftp',
+          encodingPolicy: 'UTF-8 stream files (CCSID 1208)',
+          fileCount: 1,
+          exportedFileCount: 1,
+          failedFileCount: 0,
+          traceableFileCount: 1,
+        },
         sourceSnapshot: {
           fingerprint: 'abc123',
         },
@@ -63,6 +75,9 @@ test('buildOutputBundle prefers analyze-run-manifest artifacts over directory sc
     assert.equal(result.manifest.analyzeRun.status, 'succeeded');
     assert.equal(result.manifest.analyzeRun.schemaVersion, null);
     assert.equal(result.manifest.analyzeRun.sourceFingerprint, 'abc123');
+    assert.equal(result.manifest.sourceProvenance.schemaVersion, 2);
+    assert.equal(result.manifest.sourceProvenance.sourceLib, 'APPLIB');
+    assert.equal(result.manifest.sourceProvenance.traceableFileCount, 1);
     assert.equal(result.manifest.reproducibility.enabled, false);
     assert.equal(result.manifest.summary.totalFiles, 3);
     assert.ok(result.manifest.summary.totalSizeBytes > 0);
@@ -107,6 +122,17 @@ test('buildOutputBundle can package explicit workflow preset artifacts with pres
         completedAt: '2026-04-09T10:00:00.000Z',
       },
       inputs: {
+        importManifest: {
+          manifestFile: 'zeus-import-manifest.json',
+          schemaVersion: 2,
+          sourceLib: 'APPLIB',
+          transportUsed: 'sftp',
+          encodingPolicy: 'UTF-8 stream files (CCSID 1208)',
+          fileCount: 3,
+          exportedFileCount: 3,
+          failedFileCount: 0,
+          traceableFileCount: 3,
+        },
         options: {
           workflowPreset: {
             name: 'onboarding',
@@ -153,6 +179,7 @@ test('buildOutputBundle can package explicit workflow preset artifacts with pres
     ]);
     assert.equal(result.manifest.reproducibility.enabled, false);
     assert.equal(result.manifest.workflowPreset.name, 'onboarding');
+    assert.equal(result.manifest.sourceProvenance.fileCount, 3);
     assert.deepEqual(result.manifest.workflowPreset.promptTemplates, ['documentation']);
     assert.match(result.manifest.workflowPreset.reviewWorkflow.intendedAudience.join('\n'), /New engineers/);
     assert.equal(path.basename(result.zipPath), 'ORDERPGM-onboarding-bundle.zip');
@@ -168,6 +195,7 @@ test('buildOutputBundle can package explicit workflow preset artifacts with pres
     ]);
     const readme = zip.readAsText('README.txt');
     assert.match(readme, /Workflow preset: onboarding/);
+    assert.match(readme, /Source provenance manifest: zeus-import-manifest\.json/);
     assert.match(readme, /Expected decisions:/);
     assert.match(readme, /report\.md: Quick orientation summary\./);
   } finally {

--- a/tests/canonical-analysis-model.test.js
+++ b/tests/canonical-analysis-model.test.js
@@ -64,19 +64,56 @@ test('buildCanonicalAnalysisModel creates a validated semantic core with provena
     },
     notes: ['Scanner note'],
     importManifest: {
-      schemaVersion: 1,
+      schemaVersion: 2,
       fetchedAt: '2026-03-20T10:00:00.000Z',
+      transportRequested: 'sftp',
       transportUsed: 'sftp',
+      streamFileCcsid: 1208,
+      encodingPolicy: 'UTF-8 stream files (CCSID 1208)',
+      normalizationPolicy: {
+        contentBytes: 'preserve',
+        lineEndings: 'preserve',
+        localPathFormat: 'relative-forward-slash',
+        checksumAlgorithm: 'sha256',
+      },
       summary: {
         fileCount: 1,
+        exportedFileCount: 1,
+        failedFileCount: 0,
+        invalidFileCount: 0,
       },
       files: [{
         localPath: 'ORDERPGM.rpgle',
-        sourceLib: 'APPLIB',
-        sourceFile: 'QRPGLESRC',
-        member: 'ORDERPGM',
-        remotePath: '/QSYS.LIB/APPLIB.LIB/QRPGLESRC.FILE/ORDERPGM.MBR',
-        sha256: 'abc123',
+        origin: {
+          sourceLib: 'APPLIB',
+          sourceFile: 'QRPGLESRC',
+          member: 'ORDERPGM',
+          memberPath: '/QSYS.LIB/APPLIB.LIB/QRPGLESRC.FILE/ORDERPGM.MBR',
+          remotePath: '/tmp/export/QRPGLESRC/ORDERPGM.rpgle',
+          localPath: 'ORDERPGM.rpgle',
+          sourceType: 'RPGLE',
+        },
+        export: {
+          status: 'exported',
+          transportRequested: 'sftp',
+          transportUsed: 'sftp',
+          streamFileCcsid: 1208,
+          encodingPolicy: 'UTF-8 stream files (CCSID 1208)',
+          normalizationPolicy: {
+            contentBytes: 'preserve',
+            lineEndings: 'preserve',
+            localPathFormat: 'relative-forward-slash',
+            checksumAlgorithm: 'sha256',
+          },
+        },
+        validation: {
+          exists: true,
+          sha256: 'abc123',
+          status: 'ok',
+          utf8Valid: true,
+          newlineStyle: 'LF',
+          messages: [],
+        },
       }],
     },
   });
@@ -86,6 +123,10 @@ test('buildCanonicalAnalysisModel creates a validated semantic core with provena
   assert.equal(canonicalAnalysis.sourceFiles[0].path, 'ORDERPGM.rpgle');
   assert.equal(canonicalAnalysis.sourceFiles[0].provenance.origin, 'imported');
   assert.equal(canonicalAnalysis.sourceFiles[0].provenance.import.member, 'ORDERPGM');
+  assert.equal(canonicalAnalysis.sourceFiles[0].provenance.import.memberPath, '/QSYS.LIB/APPLIB.LIB/QRPGLESRC.FILE/ORDERPGM.MBR');
+  assert.equal(canonicalAnalysis.sourceFiles[0].provenance.import.validationStatus, 'ok');
+  assert.equal(canonicalAnalysis.provenance.importManifest.failedFileCount, 0);
+  assert.equal(canonicalAnalysis.provenance.importManifest.traceableFileCount, 1);
   assert.ok(canonicalAnalysis.entities.programs.some((entry) => entry.id === 'PROGRAM:ORDERPGM' && entry.role === 'ROOT'));
   assert.ok(canonicalAnalysis.relations.some((entry) => entry.type === 'USES_TABLE' && entry.to === 'TABLE:ORDERS'));
   assert.ok(canonicalAnalysis.entities.nativeFiles.some((entry) => entry.id === 'NATIVE_FILE:ORDERS'));

--- a/tests/fetch-import-manifest.test.js
+++ b/tests/fetch-import-manifest.test.js
@@ -5,7 +5,10 @@ const os = require('os');
 const path = require('path');
 
 const { fetchSources } = require('../src/fetch/fetchService');
-const { IMPORT_MANIFEST_FILE } = require('../src/fetch/importManifest');
+const {
+  IMPORT_MANIFEST_FILE,
+  IMPORT_MANIFEST_SCHEMA_VERSION,
+} = require('../src/fetch/importManifest');
 
 test('fetchSources writes an import manifest with validated downloaded files', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-fetch-manifest-'));
@@ -50,14 +53,74 @@ test('fetchSources writes an import manifest with validated downloaded files', a
     assert.equal(fs.existsSync(manifestPath), true);
 
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    assert.equal(manifest.schemaVersion, IMPORT_MANIFEST_SCHEMA_VERSION);
     assert.equal(manifest.tool.command, 'fetch');
     assert.equal(manifest.transportUsed, 'sftp');
+    assert.equal(manifest.summary.exportedFileCount, 1);
+    assert.equal(manifest.summary.failedFileCount, 0);
     assert.equal(manifest.files.length, 1);
     assert.equal(manifest.files[0].localPath, 'QRPGLESRC/ORDERPGM.rpgle');
+    assert.equal(manifest.files[0].memberPath, '/QSYS.LIB/SOURCEN.LIB/QRPGLESRC.FILE/ORDERPGM.MBR');
+    assert.equal(manifest.files[0].origin.sourceLib, 'SOURCEN');
+    assert.equal(manifest.files[0].origin.sourceType, 'RPGLE');
+    assert.equal(manifest.files[0].export.status, 'exported');
+    assert.equal(manifest.files[0].export.transportUsed, 'sftp');
+    assert.equal(manifest.files[0].export.normalizationPolicy.lineEndings, 'preserve');
     assert.equal(manifest.files[0].utf8Valid, true);
     assert.equal(manifest.files[0].validationStatus, 'ok');
+    assert.equal(manifest.files[0].validation.status, 'ok');
     assert.equal(typeof manifest.files[0].sha256, 'string');
     assert.equal(manifest.summary.invalidFileCount, 0);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('fetchSources records failed member exports as machine-readable provenance entries', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-fetch-manifest-failure-'));
+  const outDir = path.join(tempRoot, 'rpg_sources');
+
+  try {
+    await fetchSources({
+      host: 'myibmi.example.com',
+      user: 'MYUSER',
+      password: 'MYPASSWORD',
+      sourceLib: 'SOURCEN',
+      ifsDir: '/home/zeus/rpg_sources',
+      out: outDir,
+      files: ['QRPGLESRC'],
+      members: ['BROKENPGM'],
+      replace: true,
+      transport: 'sftp',
+      streamFileCcsid: 1208,
+      verbose: false,
+    }, {
+      exportMembersForSourceFileFn() {
+        return [{
+          sourceFile: 'QRPGLESRC',
+          member: 'BROKENPGM',
+          ok: false,
+          command: 'CPYTOSTMF ...',
+          messages: ['CPF1234 export failed'],
+          stderr: 'CPF1234',
+          fallbackUsed: false,
+        }];
+      },
+      async downloadDirectoryFn() {
+        return { downloadedCount: 0 };
+      },
+    });
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(outDir, IMPORT_MANIFEST_FILE), 'utf8'));
+    assert.equal(manifest.summary.exportedFileCount, 0);
+    assert.equal(manifest.summary.failedFileCount, 1);
+    assert.equal(manifest.files.length, 1);
+    assert.equal(manifest.files[0].exported, false);
+    assert.equal(manifest.files[0].export.status, 'failed');
+    assert.equal(manifest.files[0].validation.exists, false);
+    assert.equal(manifest.files[0].validation.status, 'invalid');
+    assert.match(manifest.files[0].validation.messages.join('\n'), /Source file is missing/);
+    assert.match(manifest.files[0].messages.join('\n'), /CPF1234 export failed/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- promote zeus-import-manifest.json into an explicit public provenance contract with nested origin/export/validation metadata
- thread import-manifest summaries into canonical analysis, analyze-run manifests, and bundle manifests for downstream reuse
- add contract/regression tests and documentation for imported-member provenance

## Testing
- node --test tests/fetch-import-manifest.test.js tests/fetch-transport-contract.test.js tests/source-catalog.test.js tests/source-integrity.test.js tests/canonical-analysis-model.test.js tests/analyze-run-manifest.test.js tests/bundle-manifest.test.js
- npm test
- node cli/zeus.js --help
- node cli/zeus.js analyze --list-modes

Closes #57