### PR TITLE
Normalize source ingest and add source-type-aware scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ It helps teams quickly produce consistent analysis artifacts from legacy RPG sou
 
 ## Features
 
-- Scans RPG source files from a configurable root directory
+- Scans RPG, CL, and DDS source files from a configurable root directory
 - Exports IBM i source members to Windows-readable UTF-8 stream files by default during `zeus fetch`
 - Writes a fetch import manifest and validates imported source files before scanning
+- Normalizes supported BOM-marked local sources into a consistent analyze-time text contract
+- Classifies RPG, CL, and DDS sources before scanner dispatch
 - Detects common dependencies using practical heuristics:
   - F-spec and `dcl-f` table/file declarations
+  - CL command, `CALL PGM`, and object/file usage hints
+  - DDS record formats and referenced file hints
   - Native file I/O semantics including read/write/update/delete, workstation/printer behavior, and record-format hints
   - Embedded SQL semantics including read/write intent, cursor activity, host variables, dynamic SQL flags, and uncertainty markers
   - Module, service-program, binder-source, and binding-directory relationships where source evidence exists
@@ -30,7 +34,10 @@ It helps teams quickly produce consistent analysis artifacts from legacy RPG sou
 - `cli/zeus.js` - CLI entry point
 - `src/collector/sourceCollector.js` - Source file discovery
 - `src/scanner/rpgScanner.js` - RPG heuristics scanner
+- `src/scanner/clScanner.js` - CL command and object-usage scanner
+- `src/scanner/ddsScanner.js` - DDS metadata and file-reference scanner
 - `src/scanner/dependencyScanner.js` - Aggregated dependency extraction
+- `src/source/sourceType.js` - Source-type classification helpers
 - `src/context/canonicalAnalysisModel.js` - Canonical semantic analysis model builder and validator
 - `src/context/contextBuilder.js` - Backward-compatible `context.json` projection builder
 - `src/dependency/dependencyGraphBuilder.js` - Deterministic dependency graph model builder
@@ -181,6 +188,13 @@ Imported source validation:
 - when `zeus-import-manifest.json` is present, `zeus analyze` validates imported files before scanning
 - invalid UTF-8 sources are skipped with explicit diagnostics instead of being scanned implicitly
 - checksum drift and newline problems are surfaced as warnings in the analyze stage metadata and notes
+
+Analyze-time source ingest:
+
+- BOM-marked UTF-8 and UTF-16 inputs are normalized in memory before scanning
+- line endings are normalized to a clean LF analysis contract for scanner, snippet, and prompt flows
+- unsupported encodings fail with explicit per-file diagnostics instead of silent parser errors
+- CL and DDS files are scanned with dedicated heuristics instead of being pushed through RPG-only logic
 
 ### Basic analyze
 
@@ -805,6 +819,7 @@ See [docs/safe-sharing.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/safe-
 See [docs/fixture-sanitization.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/fixture-sanitization.md) for the shared sanitized fixture corpus rules and review checklist.
 See [docs/reproducible-output-mode.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/reproducible-output-mode.md) for the reproducible output contract and stable-timestamp mode.
 See [docs/import-manifest-contract.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/import-manifest-contract.md) for the public fetch provenance manifest contract.
+See [docs/source-ingest-normalization.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/source-ingest-normalization.md) for the analyze-time normalization contract and current CL/DDS scanner depth.
 
 ## Notes
 
@@ -816,6 +831,7 @@ IBM i source export note:
 - analyzer components read local sources as UTF-8, so keeping fetch output on that contract avoids broken umlauts and Windows-side mojibake
 - non-default `--streamfile-ccsid` values remain best-effort; the guaranteed Windows-readable contract is documented in [docs/fetch-encoding-contract.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/fetch-encoding-contract.md)
 - imported-member provenance and export diagnostics are documented in [docs/import-manifest-contract.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/import-manifest-contract.md)
+- analyze-time source normalization and CL/DDS scan depth are documented in [docs/source-ingest-normalization.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/source-ingest-normalization.md)
 
 ## License
 

--- a/docs/canonical-analysis-model.md
+++ b/docs/canonical-analysis-model.md
@@ -83,8 +83,17 @@ Each `sourceFiles[]` entry contains:
 - `path`: source-root-relative path
 - `sizeBytes`
 - `lines`
+- `sourceType`
+- `normalization`
 - `provenance.origin`: `local` or `imported`
 - `provenance.import`: populated when the source file came from `zeus-import-manifest.json`
+
+`normalization` currently carries analyze-time ingest metadata such as:
+
+- `detectedEncoding`
+- `newlineStyle`
+- `normalizedNewlineStyle`
+- `status`
 
 Imported provenance currently carries:
 
@@ -126,6 +135,8 @@ Top-level `provenance.importManifest` also summarizes the import contract when p
 - `aiContext`
 - `graph`
 - `crossProgramGraph`
+- `sourceNormalization`
+- `sourceTypeAnalysis`
 - `sourceCatalog`
 - `nativeFileUsage`
 - `bindingAnalysis`

--- a/docs/source-ingest-normalization.md
+++ b/docs/source-ingest-normalization.md
@@ -1,0 +1,78 @@
+# Source Ingest And Source-Type Scanning
+
+Zeus analyzes local source through an internal normalized text contract before scanner passes run.
+
+This keeps fetch-time UTF-8 guarantees intact while allowing `zeus analyze` to handle a limited set of non-UTF-8 local inputs explicitly.
+
+## Supported Analyze-Time Input Handling
+
+Zeus currently supports these local source cases ahead of scanning:
+
+- UTF-8 without BOM
+- UTF-8 with BOM
+- UTF-16LE with BOM
+- UTF-16BE with BOM
+
+For analyze-time ingestion:
+
+- BOM markers are removed before scanning
+- line endings are normalized to LF in memory
+- raw files are not rewritten on disk
+
+Unsupported encodings fail with explicit per-file diagnostics in the analyze collect stage.
+
+## Diagnostics And Manifests
+
+Analyze emits per-file diagnostics such as:
+
+- `SOURCE_BOM_REMOVED`
+- `SOURCE_ENCODING_CONVERTED`
+- `SOURCE_LINE_ENDINGS_NORMALIZED`
+- `INVALID_UTF8`
+- `MIXED_NEWLINES`
+- `LEGACY_CR_NEWLINES`
+
+Normalization outcomes are exposed through:
+
+- `context.json` source-file metadata
+- `canonical-analysis.json` source-file metadata and enrichments
+- `analyze-run-manifest.json` collect-stage metadata and diagnostics
+- `report.md` source ingest summary
+
+## Source-Type Classification
+
+Zeus classifies local source before scanner dispatch.
+
+Current scanner families:
+
+- RPG family: `.rpg`, `.rpgle`, `.sqlrpgle`, `.rpgile`, binder-source extensions
+- CL family: `.clp`, `.clle`
+- DDS family: `.dds`, `.dspf`, `.prtf`, `.pf`, `.lf`
+
+## Current CL Coverage
+
+CL scanning currently contributes:
+
+- command inventory
+- `CALL PGM(...)` program-call discovery
+- file-oriented object usage from `FILE(...)`, `TOFILE(...)`, and `FROMFILE(...)`
+- additional object usage hints for `MSGF`, `DTAARA`, `OUTQ`, and `JOBQ`
+
+File-oriented CL object usage is projected into shared dependency findings so graph output can remain useful for CL-driven workflows.
+
+## Current DDS Coverage
+
+DDS scanning currently contributes:
+
+- display/printer/disk-style file classification
+- record-format names
+- referenced file hints from `PFILE`, `REF`, and `JFILE`
+
+These findings feed shared context and reporting without forcing DDS through RPG-only heuristics.
+
+## Current Limits
+
+- no general-purpose transcoding is attempted for arbitrary non-UTF encodings without BOM markers
+- CL command parsing is heuristic and focused on program calls and object/file usage, not full CL syntax
+- DDS parsing is metadata-oriented and does not model every keyword or compile-time object rule yet
+- ambiguous duplicate member names remain explicit in cross-program and impact outputs instead of being silently guessed

--- a/src/ai/knowledgeProjection.js
+++ b/src/ai/knowledgeProjection.js
@@ -38,12 +38,17 @@ function toRelativeEvidenceKey(evidence) {
   ].join('|');
 }
 
-function loadSnippet(sourceRoot, evidence, maxSnippetLines = 6) {
+function loadSnippet(sourceRoot, evidence, maxSnippetLines = 6, sourceTextByRelativePath = null) {
   if (!evidence || !evidence.file) return '';
-  const resolved = path.resolve(sourceRoot || process.cwd(), evidence.file);
-  if (!fs.existsSync(resolved)) return '';
-
-  const content = fs.readFileSync(resolved, 'utf8');
+  const relativePath = String(evidence.file || '').replace(/\\/g, '/');
+  let content = null;
+  if (sourceTextByRelativePath instanceof Map && sourceTextByRelativePath.has(relativePath)) {
+    content = sourceTextByRelativePath.get(relativePath);
+  } else {
+    const resolved = path.resolve(sourceRoot || process.cwd(), relativePath);
+    if (!fs.existsSync(resolved)) return '';
+    content = fs.readFileSync(resolved, 'utf8');
+  }
   const lines = content.split(/\r?\n/);
   const startLine = Math.max(1, Number(evidence.startLine || evidence.line || 1));
   const evidenceEndLine = Math.max(startLine, Number(evidence.endLine || evidence.line || startLine));
@@ -51,7 +56,7 @@ function loadSnippet(sourceRoot, evidence, maxSnippetLines = 6) {
   return lines.slice(startLine - 1, endLine).join('\n').trim();
 }
 
-function createEvidenceIndex(sourceRoot, canonicalAnalysis) {
+function createEvidenceIndex(sourceRoot, canonicalAnalysis, sourceTextByRelativePath = null) {
   const evidenceMap = new Map();
   let sequence = 1;
 
@@ -69,7 +74,7 @@ function createEvidenceIndex(sourceRoot, canonicalAnalysis) {
         startLine: Number(evidence.startLine || evidence.line || 0) || undefined,
         endLine: Number(evidence.endLine || evidence.line || evidence.startLine || 0) || undefined,
         rawText: String(evidence.text || '').trim(),
-        snippet: loadSnippet(sourceRoot, evidence),
+        snippet: loadSnippet(sourceRoot, evidence, 6, sourceTextByRelativePath),
       });
       sequence += 1;
     }
@@ -464,12 +469,12 @@ function buildWorkflowPayload(workflowName, optimizedContext, fallbackSqlStateme
   };
 }
 
-function buildAiKnowledgeProjection({ canonicalAnalysis, context, optimizedContext = null }) {
+function buildAiKnowledgeProjection({ canonicalAnalysis, context, optimizedContext = null, sourceTextByRelativePath = null }) {
   if (!canonicalAnalysis || canonicalAnalysis.kind !== 'canonical-analysis') {
     throw new Error('AI knowledge projection requires canonical analysis input.');
   }
 
-  const evidenceIndex = createEvidenceIndex(canonicalAnalysis.sourceRoot, canonicalAnalysis);
+  const evidenceIndex = createEvidenceIndex(canonicalAnalysis.sourceRoot, canonicalAnalysis, sourceTextByRelativePath);
   const sqlStatements = projectSqlStatements(canonicalAnalysis, evidenceIndex);
   const selectedSqlStatements = projectSqlSelection(optimizedContext, sqlStatements);
 

--- a/src/analyze/analyzePipeline.js
+++ b/src/analyze/analyzePipeline.js
@@ -70,7 +70,16 @@ function collectAndScanStage(state) {
   });
   logVerbose(`Validated scannable source files: ${validation.validFiles.length}`);
 
-  const scanSummary = scanSourceFiles(validation.validFiles, { scanCache });
+  const sourceMetadataByPath = new Map(validation.results.map((result) => [result.path, result]));
+  const normalizedSourceTextByRelativePath = new Map(
+    validation.results
+      .filter((result) => typeof result.normalizedText === 'string')
+      .map((result) => [result.relativePath, result.normalizedText]),
+  );
+  const scanSummary = scanSourceFiles(validation.validFiles, {
+    scanCache,
+    sourceMetadataByPath,
+  });
   const notes = [
     ...(scanSummary.notes || []),
     ...validation.results.flatMap((result) => result.issues.map((issue) => issue.message)),
@@ -143,6 +152,9 @@ function collectAndScanStage(state) {
     scanCache,
     sourceFiles,
     scannableSourceFiles: validation.validFiles,
+    sourceMetadataByPath,
+    normalizedSourceTextByRelativePath,
+    sourceNormalizationSummary: validation.normalizationSummary,
     importManifest: importManifestResult.manifest,
     importManifestPath: importManifestResult.manifestPath,
     scanSummary,
@@ -181,6 +193,11 @@ function collectAndScanStage(state) {
       moduleCount: (scanSummary.modules || []).length,
       bindingDirectoryCount: (scanSummary.bindingDirectories || []).length,
       serviceProgramCount: (scanSummary.servicePrograms || []).length,
+      commandCount: (scanSummary.commands || []).length,
+      objectUsageCount: (scanSummary.objectUsages || []).length,
+      ddsFileCount: (scanSummary.ddsFiles || []).length,
+      sourceTypeSummary: scanSummary.sourceTypeSummary || { byType: {}, byFamily: {} },
+      sourceNormalization: validation.normalizationSummary,
       diagnosticCount: (scanSummary.diagnostics || []).length,
       noteCount: notes.length,
     },
@@ -197,6 +214,9 @@ function buildContextStage(state) {
     dependencies,
     notes,
     scanCache,
+    sourceMetadataByPath,
+    normalizedSourceTextByRelativePath,
+    sourceNormalizationSummary,
   } = state;
 
   let canonicalAnalysis = buildCanonicalAnalysisModel({
@@ -217,6 +237,7 @@ function buildContextStage(state) {
     sourceRoot,
     importManifest: state.importManifest,
     scanCache,
+    sourceMetadataByPath,
   });
 
   canonicalAnalysis = enrichCanonicalAnalysisModel(canonicalAnalysis, {
@@ -235,10 +256,15 @@ function buildContextStage(state) {
       },
     },
     sourceCatalog: crossProgramGraph.sourceCatalog,
+    sourceNormalization: sourceNormalizationSummary || null,
+    sourceTypeAnalysis: scanSummary.sourceTypeAnalysis || null,
   });
   context = buildContext({ canonicalAnalysis });
 
-  const sourceSnippet = pickSourceSnippet(scanSummary.sourceFiles, program);
+  const sourceSnippet = pickSourceSnippet(scanSummary.sourceFiles, program, {
+    normalizedSourceTextByRelativePath,
+    sourceRoot,
+  });
 
   return {
     ...state,
@@ -460,6 +486,7 @@ function writeArtifactsStage(state) {
     workflowModeSettings,
     workflowPreset,
     reproducibility,
+    normalizedSourceTextByRelativePath,
   } = state;
   const reproducibilitySettings = normalizeReproducibilitySettings(reproducibility);
   const selectedPromptTemplates = resolvePromptTemplates(promptTemplates);
@@ -468,6 +495,7 @@ function writeArtifactsStage(state) {
     canonicalAnalysis,
     context,
     optimizedContext,
+    sourceTextByRelativePath: normalizedSourceTextByRelativePath,
   });
 
   const generatedPromptFiles = selectedPromptTemplates.map((templateName) => getPromptContract(templateName).outputFileName);

--- a/src/cli/helpers/sourceSnippet.js
+++ b/src/cli/helpers/sourceSnippet.js
@@ -14,11 +14,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 const fs = require('fs');
 const path = require('path');
 
-function pickSourceSnippet(sourceFiles, programName) {
+function pickSourceSnippet(sourceFiles, programName, options = {}) {
   if (!sourceFiles || sourceFiles.length === 0) {
     return 'No source files were found.';
   }
 
+  const resolvedRoot = options.sourceRoot ? path.resolve(options.sourceRoot) : null;
+  const normalizedSourceTextByRelativePath = options.normalizedSourceTextByRelativePath instanceof Map
+    ? options.normalizedSourceTextByRelativePath
+    : null;
   const paths = sourceFiles.map((entry) => (typeof entry === 'string' ? entry : entry.path)).filter(Boolean);
   if (paths.length === 0) {
     return 'No source files were found.';
@@ -30,7 +34,10 @@ function pickSourceSnippet(sourceFiles, programName) {
     return base.startsWith(normalizedProgram);
   }) || paths[0];
 
-  const content = fs.readFileSync(preferred, 'utf8');
+  const relativePath = resolvedRoot ? path.relative(resolvedRoot, preferred).replace(/\\/g, '/') : null;
+  const content = relativePath && normalizedSourceTextByRelativePath && normalizedSourceTextByRelativePath.has(relativePath)
+    ? normalizedSourceTextByRelativePath.get(relativePath)
+    : fs.readFileSync(preferred, 'utf8');
   return content.split(/\r?\n/).slice(0, 120).join('\n');
 }
 

--- a/src/context/canonicalAnalysisModel.js
+++ b/src/context/canonicalAnalysisModel.js
@@ -355,6 +355,13 @@ function normalizeSourceFiles(sourceFiles, sourceRoot, importManifest) {
         path: relPath || absolutePath,
         sizeBytes: Number(entry && entry.sizeBytes ? entry.sizeBytes : 0),
         lines: Number(entry && entry.lines ? entry.lines : 0),
+        sourceType: normalizeName(entry && entry.sourceType ? entry.sourceType : (manifestOrigin && manifestOrigin.sourceType ? manifestOrigin.sourceType : '')),
+        normalization: {
+          detectedEncoding: entry && entry.detectedEncoding ? String(entry.detectedEncoding) : null,
+          newlineStyle: entry && entry.newlineStyle ? String(entry.newlineStyle) : null,
+          normalizedNewlineStyle: entry && entry.normalizedNewlineStyle ? String(entry.normalizedNewlineStyle) : null,
+          status: entry && entry.normalizationStatus ? String(entry.normalizationStatus) : null,
+        },
         provenance: {
           origin: manifestEntry ? 'imported' : 'local',
           import: manifestEntry ? {
@@ -1319,6 +1326,30 @@ function defaultCrossProgramSummary() {
   };
 }
 
+function defaultSourceNormalization() {
+  return {
+    fileCount: 0,
+    convertedEncodingCount: 0,
+    normalizedFileCount: 0,
+    bomRemovedCount: 0,
+    normalizedLineEndingCount: 0,
+    invalidFileCount: 0,
+    warningCount: 0,
+  };
+}
+
+function defaultSourceTypeAnalysis() {
+  return {
+    summary: {
+      byType: {},
+      byFamily: {},
+    },
+    commands: [],
+    objectUsages: [],
+    ddsFiles: [],
+  };
+}
+
 function buildCanonicalAnalysisModel({
   program,
   sourceRoot,
@@ -1444,6 +1475,8 @@ function buildCanonicalAnalysisModel({
       nativeFileUsage,
       graph: defaultGraphSummary(),
       crossProgramGraph: defaultCrossProgramSummary(),
+      sourceNormalization: defaultSourceNormalization(),
+      sourceTypeAnalysis: defaultSourceTypeAnalysis(),
       sourceCatalog: null,
       db2Metadata: null,
       testData: null,
@@ -1476,6 +1509,8 @@ function enrichCanonicalAnalysisModel(model, updates = {}) {
       ...(updates.nativeFileUsage ? { nativeFileUsage: mergeObject(model.enrichments.nativeFileUsage, updates.nativeFileUsage) } : {}),
       ...(updates.graph ? { graph: mergeObject(model.enrichments.graph, updates.graph) } : {}),
       ...(updates.crossProgramGraph ? { crossProgramGraph: mergeObject(model.enrichments.crossProgramGraph, updates.crossProgramGraph) } : {}),
+      ...(updates.sourceNormalization ? { sourceNormalization: mergeObject(model.enrichments.sourceNormalization, updates.sourceNormalization) } : {}),
+      ...(updates.sourceTypeAnalysis ? { sourceTypeAnalysis: mergeObject(model.enrichments.sourceTypeAnalysis, updates.sourceTypeAnalysis) } : {}),
       ...(updates.sourceCatalog !== undefined ? { sourceCatalog: updates.sourceCatalog } : {}),
       ...(updates.db2Metadata !== undefined ? { db2Metadata: updates.db2Metadata } : {}),
       ...(updates.testData !== undefined ? { testData: updates.testData } : {}),

--- a/src/context/contextBuilder.js
+++ b/src/context/contextBuilder.js
@@ -159,6 +159,8 @@ function projectContextFromCanonicalAnalysis(canonicalAnalysis) {
       path: entry.path,
       sizeBytes: Number(entry.sizeBytes) || 0,
       lines: Number(entry.lines) || 0,
+      sourceType: entry.sourceType || '',
+      normalization: entry.normalization || null,
     })),
     summary: canonicalAnalysis.enrichments && canonicalAnalysis.enrichments.summary
       ? canonicalAnalysis.enrichments.summary
@@ -183,6 +185,25 @@ function projectContextFromCanonicalAnalysis(canonicalAnalysis) {
     crossProgramGraph: canonicalAnalysis.enrichments && canonicalAnalysis.enrichments.crossProgramGraph
       ? canonicalAnalysis.enrichments.crossProgramGraph
       : defaultCrossProgramSummary(),
+    sourceNormalization: canonicalAnalysis.enrichments && canonicalAnalysis.enrichments.sourceNormalization
+      ? canonicalAnalysis.enrichments.sourceNormalization
+      : {
+        fileCount: 0,
+        convertedEncodingCount: 0,
+        normalizedFileCount: 0,
+        bomRemovedCount: 0,
+        normalizedLineEndingCount: 0,
+        invalidFileCount: 0,
+        warningCount: 0,
+      },
+    sourceTypeAnalysis: canonicalAnalysis.enrichments && canonicalAnalysis.enrichments.sourceTypeAnalysis
+      ? canonicalAnalysis.enrichments.sourceTypeAnalysis
+      : {
+        summary: { byType: {}, byFamily: {} },
+        commands: [],
+        objectUsages: [],
+        ddsFiles: [],
+      },
     db2Metadata: canonicalAnalysis.enrichments ? canonicalAnalysis.enrichments.db2Metadata : null,
     testData: canonicalAnalysis.enrichments ? canonicalAnalysis.enrichments.testData : null,
     aiContext: canonicalAnalysis.enrichments && canonicalAnalysis.enrichments.aiContext

--- a/src/dependency/crossProgramGraphBuilder.js
+++ b/src/dependency/crossProgramGraphBuilder.js
@@ -58,6 +58,7 @@ function buildCrossProgramGraph({
   sourceRoot,
   importManifest,
   scanCache,
+  sourceMetadataByPath,
 }) {
   const root = normalizeProgramName(rootProgram);
   if (!root) {
@@ -137,7 +138,10 @@ function buildCrossProgramGraph({
     }
     scannedFiles.add(resolved.path);
 
-    const scanResult = scanSourceFiles([resolved.path], { scanCache });
+    const scanResult = scanSourceFiles([resolved.path], {
+      scanCache,
+      sourceMetadataByPath,
+    });
 
     const tableNames = new Set(
       (scanResult.tables || []).map((table) => asName(table)).filter(Boolean),

--- a/src/fetch/importManifest.js
+++ b/src/fetch/importManifest.js
@@ -250,7 +250,11 @@ function buildImportManifest({
     exportRecords
       .map((record) => record.localPath)
       .filter(Boolean),
-    { rootDir: localDestination },
+    {
+      rootDir: localDestination,
+      strictUtf8Only: true,
+      normalizeText: false,
+    },
   );
   const validationByPath = new Map(validation.results.map((result) => [result.path, result]));
 

--- a/src/impact/impactAnalyzer.js
+++ b/src/impact/impactAnalyzer.js
@@ -80,6 +80,8 @@ function analyzeImpactFromGraph(graph, targetInput) {
   const nodes = Array.isArray(graph.nodes) ? graph.nodes : [];
   const edges = Array.isArray(graph.edges) ? graph.edges : [];
   const nodeTypeMap = buildNodeTypeMap(nodes);
+  const ambiguousPrograms = sortUnique(graph.ambiguousPrograms || []);
+  const unresolvedPrograms = sortUnique(graph.unresolvedPrograms || []);
   const type = nodeTypeMap.get(target);
   if (!type) {
     throw new Error(`Target "${target}" not found in graph nodes.`);
@@ -130,6 +132,12 @@ function analyzeImpactFromGraph(graph, targetInput) {
       directPrograms,
       indirectPrograms,
       totalAffectedPrograms,
+      ambiguity: {
+        targetAmbiguous: ambiguousPrograms.includes(target),
+        targetUnresolved: unresolvedPrograms.includes(target),
+        ambiguousPrograms,
+        unresolvedPrograms,
+      },
     };
   }
 
@@ -143,6 +151,12 @@ function analyzeImpactFromGraph(graph, targetInput) {
       directCallers,
       indirectCallers,
       totalAffectedPrograms: sortUnique([...directCallers, ...indirectCallers]).length,
+      ambiguity: {
+        targetAmbiguous: ambiguousPrograms.includes(target),
+        targetUnresolved: unresolvedPrograms.includes(target),
+        ambiguousPrograms,
+        unresolvedPrograms,
+      },
     };
   }
 
@@ -152,6 +166,12 @@ function analyzeImpactFromGraph(graph, targetInput) {
     directPrograms: [],
     indirectPrograms: [],
     totalAffectedPrograms: 0,
+    ambiguity: {
+      targetAmbiguous: ambiguousPrograms.includes(target),
+      targetUnresolved: unresolvedPrograms.includes(target),
+      ambiguousPrograms,
+      unresolvedPrograms,
+    },
   };
 }
 
@@ -181,6 +201,13 @@ ${toMarkdownList(directItems)}
 ${toMarkdownList(indirectItems)}
 
 Total affected programs: ${result.totalAffectedPrograms || 0}
+
+## Resolution Diagnostics
+
+- Target ambiguous: ${result.ambiguity && result.ambiguity.targetAmbiguous ? 'yes' : 'no'}
+- Target unresolved: ${result.ambiguity && result.ambiguity.targetUnresolved ? 'yes' : 'no'}
+- Ambiguous programs in graph: ${result.ambiguity && result.ambiguity.ambiguousPrograms && result.ambiguity.ambiguousPrograms.length > 0 ? result.ambiguity.ambiguousPrograms.join(', ') : 'None'}
+- Unresolved programs in graph: ${result.ambiguity && result.ambiguity.unresolvedPrograms && result.ambiguity.unresolvedPrograms.length > 0 ? result.ambiguity.unresolvedPrograms.join(', ') : 'None'}
 `;
 }
 
@@ -204,6 +231,12 @@ function generateImpactAnalysis({
       directCallers: result.directCallers || [],
       indirectCallers: result.indirectCallers || [],
       totalAffectedPrograms: result.totalAffectedPrograms || 0,
+      ambiguity: result.ambiguity || {
+        targetAmbiguous: false,
+        targetUnresolved: false,
+        ambiguousPrograms: [],
+        unresolvedPrograms: [],
+      },
     }),
   );
 

--- a/src/report/markdownReport.js
+++ b/src/report/markdownReport.js
@@ -25,6 +25,8 @@ function sectionList(values) {
         const details = [];
         if (typeof value.sizeBytes === 'number') details.push(`${value.sizeBytes} bytes`);
         if (typeof value.lines === 'number') details.push(`${value.lines} lines`);
+        if (value.sourceType) details.push(value.sourceType);
+        if (value.normalization && value.normalization.status) details.push(`normalization: ${value.normalization.status}`);
         return `- ${value.path}${details.length ? ` (${details.join(', ')})` : ''}`;
       }
 
@@ -43,6 +45,32 @@ function sectionList(values) {
 
     return `- ${String(value)}`;
   }).join('\n');
+}
+
+function sourceNormalizationSection(sourceNormalization) {
+  const summary = sourceNormalization || {};
+  return `## Source Ingest\n- Files Seen: ${summary.fileCount || 0}\n- Converted Encodings: ${summary.convertedEncodingCount || 0}\n- Normalized Files: ${summary.normalizedFileCount || 0}\n- BOM Removed: ${summary.bomRemovedCount || 0}\n- Line Endings Normalized: ${summary.normalizedLineEndingCount || 0}\n- Invalid Files: ${summary.invalidFileCount || 0}\n- Warnings: ${summary.warningCount || 0}\n`;
+}
+
+function sourceTypeAnalysisSection(sourceTypeAnalysis) {
+  const summary = (sourceTypeAnalysis && sourceTypeAnalysis.summary) || { byType: {}, byFamily: {} };
+  const byType = Object.keys(summary.byType || {}).length > 0
+    ? Object.entries(summary.byType).map(([key, value]) => `- ${key}: ${value}`).join('\n')
+    : '- None detected';
+  const clCommands = (sourceTypeAnalysis && sourceTypeAnalysis.commands) || [];
+  const objectUsages = (sourceTypeAnalysis && sourceTypeAnalysis.objectUsages) || [];
+  const ddsFiles = (sourceTypeAnalysis && sourceTypeAnalysis.ddsFiles) || [];
+  const commandLines = clCommands.length > 0
+    ? clCommands.slice(0, 10).map((entry) => `- ${entry.command || entry.name}: ${entry.text}`).join('\n')
+    : '- None detected';
+  const objectLines = objectUsages.length > 0
+    ? objectUsages.slice(0, 10).map((entry) => `- ${entry.name} (${entry.objectType}) via ${entry.command}`).join('\n')
+    : '- None detected';
+  const ddsLines = ddsFiles.length > 0
+    ? ddsFiles.map((entry) => `- ${entry.name} [${entry.kind}]${(entry.recordFormats || []).length > 0 ? ` formats: ${(entry.recordFormats || []).join(', ')}` : ''}${(entry.referencedFiles || []).length > 0 ? ` refs: ${(entry.referencedFiles || []).join(', ')}` : ''}`).join('\n')
+    : '- None detected';
+
+  return `## Source Type Analysis\n### Source Types\n${byType}\n\n### CL Commands\n${commandLines}\n\n### CL Object Usage\n${objectLines}\n\n### DDS Metadata\n${ddsLines}\n`;
 }
 
 function optimizationSection(tokenReport) {
@@ -158,11 +186,17 @@ function generateMarkdownReport(context, tokenReport) {
   const procedureAnalysis = context.procedureAnalysis || {};
   const bindingAnalysis = context.bindingAnalysis || {};
   const nativeFileUsage = context.nativeFileUsage || {};
+  const sourceNormalization = context.sourceNormalization || {};
+  const sourceTypeAnalysis = context.sourceTypeAnalysis || {};
   const db2Metadata = context.db2Metadata || {};
   const testData = context.testData || {};
   const unresolvedPrograms = crossProgramGraph.unresolvedPrograms || [];
+  const ambiguousPrograms = crossProgramGraph.ambiguousPrograms || [];
   const unresolvedText = unresolvedPrograms.length > 0
     ? unresolvedPrograms.join(', ')
+    : 'None';
+  const ambiguousText = ambiguousPrograms.length > 0
+    ? ambiguousPrograms.join(', ')
     : 'None';
   const db2Resolved = Array.isArray(db2Metadata.tables)
     ? db2Metadata.tables.filter((entry) => entry.matchStatus === 'resolved').length
@@ -184,7 +218,7 @@ function generateMarkdownReport(context, tokenReport) {
     : `## Test Data Extract\nTest data extraction was skipped because ${testData.reason || 'no DB2 connection configuration was available'}.\n`;
   const procedureSection = `## Procedure Semantics\n- Procedures: ${(procedureAnalysis.summary && procedureAnalysis.summary.procedureCount) || 0}\n- Prototypes: ${(procedureAnalysis.summary && procedureAnalysis.summary.prototypeCount) || 0}\n- Procedure Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.procedureCallCount) || 0}\n- Internal Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.internalCallCount) || 0}\n- External Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.externalCallCount) || 0}\n- Dynamic Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.dynamicCallCount) || 0}\n- Unresolved Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.unresolvedCallCount) || 0}\n`;
 
-  return `# Zeus RPG Analysis Report\n\n## Overview\n- Program: ${context.program}\n- Scanned At: ${context.scannedAt}\n- Source Root: ${context.sourceRoot}\n- Source File Count: ${summary.sourceFileCount || 0}\n- Table Count: ${summary.tableCount || 0}\n- Program Call Count: ${summary.programCallCount || 0}\n- Copy Member Count: ${summary.copyMemberCount || 0}\n- SQL Statement Count: ${summary.sqlStatementCount || 0}\n${summary.text ? `- Summary: ${summary.text}\n` : ''}\n${optimizationSection(tokenReport)}\n## Source Files\n${sectionList(context.sourceFiles)}\n\n## Tables\n${sectionList(dependencies.tables)}\n\n## Program Calls\n${sectionList(dependencies.programCalls)}\n\n## Copy Members\n${sectionList(dependencies.copyMembers)}\n\n${procedureSection}\n${bindingAnalysisSection(bindingAnalysis)}\n${nativeFileUsageSection(nativeFileUsage)}\n${sqlSection(sql)}\n${db2Section}\n${testDataSection}\n## Dependency Graph\nDependency graph generated for ${context.program}.\n\n- Nodes: ${graph.nodeCount || 0}\n- Edges: ${graph.edgeCount || 0}\n- Tables: ${graph.tableCount || 0}\n- Programs Called: ${graph.programCallCount || 0}\n- Copy Members: ${graph.copyMemberCount || 0}\n- Modules: ${graph.moduleCount || 0}\n- Service Programs: ${graph.serviceProgramCount || 0}\n- Binding Directories: ${graph.bindingDirectoryCount || 0}\n- Bind Relationships: ${graph.bindEdgeCount || 0}\n\nSee files:\n- ${(graph.files && graph.files.json) || 'dependency-graph.json'}\n- ${(graph.files && graph.files.mermaid) || 'dependency-graph.mmd'}\n- ${(graph.files && graph.files.markdown) || 'dependency-graph.md'}\n\n## Cross Program Dependency Graph\nA recursive program dependency graph was generated for ${context.program}.\n\n- Programs discovered: ${crossProgramGraph.programCount || 0}\n- Unresolved program calls: ${unresolvedPrograms.length}\n- Unresolved list: ${unresolvedText}\n\nSee:\n- ${(crossProgramGraph.files && crossProgramGraph.files.json) || 'program-call-tree.json'}\n- ${(crossProgramGraph.files && crossProgramGraph.files.mermaid) || 'program-call-tree.mmd'}\n- ${(crossProgramGraph.files && crossProgramGraph.files.markdown) || 'program-call-tree.md'}\n\n## Impact Analysis\nImpact analysis can identify affected programs if a component changes.\n\nSee:\n- impact-analysis.json\n- impact-analysis.md\n\n## Interactive Architecture Viewer\nAn interactive architecture visualization has been generated.\n\nOpen:\n- architecture.html\n\nin your browser to explore program dependencies visually.\n\n## Architecture\n- See architecture-report.md for a full architecture overview.\n\n## Next Steps\n- Validate detected dependencies with the application design and naming standards.\n- Use canonical-analysis.json as the semantic source and context.json or optimized-context.json as prompt-ready projections.\n- Enrich with DB metadata and sample test data when available to improve table-level reasoning.\n- Create a portable bundle with \`zeus bundle --program ${context.program}\`.\n`;
+  return `# Zeus RPG Analysis Report\n\n## Overview\n- Program: ${context.program}\n- Scanned At: ${context.scannedAt}\n- Source Root: ${context.sourceRoot}\n- Source File Count: ${summary.sourceFileCount || 0}\n- Table Count: ${summary.tableCount || 0}\n- Program Call Count: ${summary.programCallCount || 0}\n- Copy Member Count: ${summary.copyMemberCount || 0}\n- SQL Statement Count: ${summary.sqlStatementCount || 0}\n${summary.text ? `- Summary: ${summary.text}\n` : ''}\n${optimizationSection(tokenReport)}\n## Source Files\n${sectionList(context.sourceFiles)}\n\n${sourceNormalizationSection(sourceNormalization)}\n${sourceTypeAnalysisSection(sourceTypeAnalysis)}\n## Tables\n${sectionList(dependencies.tables)}\n\n## Program Calls\n${sectionList(dependencies.programCalls)}\n\n## Copy Members\n${sectionList(dependencies.copyMembers)}\n\n${procedureSection}\n${bindingAnalysisSection(bindingAnalysis)}\n${nativeFileUsageSection(nativeFileUsage)}\n${sqlSection(sql)}\n${db2Section}\n${testDataSection}\n## Dependency Graph\nDependency graph generated for ${context.program}.\n\n- Nodes: ${graph.nodeCount || 0}\n- Edges: ${graph.edgeCount || 0}\n- Tables: ${graph.tableCount || 0}\n- Programs Called: ${graph.programCallCount || 0}\n- Copy Members: ${graph.copyMemberCount || 0}\n- Modules: ${graph.moduleCount || 0}\n- Service Programs: ${graph.serviceProgramCount || 0}\n- Binding Directories: ${graph.bindingDirectoryCount || 0}\n- Bind Relationships: ${graph.bindEdgeCount || 0}\n\nSee files:\n- ${(graph.files && graph.files.json) || 'dependency-graph.json'}\n- ${(graph.files && graph.files.mermaid) || 'dependency-graph.mmd'}\n- ${(graph.files && graph.files.markdown) || 'dependency-graph.md'}\n\n## Cross Program Dependency Graph\nA recursive program dependency graph was generated for ${context.program}.\n\n- Programs discovered: ${crossProgramGraph.programCount || 0}\n- Ambiguous program calls: ${ambiguousPrograms.length}\n- Ambiguous list: ${ambiguousText}\n- Unresolved program calls: ${unresolvedPrograms.length}\n- Unresolved list: ${unresolvedText}\n\nSee:\n- ${(crossProgramGraph.files && crossProgramGraph.files.json) || 'program-call-tree.json'}\n- ${(crossProgramGraph.files && crossProgramGraph.files.mermaid) || 'program-call-tree.mmd'}\n- ${(crossProgramGraph.files && crossProgramGraph.files.markdown) || 'program-call-tree.md'}\n\n## Impact Analysis\nImpact analysis can identify affected programs if a component changes.\n\nSee:\n- impact-analysis.json\n- impact-analysis.md\n\n## Interactive Architecture Viewer\nAn interactive architecture visualization has been generated.\n\nOpen:\n- architecture.html\n\nin your browser to explore program dependencies visually.\n\n## Architecture\n- See architecture-report.md for a full architecture overview.\n\n## Next Steps\n- Validate detected dependencies with the application design and naming standards.\n- Use canonical-analysis.json as the semantic source and context.json or optimized-context.json as prompt-ready projections.\n- Enrich with DB metadata and sample test data when available to improve table-level reasoning.\n- Create a portable bundle with \`zeus bundle --program ${context.program}\`.\n`;
 }
 
 module.exports = {

--- a/src/scanner/clScanner.js
+++ b/src/scanner/clScanner.js
@@ -1,0 +1,204 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+
+function normalizeName(value) {
+  return String(value || '').trim().toUpperCase();
+}
+
+function normalizeObjectName(value) {
+  const normalized = normalizeName(value).replace(/^['"]|['"]$/g, '');
+  if (!normalized) {
+    return '';
+  }
+  const segments = normalized.split('/').filter(Boolean);
+  return segments[segments.length - 1] || normalized;
+}
+
+function isCommentLine(rawLine) {
+  const trimmed = String(rawLine || '').trim();
+  return !trimmed || trimmed.startsWith('/*') || trimmed.startsWith('*') || trimmed.startsWith('//');
+}
+
+function commandFromLine(rawLine) {
+  const trimmed = String(rawLine || '').trim();
+  const match = trimmed.match(/^([A-Z][A-Z0-9_#$@]*)\b/i);
+  return match ? normalizeName(match[1]) : '';
+}
+
+function extractKeywordValues(rawLine, keyword) {
+  const values = [];
+  const regex = new RegExp(`${keyword}\\(([^)]+)\\)`, 'ig');
+  let match = regex.exec(rawLine);
+  while (match) {
+    const normalized = normalizeObjectName(match[1]);
+    if (normalized) {
+      values.push(normalized);
+    }
+    match = regex.exec(rawLine);
+  }
+  return values;
+}
+
+function uniqueByName(items) {
+  const map = new Map();
+  for (const item of items || []) {
+    const key = item && item.name ? normalizeName(item.name) : '';
+    if (!key) continue;
+    if (!map.has(key)) {
+      map.set(key, {
+        ...item,
+        name: key,
+        evidence: [],
+      });
+    }
+    const target = map.get(key);
+    for (const evidence of item.evidence || []) {
+      const exists = target.evidence.some((entry) => JSON.stringify(entry) === JSON.stringify(evidence));
+      if (!exists) {
+        target.evidence.push(evidence);
+      }
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function scanClContent(filePath, content, sourceType = '') {
+  const lines = String(content || '').split('\n');
+  const ownerProgram = normalizeName(path.basename(String(filePath || ''), path.extname(String(filePath || ''))));
+  const commands = [];
+  const objectUsages = [];
+  const calls = [];
+  const tables = [];
+  const nativeFiles = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const rawLine = lines[index];
+    if (isCommentLine(rawLine)) {
+      continue;
+    }
+
+    const lineNumber = index + 1;
+    const trimmed = rawLine.trim();
+    const command = commandFromLine(trimmed);
+    if (!command) {
+      continue;
+    }
+
+    const evidence = [{
+      file: filePath,
+      line: lineNumber,
+      text: trimmed,
+    }];
+
+    commands.push({
+      name: command,
+      command,
+      text: trimmed,
+      evidence,
+    });
+
+    const callTargets = extractKeywordValues(trimmed, 'PGM');
+    if (command === 'CALL') {
+      for (const calledProgram of callTargets) {
+        calls.push({
+          name: calledProgram,
+          kind: 'PROGRAM',
+          evidence,
+        });
+      }
+    }
+
+    const fileKeywords = [
+      { keyword: 'FILE', objectType: 'FILE' },
+      { keyword: 'TOFILE', objectType: 'FILE' },
+      { keyword: 'FROMFILE', objectType: 'FILE' },
+    ];
+    for (const fileKeyword of fileKeywords) {
+      for (const fileName of extractKeywordValues(trimmed, fileKeyword.keyword)) {
+        objectUsages.push({
+          name: fileName,
+          objectType: fileKeyword.objectType,
+          command,
+          evidence,
+        });
+        tables.push({
+          name: fileName,
+          kind: 'CL_FILE',
+          evidence,
+        });
+        nativeFiles.push({
+          name: fileName,
+          kind: 'FILE',
+          declaredAccess: ['READ'],
+          keyed: false,
+          evidence,
+        });
+      }
+    }
+
+    const otherObjectKeywords = ['MSGF', 'DTAARA', 'OUTQ', 'JOBQ'];
+    for (const keyword of otherObjectKeywords) {
+      for (const objectName of extractKeywordValues(trimmed, keyword)) {
+        objectUsages.push({
+          name: objectName,
+          objectType: keyword,
+          command,
+          evidence,
+        });
+      }
+    }
+  }
+
+  return {
+    sourceFile: {
+      path: filePath,
+      sizeBytes: Buffer.byteLength(String(content || ''), 'utf8'),
+      lines: lines.length,
+      sourceType: normalizeName(sourceType) || 'CL',
+    },
+    tables: uniqueByName(tables),
+    calls: uniqueByName(calls),
+    copyMembers: [],
+    sqlStatements: [],
+    procedures: [],
+    prototypes: [],
+    procedureCalls: [],
+    nativeFiles: uniqueByName(nativeFiles),
+    nativeFileAccesses: [],
+    modules: [],
+    bindingDirectories: [],
+    servicePrograms: [],
+    diagnostics: [],
+    notes: [],
+    commands: uniqueByName(commands),
+    objectUsages: uniqueByName(objectUsages),
+    ddsFiles: [],
+    sourceTypeAnalysis: {
+      ownerProgram,
+      sourceType: normalizeName(sourceType) || 'CL',
+    },
+  };
+}
+
+function scanClFile(filePath, options = {}) {
+  const content = options.content !== undefined ? String(options.content) : fs.readFileSync(filePath, 'utf8');
+  return scanClContent(filePath, content, options.sourceType || '');
+}
+
+module.exports = {
+  scanClContent,
+  scanClFile,
+};

--- a/src/scanner/ddsScanner.js
+++ b/src/scanner/ddsScanner.js
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+
+function normalizeName(value) {
+  return String(value || '').trim().toUpperCase();
+}
+
+function normalizeObjectName(value) {
+  const normalized = normalizeName(value).replace(/^['"]|['"]$/g, '');
+  if (!normalized) {
+    return '';
+  }
+  const segments = normalized.split('/').filter(Boolean);
+  return segments[segments.length - 1] || normalized;
+}
+
+function uniqueByName(items) {
+  const map = new Map();
+  for (const item of items || []) {
+    const key = item && item.name ? normalizeName(item.name) : '';
+    if (!key) continue;
+    if (!map.has(key)) {
+      map.set(key, {
+        ...item,
+        name: key,
+        evidence: [],
+      });
+    }
+    const target = map.get(key);
+    for (const evidence of item.evidence || []) {
+      const exists = target.evidence.some((entry) => JSON.stringify(entry) === JSON.stringify(evidence));
+      if (!exists) {
+        target.evidence.push(evidence);
+      }
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function detectDdsKind(filePath, lines, sourceType) {
+  const normalizedType = normalizeName(sourceType);
+  if (['DSPF', 'WORKSTN'].includes(normalizedType)) return 'WORKSTN';
+  if (['PRTF', 'PRINTER'].includes(normalizedType)) return 'PRINTER';
+  if (['PF', 'LF'].includes(normalizedType)) return 'DISK';
+
+  const joined = (lines || []).join('\n').toUpperCase();
+  if (joined.includes('WORKSTN')) return 'WORKSTN';
+  if (joined.includes('PRINTER')) return 'PRINTER';
+  return 'DISK';
+}
+
+function scanDdsContent(filePath, content, sourceType = '') {
+  const lines = String(content || '').split('\n');
+  const objectName = normalizeName(path.basename(String(filePath || ''), path.extname(String(filePath || ''))));
+  const fileKind = detectDdsKind(filePath, lines, sourceType);
+  const recordFormats = [];
+  const referencedFiles = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const rawLine = lines[index];
+    const lineNumber = index + 1;
+    const trimmed = rawLine.trim();
+    const evidence = [{
+      file: filePath,
+      line: lineNumber,
+      text: trimmed,
+    }];
+
+    const recordMatch = trimmed.match(/\bR\s+([A-Z0-9_#$@]+)\b/i);
+    if (recordMatch) {
+      recordFormats.push({
+        name: normalizeName(recordMatch[1]),
+        evidence,
+      });
+    }
+
+    const referencePatterns = ['PFILE', 'REF', 'JFILE'];
+    for (const keyword of referencePatterns) {
+      const regex = new RegExp(`${keyword}\\(([^)]+)\\)`, 'ig');
+      let match = regex.exec(trimmed);
+      while (match) {
+        const referencedName = normalizeObjectName(match[1]);
+        if (referencedName) {
+          referencedFiles.push({
+            name: referencedName,
+            kind: 'DDS_REF',
+            evidence: evidence[0],
+          });
+        }
+        match = regex.exec(trimmed);
+      }
+    }
+  }
+
+  return {
+    sourceFile: {
+      path: filePath,
+      sizeBytes: Buffer.byteLength(String(content || ''), 'utf8'),
+      lines: lines.length,
+      sourceType: normalizeName(sourceType) || 'DDS',
+    },
+    tables: uniqueByName(referencedFiles),
+    calls: [],
+    copyMembers: [],
+    sqlStatements: [],
+    procedures: [],
+    prototypes: [],
+    procedureCalls: [],
+    nativeFiles: [{
+      name: objectName,
+      kind: fileKind,
+      declaredAccess: [],
+      keyed: false,
+      evidence: [{
+        file: filePath,
+        line: 1,
+        text: `${objectName} ${fileKind}`,
+      }],
+    }],
+    nativeFileAccesses: [],
+    modules: [],
+    bindingDirectories: [],
+    servicePrograms: [],
+    diagnostics: [],
+    notes: [],
+    commands: [],
+    objectUsages: [],
+    ddsFiles: [{
+      name: objectName,
+      kind: fileKind,
+      sourceType: normalizeName(sourceType) || 'DDS',
+      recordFormats: uniqueByName(recordFormats).map((entry) => entry.name),
+      referencedFiles: uniqueByName(referencedFiles).map((entry) => entry.name),
+      evidence: [{
+        file: filePath,
+        line: 1,
+        text: objectName,
+      }],
+    }],
+    sourceTypeAnalysis: {
+      ownerProgram: objectName,
+      sourceType: normalizeName(sourceType) || 'DDS',
+    },
+  };
+}
+
+function scanDdsFile(filePath, options = {}) {
+  const content = options.content !== undefined ? String(options.content) : fs.readFileSync(filePath, 'utf8');
+  return scanDdsContent(filePath, content, options.sourceType || '');
+}
+
+module.exports = {
+  scanDdsContent,
+  scanDdsFile,
+};

--- a/src/scanner/rpgScanner.js
+++ b/src/scanner/rpgScanner.js
@@ -13,6 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const fs = require('fs');
 const path = require('path');
+const { scanClFile } = require('./clScanner');
+const { scanDdsFile } = require('./ddsScanner');
+const {
+  classifySourceFile,
+  normalizeSourceType,
+  sourceTypeFamily,
+  summarizeSourceTypes,
+} = require('../source/sourceType');
 
 const NATIVE_IO_OPCODES = new Set([
   'CHAIN',
@@ -1638,9 +1646,35 @@ function scanContent(filePath, content) {
   };
 }
 
-function scanRpgFile(filePath) {
-  const content = fs.readFileSync(filePath, 'utf8');
-  return scanContent(filePath, content);
+function scanRpgFile(filePath, options = {}) {
+  const content = options.content !== undefined ? String(options.content) : fs.readFileSync(filePath, 'utf8');
+  const result = scanContent(filePath, content);
+  result.sourceFile.sourceType = normalizeSourceType(options.sourceType || classifySourceFile(filePath));
+  return result;
+}
+
+function scanStructuredSourceFile(filePath, options = {}) {
+  const sourceType = normalizeSourceType(options.sourceType || classifySourceFile(filePath));
+  const family = sourceTypeFamily(sourceType);
+
+  if (family === 'CL') {
+    return scanClFile(filePath, {
+      content: options.content,
+      sourceType,
+    });
+  }
+
+  if (family === 'DDS') {
+    return scanDdsFile(filePath, {
+      content: options.content,
+      sourceType,
+    });
+  }
+
+  return scanRpgFile(filePath, {
+    content: options.content,
+    sourceType,
+  });
 }
 
 function mergeEntities(targetMap, entities, withKind) {
@@ -1772,9 +1806,35 @@ function scanSourceFiles(filePaths, options = {}) {
 
   for (const filePath of filePaths || []) {
     try {
+      const sourceMetadata = options.sourceMetadataByPath instanceof Map
+        ? (options.sourceMetadataByPath.get(path.resolve(String(filePath || ''))) || null)
+        : null;
+      const scanFn = (resolvedPath) => scanStructuredSourceFile(resolvedPath, {
+        content: sourceMetadata && typeof sourceMetadata.normalizedText === 'string'
+          ? sourceMetadata.normalizedText
+          : undefined,
+        sourceType: sourceMetadata && sourceMetadata.sourceType
+          ? sourceMetadata.sourceType
+          : undefined,
+      });
       const result = scanCache && typeof scanCache.getOrScan === 'function'
-        ? scanCache.getOrScan(filePath, scanRpgFile)
-        : scanRpgFile(filePath);
+        ? scanCache.getOrScan(filePath, scanFn)
+        : scanFn(filePath);
+      if (sourceMetadata) {
+        result.sourceFile = {
+          ...result.sourceFile,
+          path: result.sourceFile && result.sourceFile.path ? result.sourceFile.path : sourceMetadata.path,
+          sizeBytes: Number(sourceMetadata.sizeBytes) || result.sourceFile.sizeBytes || 0,
+          lines: typeof sourceMetadata.normalizedText === 'string'
+            ? sourceMetadata.normalizedText.split('\n').length
+            : result.sourceFile.lines,
+          sourceType: sourceMetadata.sourceType || result.sourceFile.sourceType || classifySourceFile(filePath),
+          detectedEncoding: sourceMetadata.detectedEncoding || null,
+          normalizationStatus: sourceMetadata.normalizationStatus || 'ok',
+          newlineStyle: sourceMetadata.newlineStyle || 'UNKNOWN',
+          normalizedNewlineStyle: sourceMetadata.normalizedNewlineStyle || 'UNKNOWN',
+        };
+      }
       scanResults.push(result);
     } catch (error) {
       notes.push(`Skipped file ${filePath}: ${error.message}`);
@@ -1885,6 +1945,48 @@ function scanSourceFiles(filePaths, options = {}) {
     notes.push(diagnostic.message);
   }
 
+  const commands = mergeStructuredItems(
+    scanResults,
+    'commands',
+    (item) => [
+      item.command || item.name,
+      item.text || '',
+      item.evidence && item.evidence[0] && item.evidence[0].file,
+      item.evidence && item.evidence[0] && item.evidence[0].line,
+    ].join('|'),
+  ).sort((a, b) => {
+    if (String(a.command || a.name) !== String(b.command || b.name)) {
+      return String(a.command || a.name).localeCompare(String(b.command || b.name));
+    }
+    return String(a.text || '').localeCompare(String(b.text || ''));
+  });
+  const objectUsages = mergeStructuredItems(
+    scanResults,
+    'objectUsages',
+    (item) => [
+      item.objectType,
+      item.name,
+      item.command,
+      item.evidence && item.evidence[0] && item.evidence[0].file,
+      item.evidence && item.evidence[0] && item.evidence[0].line,
+    ].join('|'),
+  ).sort((a, b) => {
+    if (String(a.objectType || '') !== String(b.objectType || '')) return String(a.objectType || '').localeCompare(String(b.objectType || ''));
+    return String(a.name || '').localeCompare(String(b.name || ''));
+  });
+  const ddsFiles = mergeStructuredItems(
+    scanResults,
+    'ddsFiles',
+    (item) => item.name,
+    (target, item) => {
+      target.kind = target.kind || item.kind || 'DISK';
+      target.sourceType = target.sourceType || item.sourceType || 'DDS';
+      target.recordFormats = uniqueSortedStrings([...(target.recordFormats || []), ...(item.recordFormats || [])]);
+      target.referencedFiles = uniqueSortedStrings([...(target.referencedFiles || []), ...(item.referencedFiles || [])]);
+    },
+  ).sort((a, b) => a.name.localeCompare(b.name));
+  const sourceTypeSummary = summarizeSourceTypes(sourceFiles);
+
   return {
     sourceFiles,
     tables: Array.from(tablesMap.values()).sort((a, b) => a.name.localeCompare(b.name)),
@@ -1949,6 +2051,16 @@ function scanSourceFiles(filePaths, options = {}) {
     servicePrograms,
     diagnostics,
     notes,
+    commands,
+    objectUsages,
+    ddsFiles,
+    sourceTypeSummary,
+    sourceTypeAnalysis: {
+      summary: sourceTypeSummary,
+      commands,
+      objectUsages,
+      ddsFiles,
+    },
   };
 }
 

--- a/src/source/sourceIntegrity.js
+++ b/src/source/sourceIntegrity.js
@@ -15,8 +15,11 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { TextDecoder } = require('util');
+const { classifySourceFile } = require('./sourceType');
 
 const UTF8_DECODER = new TextDecoder('utf-8', { fatal: true });
+const UTF16LE_DECODER = new TextDecoder('utf-16le', { fatal: true });
+const UTF16BE_DECODER = new TextDecoder('utf-16be', { fatal: true });
 
 function normalizeRelativePath(rootDir, filePath) {
   const normalizedRoot = rootDir ? path.resolve(rootDir) : null;
@@ -61,23 +64,127 @@ function buildIssue(severity, code, message) {
   };
 }
 
+function decodeBuffer(buffer, decoder) {
+  try {
+    return decoder.decode(buffer);
+  } catch (_) {
+    return null;
+  }
+}
+
+function detectEncoding(buffer, options = {}) {
+  const strictUtf8Only = Boolean(options.strictUtf8Only);
+  const bytes = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer || '');
+
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    const decoded = decodeBuffer(bytes.subarray(3), UTF8_DECODER);
+    if (decoded !== null) {
+      return {
+        detectedEncoding: 'UTF-8',
+        hadBom: true,
+        encodingConverted: false,
+        text: decoded,
+      };
+    }
+  }
+
+  if (!strictUtf8Only && bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe) {
+    const decoded = decodeBuffer(bytes.subarray(2), UTF16LE_DECODER);
+    if (decoded !== null) {
+      return {
+        detectedEncoding: 'UTF-16LE',
+        hadBom: true,
+        encodingConverted: true,
+        text: decoded,
+      };
+    }
+  }
+
+  if (!strictUtf8Only && bytes.length >= 2 && bytes[0] === 0xfe && bytes[1] === 0xff) {
+    const decoded = decodeBuffer(bytes.subarray(2), UTF16BE_DECODER);
+    if (decoded !== null) {
+      return {
+        detectedEncoding: 'UTF-16BE',
+        hadBom: true,
+        encodingConverted: true,
+        text: decoded,
+      };
+    }
+  }
+
+  const utf8 = decodeBuffer(bytes, UTF8_DECODER);
+  if (utf8 !== null) {
+    return {
+      detectedEncoding: 'UTF-8',
+      hadBom: false,
+      encodingConverted: false,
+      text: utf8,
+    };
+  }
+
+  return null;
+}
+
+function normalizeTextContract(text, options = {}) {
+  const originalText = String(text || '');
+  const originalNewlineStyle = detectNewlineStyle(originalText);
+  const normalizedText = options.normalizeText === false
+    ? originalText
+    : originalText.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const normalizedNewlineStyle = detectNewlineStyle(normalizedText);
+  const lineEndingsNormalized = normalizedText !== originalText;
+
+  return {
+    text: normalizedText,
+    originalNewlineStyle,
+    normalizedNewlineStyle,
+    lineEndingsNormalized,
+  };
+}
+
+function getManifestLocalPath(entry) {
+  return String(
+    (entry && entry.origin && entry.origin.localPath)
+    || (entry && entry.localPath)
+    || '',
+  ).trim().replace(/\\/g, '/');
+}
+
+function getManifestSha256(entry) {
+  if (entry && entry.validation && typeof entry.validation.sha256 === 'string') {
+    return entry.validation.sha256;
+  }
+  if (entry && typeof entry.sha256 === 'string') {
+    return entry.sha256;
+  }
+  return null;
+}
+
 function validateSourceFile(filePath, options = {}) {
   const rootDir = options.rootDir ? path.resolve(options.rootDir) : null;
   const absolutePath = path.resolve(String(filePath || ''));
   const relativePath = normalizeRelativePath(rootDir, absolutePath);
   const issues = [];
+  const strictUtf8Only = Boolean(options.strictUtf8Only);
 
   if (!fs.existsSync(absolutePath)) {
     issues.push(buildIssue('warning', 'SOURCE_FILE_MISSING', `Source file is missing: ${relativePath}`));
     return {
       path: absolutePath,
       relativePath,
+      sourceType: classifySourceFile(absolutePath, options.sourceType || ''),
       exists: false,
       sizeBytes: 0,
       sha256: null,
       utf8Valid: false,
+      detectedEncoding: null,
+      hadBom: false,
       newlineStyle: 'UNKNOWN',
+      normalizedNewlineStyle: 'UNKNOWN',
       normalizedNewlines: false,
+      normalizationStatus: 'invalid',
+      normalizationActions: [],
+      normalizedText: null,
       importChecksumMatch: null,
       status: 'invalid',
       issues,
@@ -86,33 +193,62 @@ function validateSourceFile(filePath, options = {}) {
 
   const buffer = fs.readFileSync(absolutePath);
   const sha256 = hashBuffer(buffer);
+  const sizeBytes = buffer.length;
+  const sourceType = classifySourceFile(absolutePath, options.sourceType || '');
+  const decoded = detectEncoding(buffer, { strictUtf8Only });
 
-  let text;
-  try {
-    text = UTF8_DECODER.decode(buffer);
-  } catch (error) {
-    issues.push(buildIssue('warning', 'INVALID_UTF8', `Invalid UTF-8 source encoding detected in ${relativePath}`));
+  if (!decoded) {
+    issues.push(buildIssue(
+      'warning',
+      'INVALID_UTF8',
+      `Invalid UTF-8 source encoding detected in ${relativePath}. Supported analyze conversions currently require UTF-8 or UTF-16 BOM markers.`,
+    ));
     return {
       path: absolutePath,
       relativePath,
+      sourceType,
       exists: true,
-      sizeBytes: buffer.length,
+      sizeBytes,
       sha256,
       utf8Valid: false,
+      detectedEncoding: null,
+      hadBom: false,
       newlineStyle: 'UNKNOWN',
+      normalizedNewlineStyle: 'UNKNOWN',
       normalizedNewlines: false,
+      normalizationStatus: 'invalid',
+      normalizationActions: [],
+      normalizedText: null,
       importChecksumMatch: options.expectedSha256 ? false : null,
       status: 'invalid',
       issues,
     };
   }
 
-  const newlineStyle = detectNewlineStyle(text);
-  const normalizedNewlines = ['LF', 'CRLF', 'NONE'].includes(newlineStyle);
+  const normalized = normalizeTextContract(decoded.text, { normalizeText: options.normalizeText !== false });
+  const normalizationActions = [];
 
-  if (newlineStyle === 'MIXED') {
+  if (decoded.hadBom) {
+    normalizationActions.push('STRIP_BOM');
+    issues.push(buildIssue('info', 'SOURCE_BOM_REMOVED', `Removed BOM from ${relativePath} before analysis.`));
+  }
+
+  if (decoded.encodingConverted) {
+    normalizationActions.push(`DECODE_${decoded.detectedEncoding}`);
+    issues.push(buildIssue('warning', 'SOURCE_ENCODING_CONVERTED', `Converted ${relativePath} from ${decoded.detectedEncoding} into the UTF-8 analysis contract.`));
+  }
+
+  if (normalized.lineEndingsNormalized) {
+    normalizationActions.push('NORMALIZE_LINE_ENDINGS');
+    const severity = ['MIXED', 'CR'].includes(normalized.originalNewlineStyle) ? 'warning' : 'info';
+    issues.push(buildIssue(
+      severity,
+      'SOURCE_LINE_ENDINGS_NORMALIZED',
+      `Normalized ${relativePath} line endings from ${normalized.originalNewlineStyle} to ${normalized.normalizedNewlineStyle}.`,
+    ));
+  } else if (normalized.originalNewlineStyle === 'MIXED') {
     issues.push(buildIssue('warning', 'MIXED_NEWLINES', `Mixed newline styles detected in ${relativePath}`));
-  } else if (newlineStyle === 'CR') {
+  } else if (normalized.originalNewlineStyle === 'CR') {
     issues.push(buildIssue('warning', 'LEGACY_CR_NEWLINES', `Legacy CR-only newlines detected in ${relativePath}`));
   }
 
@@ -124,17 +260,32 @@ function validateSourceFile(filePath, options = {}) {
     }
   }
 
+  const warningCount = issues.filter((issue) => issue.severity === 'warning').length;
+  let normalizationStatus = 'ok';
+  if (decoded.encodingConverted) {
+    normalizationStatus = 'converted';
+  } else if (decoded.hadBom || normalized.lineEndingsNormalized) {
+    normalizationStatus = 'normalized';
+  }
+
   return {
     path: absolutePath,
     relativePath,
+    sourceType,
     exists: true,
-    sizeBytes: buffer.length,
+    sizeBytes,
     sha256,
-    utf8Valid: true,
-    newlineStyle,
-    normalizedNewlines,
+    utf8Valid: decoded.detectedEncoding === 'UTF-8',
+    detectedEncoding: decoded.detectedEncoding,
+    hadBom: decoded.hadBom,
+    newlineStyle: normalized.originalNewlineStyle,
+    normalizedNewlineStyle: normalized.normalizedNewlineStyle,
+    normalizedNewlines: ['LF', 'NONE'].includes(normalized.normalizedNewlineStyle),
+    normalizationStatus,
+    normalizationActions,
+    normalizedText: normalized.text,
     importChecksumMatch,
-    status: issues.length > 0 ? 'warning' : 'ok',
+    status: warningCount > 0 ? 'warning' : 'ok',
     issues,
   };
 }
@@ -147,7 +298,7 @@ function validateSourceFiles(filePaths, options = {}) {
 
   if (importManifest) {
     for (const entry of importManifest.files) {
-      const relativePath = String(entry && entry.localPath ? entry.localPath : '').trim().replace(/\\/g, '/');
+      const relativePath = getManifestLocalPath(entry);
       if (!relativePath) continue;
       manifestEntries.set(relativePath, entry);
     }
@@ -158,7 +309,12 @@ function validateSourceFiles(filePaths, options = {}) {
     const manifestEntry = manifestEntries.get(relativePath) || null;
     return validateSourceFile(filePath, {
       rootDir: options.rootDir,
-      expectedSha256: manifestEntry && typeof manifestEntry.sha256 === 'string' ? manifestEntry.sha256 : null,
+      sourceType: options.sourceTypeByPath && options.sourceTypeByPath.get
+        ? options.sourceTypeByPath.get(path.resolve(filePath))
+        : null,
+      expectedSha256: manifestEntry ? getManifestSha256(manifestEntry) : null,
+      strictUtf8Only: Boolean(options.strictUtf8Only),
+      normalizeText: options.normalizeText !== false,
     });
   });
 
@@ -175,6 +331,15 @@ function validateSourceFiles(filePaths, options = {}) {
     results,
     warningCount,
     invalidCount,
+    normalizationSummary: {
+      fileCount: results.length,
+      convertedEncodingCount: results.filter((result) => result.normalizationStatus === 'converted').length,
+      normalizedFileCount: results.filter((result) => ['normalized', 'converted'].includes(result.normalizationStatus)).length,
+      bomRemovedCount: results.filter((result) => result.hadBom).length,
+      normalizedLineEndingCount: results.filter((result) => result.normalizationActions.includes('NORMALIZE_LINE_ENDINGS')).length,
+      invalidFileCount: invalidCount,
+      warningCount,
+    },
   };
 }
 

--- a/src/source/sourceType.js
+++ b/src/source/sourceType.js
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const path = require('path');
+
+const SOURCE_TYPE_BY_EXTENSION = Object.freeze({
+  '.rpg': 'RPG',
+  '.rpgle': 'RPGLE',
+  '.sqlrpgle': 'SQLRPGLE',
+  '.rpgile': 'RPGILE',
+  '.clp': 'CLP',
+  '.clle': 'CLLE',
+  '.dds': 'DDS',
+  '.dspf': 'DSPF',
+  '.prtf': 'PRTF',
+  '.pf': 'PF',
+  '.lf': 'LF',
+  '.bnd': 'BND',
+  '.binder': 'BINDER',
+  '.bndsrc': 'BNDSRC',
+});
+
+function normalizeSourceType(value) {
+  return String(value || '').trim().toUpperCase();
+}
+
+function classifySourceFile(filePath, explicitSourceType = '') {
+  const normalizedExplicit = normalizeSourceType(explicitSourceType);
+  if (normalizedExplicit) {
+    return normalizedExplicit;
+  }
+
+  const ext = path.extname(String(filePath || '')).toLowerCase();
+  return SOURCE_TYPE_BY_EXTENSION[ext] || 'UNKNOWN';
+}
+
+function sourceTypeFamily(sourceType) {
+  const normalized = normalizeSourceType(sourceType);
+  if (['RPG', 'RPGLE', 'SQLRPGLE', 'RPGILE', 'BND', 'BINDER', 'BNDSRC'].includes(normalized)) {
+    return 'RPG';
+  }
+  if (['CLP', 'CLLE'].includes(normalized)) {
+    return 'CL';
+  }
+  if (['DDS', 'DSPF', 'PRTF', 'PF', 'LF'].includes(normalized)) {
+    return 'DDS';
+  }
+  return 'UNKNOWN';
+}
+
+function summarizeSourceTypes(entries) {
+  const byType = {};
+  const byFamily = {};
+
+  for (const entry of entries || []) {
+    const sourceType = normalizeSourceType(entry && entry.sourceType);
+    const family = sourceTypeFamily(sourceType);
+    if (!sourceType) {
+      continue;
+    }
+    byType[sourceType] = (byType[sourceType] || 0) + 1;
+    byFamily[family] = (byFamily[family] || 0) + 1;
+  }
+
+  return {
+    byType: Object.fromEntries(Object.entries(byType).sort((a, b) => a[0].localeCompare(b[0]))),
+    byFamily: Object.fromEntries(Object.entries(byFamily).sort((a, b) => a[0].localeCompare(b[0]))),
+  };
+}
+
+module.exports = {
+  classifySourceFile,
+  normalizeSourceType,
+  sourceTypeFamily,
+  summarizeSourceTypes,
+};

--- a/tests/fetch-readability-contract.test.js
+++ b/tests/fetch-readability-contract.test.js
@@ -1,0 +1,102 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { fetchSources } = require('../src/fetch/fetchService');
+const { runAnalyzePipeline } = require('../src/analyze/analyzePipeline');
+const { IMPORT_MANIFEST_FILE } = require('../src/fetch/importManifest');
+
+function writeFetchedProgram(params) {
+  const filePath = path.join(params.localDir, 'QRPGLESRC', 'ORDERPGM.rpgle');
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, [
+    '**FREE',
+    '// Größe für München',
+    'CALL INVPGM;',
+    '',
+  ].join('\r\n'), 'utf8');
+  return { downloadedCount: 1 };
+}
+
+test('fetched UTF-8 source with national characters remains readable for analyze across supported transports', async () => {
+  const transports = ['sftp', 'jt400', 'ftp'];
+
+  for (const transport of transports) {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), `zeus-fetch-readability-${transport}-`));
+    const outDir = path.join(tempRoot, 'rpg_sources');
+    const outputRoot = path.join(tempRoot, 'output');
+    const outputProgramDir = path.join(outputRoot, 'ORDERPGM');
+
+    try {
+      const options = {
+        host: 'fixture.example.com',
+        user: 'FIXUSER',
+        password: 'FIXPASSWORD',
+        sourceLib: 'FIXLIB',
+        ifsDir: '/tmp/zeus_fixture/exported_source',
+        out: outDir,
+        files: ['QRPGLESRC'],
+        members: ['ORDERPGM'],
+        replace: true,
+        transport,
+        streamFileCcsid: 1208,
+        verbose: false,
+      };
+
+      const services = {
+        exportMembersForSourceFileFn() {
+          return [{
+            sourceFile: 'QRPGLESRC',
+            member: 'ORDERPGM',
+            ok: true,
+            command: 'CPYTOSTMF ...',
+            messages: [],
+            stderr: '',
+            fallbackUsed: false,
+          }];
+        },
+      };
+
+      if (transport === 'sftp') {
+        services.downloadDirectoryFn = async (params) => writeFetchedProgram(params);
+      } else if (transport === 'jt400') {
+        services.downloadDirectoryViaJt400Fn = async (params) => writeFetchedProgram(params);
+      } else {
+        services.downloadDirectoryViaFtpFn = async (params) => writeFetchedProgram(params);
+      }
+
+      const summary = await fetchSources(options, services);
+      assert.equal(summary.transportUsed, transport);
+
+      fs.mkdirSync(outputProgramDir, { recursive: true });
+      const result = runAnalyzePipeline({
+        program: 'ORDERPGM',
+        sourceRoot: outDir,
+        outputRoot,
+        outputProgramDir,
+        config: {
+          extensions: ['.rpgle'],
+          contextOptimizer: {},
+          testData: { limit: 25, maskColumns: [] },
+          db: null,
+        },
+        testDataLimit: 25,
+        skipTestData: true,
+        verbose: false,
+        optimizeContextEnabled: false,
+        logVerbose() {},
+      });
+
+      const manifest = JSON.parse(fs.readFileSync(path.join(outDir, IMPORT_MANIFEST_FILE), 'utf8'));
+      assert.equal(manifest.transportUsed, transport);
+      assert.equal(manifest.files[0].utf8Valid, true);
+      assert.equal(result.context.program, 'ORDERPGM');
+      assert.deepEqual(result.context.dependencies.programCalls.map((entry) => entry.name), ['INVPGM']);
+      assert.ok(!result.notes.some((note) => /Invalid UTF-8/.test(note)));
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  }
+});

--- a/tests/impact-ambiguity.test.js
+++ b/tests/impact-ambiguity.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const { copySanitizedFixtureTree } = require('./helpers/fixtureCorpus');
+
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'cli', 'zeus.js');
+
+function runCli(args, cwd) {
+  return execFileSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('analyze and impact keep duplicate-member ambiguity explicit instead of silently resolving it', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-impact-ambiguity-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const outputRoot = path.join(tempRoot, 'output');
+
+  copySanitizedFixtureTree(path.join('source', 'catalog-cross-program-root'), sourceRoot);
+
+  try {
+    runCli([
+      'analyze',
+      '--source',
+      sourceRoot,
+      '--program',
+      'CALLERPGM',
+      '--out',
+      outputRoot,
+      '--skip-test-data',
+    ], projectRoot);
+
+    runCli([
+      'impact',
+      '--program',
+      'CALLERPGM',
+      '--target',
+      'PROGRAM_020',
+      '--out',
+      outputRoot,
+    ], projectRoot);
+
+    const programOutputDir = path.join(outputRoot, 'CALLERPGM');
+    const report = fs.readFileSync(path.join(programOutputDir, 'report.md'), 'utf8');
+    const graph = readJson(path.join(programOutputDir, 'program-call-tree.json'));
+    const impact = readJson(path.join(programOutputDir, 'impact-analysis.json'));
+
+    assert.deepEqual(graph.ambiguousPrograms, ['PROGRAM_020']);
+    assert.deepEqual(graph.unresolvedPrograms, ['PROGRAM_020']);
+    assert.match(report, /Ambiguous program calls: 1/);
+    assert.match(report, /Ambiguous list: PROGRAM_020/);
+    assert.equal(impact.target, 'PROGRAM_020');
+    assert.equal(impact.type, 'PROGRAM');
+    assert.deepEqual(impact.directCallers, ['CALLERPGM']);
+    assert.equal(impact.ambiguity.targetAmbiguous, true);
+    assert.equal(impact.ambiguity.targetUnresolved, true);
+    assert.deepEqual(impact.ambiguity.ambiguousPrograms, ['PROGRAM_020']);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/source-normalization.test.js
+++ b/tests/source-normalization.test.js
@@ -1,0 +1,76 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { runAnalyzePipeline } = require('../src/analyze/analyzePipeline');
+
+test('analyze pipeline normalizes BOM-marked and UTF-16 sources into a consistent scan contract', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-source-normalization-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const outputRoot = path.join(tempRoot, 'output');
+  const outputProgramDir = path.join(outputRoot, 'ORDERPGM');
+
+  fs.mkdirSync(sourceRoot, { recursive: true });
+  fs.mkdirSync(outputProgramDir, { recursive: true });
+
+  const rootFile = path.join(sourceRoot, 'ORDERPGM.rpgle');
+  const calleeFile = path.join(sourceRoot, 'INVPGM.rpgle');
+
+  fs.writeFileSync(
+    rootFile,
+    Buffer.concat([
+      Buffer.from([0xef, 0xbb, 0xbf]),
+      Buffer.from('**FREE\r\nCALL INVPGM;\r\n', 'utf8'),
+    ]),
+  );
+  fs.writeFileSync(
+    calleeFile,
+    Buffer.from('\ufeff**FREE\r\nDCL-F ORDERS DISK;\r\n', 'utf16le'),
+  );
+
+  try {
+    const result = runAnalyzePipeline({
+      program: 'ORDERPGM',
+      sourceRoot,
+      outputRoot,
+      outputProgramDir,
+      config: {
+        extensions: ['.rpgle'],
+        contextOptimizer: {},
+        testData: { limit: 25, maskColumns: [] },
+        db: null,
+      },
+      testDataLimit: 25,
+      skipTestData: true,
+      verbose: false,
+      optimizeContextEnabled: false,
+      logVerbose() {},
+    });
+
+    const collectStage = result.stageReports.find((stage) => stage.id === 'collect-scan');
+    assert.ok(collectStage);
+    assert.equal(collectStage.metadata.scannableSourceFileCount, 2);
+    assert.equal(collectStage.metadata.sourceNormalization.convertedEncodingCount, 1);
+    assert.equal(collectStage.metadata.sourceNormalization.bomRemovedCount, 2);
+    assert.equal(collectStage.metadata.sourceNormalization.normalizedLineEndingCount, 2);
+    assert.ok(collectStage.diagnostics.some((entry) => entry.code === 'SOURCE_ENCODING_CONVERTED'));
+    assert.ok(collectStage.diagnostics.some((entry) => entry.code === 'SOURCE_BOM_REMOVED'));
+    assert.ok(collectStage.diagnostics.some((entry) => entry.code === 'SOURCE_LINE_ENDINGS_NORMALIZED'));
+
+    assert.deepEqual(
+      result.context.dependencies.programCalls.map((entry) => entry.name),
+      ['INVPGM'],
+    );
+    const sourceFiles = result.context.sourceFiles.reduce((acc, entry) => {
+      acc[entry.path] = entry;
+      return acc;
+    }, {});
+    assert.equal(sourceFiles['ORDERPGM.rpgle'].normalization.status, 'normalized');
+    assert.equal(sourceFiles['INVPGM.rpgle'].normalization.status, 'converted');
+    assert.equal(sourceFiles['INVPGM.rpgle'].normalization.detectedEncoding, 'UTF-16LE');
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/source-type-scanners.test.js
+++ b/tests/source-type-scanners.test.js
@@ -1,0 +1,84 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { runAnalyzePipeline } = require('../src/analyze/analyzePipeline');
+
+test('analyze pipeline classifies CL and DDS sources and emits source-type-specific findings', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-source-type-scan-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const outputRoot = path.join(tempRoot, 'output');
+  const outputProgramDir = path.join(outputRoot, 'ROOTCL');
+
+  fs.mkdirSync(sourceRoot, { recursive: true });
+  fs.mkdirSync(outputProgramDir, { recursive: true });
+
+  fs.writeFileSync(path.join(sourceRoot, 'ROOTCL.clle'), [
+    'PGM',
+    'DCLF FILE(ORDERS)',
+    'OVRDBF FILE(ORDERS) TOFILE(APPLIB/ORDERSH)',
+    'CALL PGM(INVPGM)',
+    'ENDPGM',
+    '',
+  ].join('\n'), 'utf8');
+  fs.writeFileSync(path.join(sourceRoot, 'SCREEN.dspf'), [
+    'A          R SCREEN01',
+    'A                                      CA03',
+    '',
+  ].join('\n'), 'utf8');
+
+  try {
+    const result = runAnalyzePipeline({
+      program: 'ROOTCL',
+      sourceRoot,
+      outputRoot,
+      outputProgramDir,
+      config: {
+        extensions: ['.clle', '.dspf'],
+        contextOptimizer: {},
+        testData: { limit: 25, maskColumns: [] },
+        db: null,
+      },
+      testDataLimit: 25,
+      skipTestData: true,
+      verbose: false,
+      optimizeContextEnabled: false,
+      logVerbose() {},
+    });
+
+    const collectStage = result.stageReports.find((stage) => stage.id === 'collect-scan');
+    assert.ok(collectStage);
+    assert.equal(collectStage.metadata.sourceTypeSummary.byType.CLLE, 1);
+    assert.equal(collectStage.metadata.sourceTypeSummary.byType.DSPF, 1);
+    assert.ok(collectStage.metadata.commandCount >= 4);
+    assert.ok(collectStage.metadata.objectUsageCount >= 2);
+    assert.equal(collectStage.metadata.ddsFileCount, 1);
+
+    assert.deepEqual(
+      result.context.dependencies.programCalls.map((entry) => entry.name),
+      ['INVPGM'],
+    );
+    assert.deepEqual(
+      result.context.dependencies.tables.map((entry) => entry.name),
+      ['ORDERS', 'ORDERSH'],
+    );
+    assert.ok(result.context.sourceTypeAnalysis.commands.some((entry) => entry.command === 'CALL'));
+    assert.ok(result.context.sourceTypeAnalysis.objectUsages.some((entry) => entry.name === 'ORDERSH' && entry.objectType === 'FILE'));
+    assert.deepEqual(
+      result.context.sourceTypeAnalysis.ddsFiles.map((entry) => ({
+        name: entry.name,
+        kind: entry.kind,
+        recordFormats: entry.recordFormats,
+      })),
+      [{
+        name: 'SCREEN',
+        kind: 'WORKSTN',
+        recordFormats: ['SCREEN01'],
+      }],
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- finish the UTF-8 fetch readability contract with regression coverage for national characters across all supported transports
- add analyze-time source ingest normalization for BOM-marked UTF-8 and UTF-16 sources, with explicit per-file diagnostics and normalized snippet usage
- keep duplicate-member ambiguity explicit through reports and impact analysis instead of silently resolving ambiguous identities
- add source-type-aware CL and DDS scanning with shared context/report output for commands, object usage, and DDS metadata

## Testing
- npm test
- node cli/zeus.js --help

Closes #55
Closes #56
Closes #58
Closes #59