### PR TITLE
Add investigation workflows and specialized prompt packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ It helps teams quickly produce consistent analysis artifacts from legacy RPG sou
 - Writes a fetch import manifest and validates imported source files before scanning
 - Normalizes supported BOM-marked local sources into a consistent analyze-time text contract
 - Classifies RPG, CL, and DDS sources before scanner dispatch
+- Optionally scans sources and imported artifacts for likely IFS path usage with evidence-backed outputs
+- Optionally runs full-text search workflows for configurable terms across local and imported analysis inputs
+- Optionally executes structured read-only diagnostic query packs for table, program, and object investigation
 - Detects common dependencies using practical heuristics:
   - F-spec and `dcl-f` table/file declarations
   - CL command, `CALL PGM`, and object/file usage hints
@@ -101,7 +104,7 @@ npm test
 Command syntax:
 
 ```bash
-zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]
+zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.sqlrpgle,.rpg] [--mode <name>] [--list-modes] [--list-diagnostic-packs] [--optimize-context] [--scan-ifs-paths] [--search-terms <csv>] [--search-ignore <csv>] [--search-max-results <n>] [--diagnostic-packs <csv>] [--diagnostic-params <k=v,...>] [--host <hostname>] [--user <username>] [--password <password>] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]
 ```
 
 Workflow command syntax:
@@ -117,6 +120,8 @@ Guided analyze modes:
 - use `--mode documentation` for documentation-first prompt packaging
 - use `--mode error-analysis` or `--mode defect-analysis` for failure-oriented evidence packaging
 - use `--mode modernization` for modernization prompt generation and extraction-boundary review
+- use `--mode refactoring` for dependency-aware refactoring guidance
+- use `--mode test-generation` for evidence-backed scenario and fixture planning
 - use `--mode impact` to highlight dependency artifacts and the next `zeus impact` step
 
 When a guided mode is selected, Zeus records the mode and derived behavior in `analyze-run-manifest.json`, writes `analysis-index.json`, and may auto-enable context optimization for prompt-heavy workflows.
@@ -130,6 +135,8 @@ Named workflow presets build on top of those guided modes and package a shareabl
 - `modernization-review`
 - `onboarding`
 - `dependency-risk`
+- `refactoring-review`
+- `test-generation-review`
 
 Use `zeus workflow --list-presets` to inspect the available presets and `zeus workflow --preset modernization-review ...` to run analyze plus bundle with one command.
 
@@ -142,6 +149,13 @@ Guided modes and workflow presets now also expose opinionated review metadata:
 - recommended outputs for sharing
 
 `zeus analyze --list-modes` and `zeus workflow --list-presets` print the audience and decision framing so users can choose a workflow by review intent, not only by file list.
+
+Investigation options extend the same analyze pipeline and output contract:
+
+- `--scan-ifs-paths` writes `ifs-paths.json` and `ifs-paths.md`
+- `--search-terms ORDERS,INVPGM` writes `search-results.json` and `search-results.md`
+- `--diagnostic-packs table-investigation --diagnostic-params table=ORDERS` writes `diagnostic-query-packs.json`, `diagnostic-query-packs.md`, and `diagnostic-query-pack-manifest.json`
+- `--list-diagnostic-packs` prints the bundled starter packs and their parameters
 
 Bundle command syntax:
 
@@ -247,13 +261,23 @@ Generated files:
 - `ai-knowledge.json`
 - `analysis-index.json`
 - `workflow-run-manifest.json` (when `zeus workflow` is executed)
+- `ifs-paths.json` (when `--scan-ifs-paths` is enabled)
+- `ifs-paths.md` (when `--scan-ifs-paths` is enabled)
+- `search-results.json` (when `--search-terms` is used)
+- `search-results.md` (when `--search-terms` is used)
+- `diagnostic-query-packs.json` (when `--diagnostic-packs` is used)
+- `diagnostic-query-packs.md` (when `--diagnostic-packs` is used)
+- `diagnostic-query-pack-manifest.json` (when `--diagnostic-packs` is used)
 - `safe-sharing/redaction-manifest.json` (when `--safe-sharing` is enabled)
 - `report.md`
 - `architecture-report.md`
 - `ai_prompt_documentation.md`
 - `ai_prompt_error_analysis.md`
 - `ai_prompt_defect_analysis.md` (when `--mode defect-analysis` is selected)
+- `ai_prompt_architecture_review.md` (when `architecture`, `modernization`, or `refactoring` modes are selected)
 - `ai_prompt_modernization.md` (when `--mode modernization` is selected)
+- `ai_prompt_refactoring_plan.md` (when `--mode refactoring` is selected)
+- `ai_prompt_test_generation.md` (when `--mode test-generation` is selected)
 - `dependency-graph.json`
 - `dependency-graph.mmd`
 - `dependency-graph.md`
@@ -289,6 +313,9 @@ The safe-sharing directory reuses the same artifact filenames where possible, bu
 - `sql`
 - `graph`
 - `crossProgramGraph`
+- `ifsPaths`
+- `searchResults`
+- `diagnosticPacks`
 - `db2Metadata`
 - `testData`
 - `aiContext`
@@ -323,6 +350,9 @@ The canonical schema and invariants are documented in `docs/canonical-analysis-m
 
 - `Overview`
 - `Source Files`
+- `IFS Path Usage`
+- `Full-Text Search`
+- `Diagnostic Query Packs`
 - `Tables`
 - `Program Calls`
 - `Procedure Semantics`
@@ -505,6 +535,9 @@ Available prompt types today:
 - `error-analysis`
 - `defect-analysis`
 - `modernization`
+- `architecture-review`
+- `refactoring-plan`
+- `test-generation`
 
 Guided analyze modes reuse these prompt contracts instead of inventing a separate prompt-selection system.
 
@@ -529,6 +562,9 @@ Supported placeholders include:
 - `{{sqlStatements}}`
 - `{{dependencyGraphSummary}}`
 - `{{sourceSnippet}}`
+- `{{ifsPaths}}`
+- `{{searchResults}}`
+- `{{diagnosticFindings}}`
 
 To add a new template:
 
@@ -649,6 +685,15 @@ Example:
 
 ```bash
 zeus analyze --source ./rpg_sources --program ORDERPGM --test-data-limit 25
+```
+
+Investigation examples:
+
+```bash
+zeus analyze --source ./rpg_sources --program ORDERPGM --scan-ifs-paths
+zeus analyze --source ./rpg_sources --program ORDERPGM --search-terms ORDERS,INVPGM --search-ignore archive/,old/
+zeus analyze --source ./rpg_sources --program ORDERPGM --diagnostic-packs table-investigation --diagnostic-params table=ORDERS
+zeus analyze --list-diagnostic-packs
 ```
 
 ## Output Bundle Packaging
@@ -820,6 +865,7 @@ See [docs/fixture-sanitization.md](/c:/Java/workspace-java/zeus-rpg-promptkit/do
 See [docs/reproducible-output-mode.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/reproducible-output-mode.md) for the reproducible output contract and stable-timestamp mode.
 See [docs/import-manifest-contract.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/import-manifest-contract.md) for the public fetch provenance manifest contract.
 See [docs/source-ingest-normalization.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/source-ingest-normalization.md) for the analyze-time normalization contract and current CL/DDS scanner depth.
+See [docs/investigation-workflows.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/investigation-workflows.md) for the new IFS-path, full-text search, diagnostic-pack, and prompt-pack workflow additions.
 
 ## Notes
 

--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -22,7 +22,7 @@ const { runWorkflow } = require('../src/cli/commands/workflowCommand');
 
 function printHelp() {
   console.log('Usage:');
-  console.log('  zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.rpg] [--mode <name>] [--list-modes] [--optimize-context] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
+  console.log('  zeus analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.rpg] [--mode <name>] [--list-modes] [--list-diagnostic-packs] [--optimize-context] [--scan-ifs-paths] [--search-terms a,b] [--search-ignore path1,path2] [--search-max-results <n>] [--diagnostic-packs a,b] [--diagnostic-params k=v] [--host <hostname>] [--user <username>] [--password <password>] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
   console.log('  zeus workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.rpg] [--list-presets] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
   console.log('  zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--safe-sharing] [--reproducible] [--profile <name>] [--verbose]');
   console.log('  zeus impact --target <name> [--program <name>] [--out <path>] [--profile <name>] [--source <path>] [--reproducible] [--verbose]');

--- a/docs/ai-knowledge-projection.md
+++ b/docs/ai-knowledge-projection.md
@@ -31,6 +31,9 @@ Current `entities` blocks include:
 - `sqlStatements`
 - `nativeFiles`
 - `db2Tables`
+- `ifsPaths`
+- `searchFindings`
+- `diagnosticPacks`
 - `binding`
 - `modules`
 
@@ -75,10 +78,15 @@ Each workflow may include:
 - `rankedEvidence`
 - `dependencyGraphSummary`
 - `testData`
+- `ifsPaths`
+- `searchFindings`
+- `diagnosticPacks`
 
 Workflow `db2Tables` is selected from the projected DB2 table set using the workflow's semantic table focus rather than a second ranking system.
 
 Workflow `testData` remains the compact compatibility summary from `context.json`, but when DB2 linkage is available Zeus narrows `testData.tables` to source-relevant DB2 tables for that workflow. This keeps sample rows available to prompts without flooding the workflow payload.
+
+Workflow `ifsPaths`, `searchFindings`, and `diagnosticPacks` are included only when those optional investigation features are present. This keeps prompt noise controlled while still making search and diagnostic evidence available to specialized prompt packs.
 
 `evidencePacks` currently groups ranked evidence into:
 

--- a/docs/canonical-analysis-model.md
+++ b/docs/canonical-analysis-model.md
@@ -137,6 +137,9 @@ Top-level `provenance.importManifest` also summarizes the import contract when p
 - `crossProgramGraph`
 - `sourceNormalization`
 - `sourceTypeAnalysis`
+- `ifsPaths`
+- `searchResults`
+- `diagnosticPacks`
 - `sourceCatalog`
 - `nativeFileUsage`
 - `bindingAnalysis`
@@ -144,6 +147,8 @@ Top-level `provenance.importManifest` also summarizes the import contract when p
 - `testData`
 
 `db2Metadata` and `testData` remain compatibility enrichments rather than first-class semantic entities. When present, they should preserve explicit linkage back to canonical source evidence, SQL references, and native file usage so downstream AI/report projections can stay evidence-backed without reparsing DB2 artifacts.
+
+`ifsPaths`, `searchResults`, and `diagnosticPacks` are also compatibility enrichments. They extend investigation and prompt workflows without changing the canonical entity graph, and they should remain deterministic, evidence-backed, and safe to bundle or redact.
 
 ## SQL Semantics
 

--- a/docs/investigation-workflows.md
+++ b/docs/investigation-workflows.md
@@ -1,0 +1,104 @@
+# Investigation Workflows
+
+Zeus now includes three opt-in investigation features that extend the existing analyze pipeline without introducing a second workflow framework:
+
+- IFS path scanning
+- full-text search
+- structured read-only diagnostic query packs
+
+These features reuse the same manifests, bundle contract, safe-sharing flow, and AI knowledge projection that the core analyze pipeline already uses.
+
+## CLI Surface
+
+Analyze options:
+
+- `--scan-ifs-paths`
+- `--search-terms <csv>`
+- `--search-ignore <csv>`
+- `--search-max-results <n>`
+- `--diagnostic-packs <csv>`
+- `--diagnostic-params <k=v,...>`
+- `--list-diagnostic-packs`
+
+Optional IBM i host credentials for command-based diagnostic steps:
+
+- `--host <hostname>`
+- `--user <username>`
+- `--password <password>`
+
+## Artifacts
+
+IFS path scanning writes:
+
+- `ifs-paths.json`
+- `ifs-paths.md`
+
+Full-text search writes:
+
+- `search-results.json`
+- `search-results.md`
+
+Diagnostic query packs write:
+
+- `diagnostic-query-packs.json`
+- `diagnostic-query-packs.md`
+- `diagnostic-query-pack-manifest.json`
+
+These artifacts are also recorded in:
+
+- `analyze-run-manifest.json`
+- `bundle-manifest.json` when bundled
+- `safe-sharing/` when safe-sharing is enabled
+
+## Read-Only Diagnostic Packs
+
+Pack format characteristics:
+
+- ordered named steps
+- step kinds: `sql`, `catalog`, `command`
+- parameter substitution through `${name}` placeholders
+- read-only validation before execution
+
+Current starter packs:
+
+- `table-investigation`
+- `program-investigation`
+- `object-investigation`
+
+Read-only enforcement:
+
+- SQL steps must start with `SELECT` or `WITH`
+- SQL steps reject mutation-oriented keywords
+- command steps are restricted to a read-only allowlist such as `DSPOBJD`, `DSPFD`, `DSPPGMREF`, `DSPSRVPGM`, and `DSPDBR`
+
+Credentials are consumed only at runtime. They are not written into output files or manifests.
+
+## Prompt Packs
+
+Prompt-pack coverage now includes:
+
+- `documentation`
+- `architecture-review`
+- `modernization`
+- `refactoring-plan`
+- `test-generation`
+
+New prompt-oriented modes:
+
+- `refactoring`
+- `test-generation`
+
+New workflow presets:
+
+- `refactoring-review`
+- `test-generation-review`
+
+## Examples
+
+```bash
+zeus analyze --source ./rpg_sources --program ORDERPGM --scan-ifs-paths
+zeus analyze --source ./rpg_sources --program ORDERPGM --search-terms ORDERS,INVPGM --search-ignore archive/,old/
+zeus analyze --source ./rpg_sources --program ORDERPGM --diagnostic-packs table-investigation --diagnostic-params table=ORDERS
+zeus workflow --preset refactoring-review --source ./rpg_sources --program ORDERPGM
+zeus workflow --preset test-generation-review --source ./rpg_sources --program ORDERPGM
+```

--- a/docs/prompt-contracts.md
+++ b/docs/prompt-contracts.md
@@ -58,3 +58,11 @@ Current fixture coverage includes:
 - `documentation`
 - `defect-analysis`
 - `modernization`
+
+Specialized prompt packs now also include:
+
+- `architecture-review`
+- `refactoring-plan`
+- `test-generation`
+
+These prompt packs still consume the same shared AI knowledge projection and can be selected through guided analyze modes or workflow presets instead of a second prompt-selection system.

--- a/java/Db2DiagnosticQueryRunner.java
+++ b/java/Db2DiagnosticQueryRunner.java
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Db2DiagnosticQueryRunner {
+    private static String escape(String value) {
+        if (value == null) return "";
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r");
+    }
+
+    private static int parseMaxRows(String value) {
+        try {
+            int parsed = Integer.parseInt(String.valueOf(value).trim());
+            return parsed > 0 ? parsed : 50;
+        } catch (NumberFormatException e) {
+            return 50;
+        }
+    }
+
+    private static String encodeValue(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof Number) {
+            if (value instanceof BigDecimal) {
+                return ((BigDecimal) value).toPlainString();
+            }
+            return String.valueOf(value);
+        }
+        if (value instanceof Boolean) {
+            return String.valueOf(value);
+        }
+        if (value instanceof byte[]) {
+            return "\"<binary>\"";
+        }
+        return "\"" + escape(String.valueOf(value)) + "\"";
+    }
+
+    private static Object readValue(ResultSet rs, int columnIndex, int sqlType) throws SQLException {
+        switch (sqlType) {
+            case Types.DATE:
+            case Types.TIME:
+            case Types.TIMESTAMP:
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return rs.getString(columnIndex);
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+            case Types.BLOB:
+                return rs.getBytes(columnIndex);
+            default:
+                return rs.getObject(columnIndex);
+        }
+    }
+
+    public static void main(String[] args) {
+        if (args.length < 4) {
+            System.err.println("Usage: java Db2DiagnosticQueryRunner <jdbcUrl> <user> <password> <query> [maxRows]");
+            System.exit(1);
+        }
+
+        String jdbcUrl = args[0];
+        String user = args[1];
+        String password = args[2];
+        String query = args[3];
+        int maxRows = parseMaxRows(args.length >= 5 ? args[4] : "50");
+
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, user, password)) {
+            connection.setReadOnly(true);
+
+            try (Statement statement = connection.createStatement()) {
+                statement.setMaxRows(maxRows);
+                try (ResultSet rs = statement.executeQuery(query)) {
+                    ResultSetMetaData metaData = rs.getMetaData();
+                    int columnCount = metaData.getColumnCount();
+                    List<String> columns = new ArrayList<>();
+
+                    for (int i = 1; i <= columnCount; i += 1) {
+                        columns.add(metaData.getColumnLabel(i));
+                    }
+
+                    StringBuilder json = new StringBuilder();
+                    json.append("{\"columns\":[");
+                    for (int i = 0; i < columns.size(); i += 1) {
+                        if (i > 0) {
+                            json.append(",");
+                        }
+                        json.append("\"").append(escape(columns.get(i))).append("\"");
+                    }
+
+                    json.append("],\"rows\":[");
+                    int rowCount = 0;
+                    while (rs.next()) {
+                        if (rowCount > 0) {
+                            json.append(",");
+                        }
+                        json.append("{");
+                        for (int i = 1; i <= columnCount; i += 1) {
+                            if (i > 1) {
+                                json.append(",");
+                            }
+                            Object value = readValue(rs, i, metaData.getColumnType(i));
+                            json.append("\"").append(escape(columns.get(i - 1))).append("\":")
+                                .append(encodeValue(value));
+                        }
+                        json.append("}");
+                        rowCount += 1;
+                    }
+                    json.append("],\"rowCount\":").append(rowCount).append("}");
+                    System.out.println(json.toString());
+                }
+            }
+        } catch (SQLException e) {
+            System.err.println("DB2 diagnostic query failed: " + e.getMessage());
+            System.exit(2);
+        }
+    }
+}

--- a/src/ai/knowledgeProjection.js
+++ b/src/ai/knowledgeProjection.js
@@ -293,6 +293,59 @@ function projectDb2Tables(context, evidenceIndex) {
     });
 }
 
+function projectIfsPaths(context, evidenceIndex) {
+  return asArray(context && context.ifsPaths && context.ifsPaths.paths)
+    .map((entry) => ({
+      path: entry.path,
+      family: entry.family,
+      evidenceRefs: evidenceRefsFor(evidenceIndex, entry.evidence),
+    }))
+    .sort((a, b) => {
+      if (a.family !== b.family) return a.family.localeCompare(b.family);
+      return a.path.localeCompare(b.path);
+    });
+}
+
+function projectSearchFindings(context) {
+  return asArray(context && context.searchResults && context.searchResults.matches)
+    .slice(0, 25)
+    .map((entry) => ({
+      term: entry.term,
+      sourcePath: entry.sourcePath,
+      sourceCategory: entry.sourceCategory,
+      sourceType: entry.sourceType,
+      line: Number(entry.line) || 1,
+      context: entry.context,
+    }))
+    .sort((a, b) => {
+      if (a.term !== b.term) return a.term.localeCompare(b.term);
+      if (a.sourceCategory !== b.sourceCategory) return a.sourceCategory.localeCompare(b.sourceCategory);
+      if (a.sourcePath !== b.sourcePath) return a.sourcePath.localeCompare(b.sourcePath);
+      return a.line - b.line;
+    });
+}
+
+function projectDiagnosticPacks(context) {
+  return asArray(context && context.diagnosticPacks && context.diagnosticPacks.packs)
+    .map((entry) => ({
+      name: entry.name,
+      title: entry.title,
+      summary: entry.summary || {},
+      highlights: asArray(entry.steps)
+        .filter((step) => step.status === 'failed' || step.status === 'succeeded')
+        .slice(0, 5)
+        .map((step) => ({
+          id: step.id,
+          title: step.title,
+          kind: step.kind,
+          status: step.status,
+          reason: step.reason || null,
+          outputSummary: step.outputSummary || {},
+        })),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
 function projectWorkflowDb2Tables(projectionTables, workflow) {
   const workflowTableNames = new Set(asArray(workflow && workflow.tables).map((entry) => normalizeName(entry && entry.name)));
   const selected = asArray(projectionTables).filter((entry) => {
@@ -330,6 +383,9 @@ function buildWorkflow(name, context, projection, payload = {}) {
     sqlStatements: cloneEntityList(payload.sqlStatements),
     nativeFiles: cloneEntityList(payload.nativeFiles && payload.nativeFiles.length > 0 ? payload.nativeFiles : projection.entities.nativeFiles),
     db2Tables: cloneEntityList(payload.db2Tables && payload.db2Tables.length > 0 ? payload.db2Tables : projection.entities.db2Tables),
+    ifsPaths: cloneEntityList(payload.ifsPaths && payload.ifsPaths.length > 0 ? payload.ifsPaths : projection.entities.ifsPaths),
+    searchFindings: cloneEntityList(payload.searchFindings && payload.searchFindings.length > 0 ? payload.searchFindings : projection.entities.searchFindings),
+    diagnosticPacks: cloneEntityList(payload.diagnosticPacks && payload.diagnosticPacks.length > 0 ? payload.diagnosticPacks : projection.entities.diagnosticPacks),
     riskMarkers: projection.riskMarkers,
     uncertaintyMarkers: projection.uncertaintyMarkers,
     tokenBudget: Number(payload.tokenBudget) || null,
@@ -505,6 +561,9 @@ function buildAiKnowledgeProjection({ canonicalAnalysis, context, optimizedConte
       sqlStatements,
       nativeFiles: projectNativeFiles(context, canonicalAnalysis, evidenceIndex),
       db2Tables: projectDb2Tables(context, evidenceIndex),
+      ifsPaths: projectIfsPaths(context, evidenceIndex),
+      searchFindings: projectSearchFindings(context),
+      diagnosticPacks: projectDiagnosticPacks(context),
       binding: projectBinding(context, canonicalAnalysis, evidenceIndex),
       modules: asArray(canonicalAnalysis.entities && canonicalAnalysis.entities.modules).map((entry) => ({
         name: entry.name,

--- a/src/analyze/analyzePipeline.js
+++ b/src/analyze/analyzePipeline.js
@@ -45,6 +45,9 @@ const { readImportManifest } = require('../fetch/importManifest');
 const { validateSourceFiles } = require('../source/sourceIntegrity');
 const { buildAnalysisIndex } = require('../workflow/analysisIndex');
 const { getPromptContract } = require('../prompt/promptRegistry');
+const { scanIfsPaths, renderIfsPathMarkdown } = require('../investigation/ifsPathScanner');
+const { runFullTextSearch, renderFullTextSearchMarkdown } = require('../investigation/fullTextSearch');
+const { runDiagnosticPacks, renderDiagnosticPackMarkdown } = require('../investigation/diagnosticPackRunner');
 const {
   buildReproduciblePathReplacements,
   normalizeReproducibilitySettings,
@@ -54,6 +57,11 @@ const {
 
 function resolvePromptContext(context, optimizedContext) {
   return optimizedContext || context;
+}
+
+function buildSourceFileMetadataMap(canonicalAnalysis) {
+  return new Map((canonicalAnalysis && canonicalAnalysis.sourceFiles ? canonicalAnalysis.sourceFiles : [])
+    .map((entry) => [entry.path, entry]));
 }
 
 function collectAndScanStage(state) {
@@ -288,6 +296,65 @@ function buildContextStage(state) {
   };
 }
 
+function investigateSourcesStage(state) {
+  const {
+    canonicalAnalysis,
+    context,
+    optimizedContext,
+    normalizedSourceTextByRelativePath,
+    scanIfsPathsEnabled,
+    searchTerms,
+    searchIgnorePatterns,
+    searchMaxResults,
+  } = state;
+  const sourceFileMetadata = buildSourceFileMetadataMap(canonicalAnalysis);
+  const ifsPathReport = scanIfsPaths(normalizedSourceTextByRelativePath, {
+    enabled: scanIfsPathsEnabled,
+  });
+  const searchResults = runFullTextSearch(normalizedSourceTextByRelativePath, sourceFileMetadata, {
+    terms: searchTerms,
+    ignorePatterns: searchIgnorePatterns,
+    maxResults: searchMaxResults,
+  });
+
+  const nextCanonicalAnalysis = enrichCanonicalAnalysisModel(canonicalAnalysis, {
+    ifsPaths: ifsPathReport,
+    searchResults,
+  });
+  const nextContext = buildContext({ canonicalAnalysis: nextCanonicalAnalysis });
+  const nextOptimizedContext = optimizedContext
+    ? {
+      ...optimizedContext,
+      ifsPaths: ifsPathReport,
+      searchResults,
+      notes: nextContext.notes,
+    }
+    : null;
+
+  return {
+    ...state,
+    canonicalAnalysis: nextCanonicalAnalysis,
+    context: nextContext,
+    optimizedContext: nextOptimizedContext,
+    promptContext: resolvePromptContext(nextContext, nextOptimizedContext),
+    ifsPathReport,
+    searchResults,
+    stageMetadata: {
+      ifsPathScanEnabled: Boolean(scanIfsPathsEnabled),
+      ifsPathCount: Number(ifsPathReport.summary.uniquePathCount) || 0,
+      searchEnabled: Boolean((searchTerms || []).length > 0),
+      searchTermCount: (searchResults.terms || []).length,
+      searchMatchCount: Number(searchResults.summary.matchCount) || 0,
+      searchTruncated: Boolean(searchResults.summary.truncated),
+    },
+    stageDiagnostics: (searchResults.notes || []).map((message) => ({
+      severity: 'warning',
+      code: 'SEARCH_RESULT_LIMIT',
+      message,
+    })),
+  };
+}
+
 function optimizeContextStage(state) {
   const { canonicalAnalysis, context, config, optimizeContextEnabled } = state;
   const contextTokens = estimateTokensFromObject(context);
@@ -470,6 +537,63 @@ function exportTestDataStage(state) {
   };
 }
 
+function runDiagnosticPacksStage(state) {
+  const {
+    canonicalAnalysis,
+    context,
+    optimizedContext,
+    diagnosticPacks,
+    diagnosticParameterString,
+    config,
+    ibmiConfig,
+    reproducibility,
+    verbose,
+  } = state;
+  const diagnosticResult = runDiagnosticPacks({
+    packNames: diagnosticPacks,
+    parameterString: diagnosticParameterString,
+    dbConfig: config.db,
+    ibmiConfig,
+    reproducibility,
+    verbose,
+    executors: state.diagnosticExecutors || null,
+  });
+
+  const nextCanonicalAnalysis = enrichCanonicalAnalysisModel(canonicalAnalysis, {
+    diagnosticPacks: diagnosticResult.report,
+    notes: diagnosticResult.notes || [],
+  });
+  const nextContext = buildContext({ canonicalAnalysis: nextCanonicalAnalysis });
+  const nextOptimizedContext = optimizedContext
+    ? {
+      ...optimizedContext,
+      diagnosticPacks: diagnosticResult.report,
+      notes: nextContext.notes,
+    }
+    : null;
+
+  return {
+    ...state,
+    canonicalAnalysis: nextCanonicalAnalysis,
+    context: nextContext,
+    optimizedContext: nextOptimizedContext,
+    promptContext: resolvePromptContext(nextContext, nextOptimizedContext),
+    diagnosticPackReport: diagnosticResult.report,
+    diagnosticPackManifest: diagnosticResult.manifest,
+    stageMetadata: {
+      enabled: Boolean((diagnosticPacks || []).length > 0),
+      packCount: Number(diagnosticResult.report.summary.packCount) || 0,
+      failedPackCount: Number(diagnosticResult.report.summary.failedPackCount) || 0,
+      stepCount: Number(diagnosticResult.report.summary.stepCount) || 0,
+    },
+    stageDiagnostics: (diagnosticResult.notes || []).map((message) => ({
+      severity: 'warning',
+      code: 'DIAGNOSTIC_PACK_NOTE',
+      message,
+    })),
+  };
+}
+
 function writeArtifactsStage(state) {
   const {
     canonicalAnalysis,
@@ -487,6 +611,10 @@ function writeArtifactsStage(state) {
     workflowPreset,
     reproducibility,
     normalizedSourceTextByRelativePath,
+    ifsPathReport,
+    searchResults,
+    diagnosticPackReport,
+    diagnosticPackManifest,
   } = state;
   const reproducibilitySettings = normalizeReproducibilitySettings(reproducibility);
   const selectedPromptTemplates = resolvePromptTemplates(promptTemplates);
@@ -511,6 +639,20 @@ function writeArtifactsStage(state) {
       context.testData.markdownFile || 'test-data.md',
     ]
     : [];
+  const generatedInvestigationFiles = [];
+  if (ifsPathReport && ifsPathReport.enabled) {
+    generatedInvestigationFiles.push('ifs-paths.json', 'ifs-paths.md');
+  }
+  if (searchResults && searchResults.enabled) {
+    generatedInvestigationFiles.push('search-results.json', 'search-results.md');
+  }
+  if (diagnosticPackReport && diagnosticPackReport.enabled) {
+    generatedInvestigationFiles.push(
+      'diagnostic-query-packs.json',
+      'diagnostic-query-packs.md',
+      'diagnostic-query-pack-manifest.json',
+    );
+  }
   const generatedFiles = [
     'canonical-analysis.json',
     'context.json',
@@ -527,6 +669,7 @@ function writeArtifactsStage(state) {
     'architecture-report.md',
     ...generatedDb2Files,
     ...generatedTestDataFiles,
+    ...generatedInvestigationFiles,
     ...generatedPromptFiles,
     'report.md',
   ];
@@ -570,6 +713,23 @@ function writeArtifactsStage(state) {
     writeJsonReport(path.join(outputProgramDir, 'optimized-context.json'), writtenOptimizedContext);
   }
   writeJsonReport(path.join(outputProgramDir, 'ai-knowledge.json'), writtenAiKnowledge);
+  if (ifsPathReport && ifsPathReport.enabled) {
+    writeJsonReport(path.join(outputProgramDir, 'ifs-paths.json'), ifsPathReport);
+    fs.writeFileSync(path.join(outputProgramDir, 'ifs-paths.md'), renderIfsPathMarkdown(ifsPathReport), 'utf8');
+  }
+  if (searchResults && searchResults.enabled) {
+    writeJsonReport(path.join(outputProgramDir, 'search-results.json'), searchResults);
+    fs.writeFileSync(path.join(outputProgramDir, 'search-results.md'), renderFullTextSearchMarkdown(searchResults), 'utf8');
+  }
+  if (diagnosticPackReport && diagnosticPackReport.enabled) {
+    writeJsonReport(path.join(outputProgramDir, 'diagnostic-query-packs.json'), diagnosticPackReport);
+    writeJsonReport(path.join(outputProgramDir, 'diagnostic-query-pack-manifest.json'), diagnosticPackManifest);
+    fs.writeFileSync(
+      path.join(outputProgramDir, 'diagnostic-query-packs.md'),
+      renderDiagnosticPackMarkdown(diagnosticPackReport),
+      'utf8',
+    );
+  }
 
   const programCallTreeJsonPath = path.join(outputProgramDir, 'program-call-tree.json');
   fs.writeFileSync(path.join(outputProgramDir, 'dependency-graph.json'), renderJson(graph), 'utf8');
@@ -619,9 +779,11 @@ function runAnalyzePipeline(initialState) {
   return runStages([
     { id: 'collect-scan', run: collectAndScanStage },
     { id: 'build-context', run: buildContextStage },
+    { id: 'investigate-sources', run: investigateSourcesStage },
     { id: 'optimize-context', run: optimizeContextStage },
     { id: 'export-db2', run: exportDb2Stage },
     { id: 'export-test-data', run: exportTestDataStage },
+    { id: 'run-diagnostic-packs', run: runDiagnosticPacksStage },
     { id: 'write-artifacts', run: writeArtifactsStage },
   ], initialState);
 }

--- a/src/analyze/analyzeRunManifest.js
+++ b/src/analyze/analyzeRunManifest.js
@@ -225,6 +225,18 @@ function buildAnalyzeRunManifest({
         reproducibleEnabled: reproducibility.enabled,
         guidedMode: context.guidedMode || null,
         workflowPreset: context.workflowPreset || null,
+        investigation: context.investigation && typeof context.investigation === 'object'
+          ? {
+            scanIfsPathsEnabled: Boolean(context.investigation.scanIfsPathsEnabled),
+            searchTerms: Array.isArray(context.investigation.searchTerms) ? context.investigation.searchTerms : [],
+            searchIgnorePatterns: Array.isArray(context.investigation.searchIgnorePatterns) ? context.investigation.searchIgnorePatterns : [],
+            searchMaxResults: Number(context.investigation.searchMaxResults) || 0,
+            diagnosticPacks: Array.isArray(context.investigation.diagnosticPacks) ? context.investigation.diagnosticPacks : [],
+            diagnosticParameterString: typeof context.investigation.diagnosticParameterString === 'string'
+              ? context.investigation.diagnosticParameterString
+              : '',
+          }
+          : null,
       },
       sourceSnapshot,
       importManifest: importManifestSummary,

--- a/src/cli/commands/analyzeCommand.js
+++ b/src/cli/commands/analyzeCommand.js
@@ -24,6 +24,7 @@ const {
 const { buildSafeSharingArtifacts } = require('../../sharing/safeSharingArtifactBuilder');
 const { listWorkflowModes, resolveWorkflowModeSettings } = require('../../workflow/workflowModeRegistry');
 const { resolvePromptTemplates } = require('../../prompt/promptBuilder');
+const { listDiagnosticPacks } = require('../../investigation/diagnosticPackRegistry');
 const {
   normalizeReproducibilitySettings,
   resolveDurationMs,
@@ -35,6 +36,17 @@ function parsePositiveInteger(value, fallback) {
   const parsed = Number.parseInt(String(value).trim(), 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return null;
   return parsed;
+}
+
+function parseCsv(value) {
+  if (value === undefined || value === null || value === true) {
+    return [];
+  }
+  return Array.from(new Set(String(value)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b));
 }
 
 function printWorkflowModes() {
@@ -51,11 +63,24 @@ function printWorkflowModes() {
   }
 }
 
+function printDiagnosticPacks() {
+  console.log('Supported diagnostic packs:');
+  for (const pack of listDiagnosticPacks()) {
+    console.log(`- ${pack.name}: ${pack.description}`);
+    console.log(`  parameters: ${pack.parameters.map((parameter) => `${parameter.name}${parameter.required ? ' (required)' : ''}`).join(', ')}`);
+    console.log(`  steps: ${(pack.steps || []).length}`);
+  }
+}
+
 function runAnalyze(args) {
   const verbose = Boolean(args.verbose);
 
   if (args['list-modes']) {
     printWorkflowModes();
+    return;
+  }
+  if (args['list-diagnostic-packs']) {
+    printDiagnosticPacks();
     return;
   }
 
@@ -108,12 +133,22 @@ function runAnalyze(args) {
     ? resolvePromptTemplates(workflowModeSettings.promptTemplates)
     : resolvePromptTemplates();
   const testDataLimit = parsePositiveInteger(args['test-data-limit'], Number(config.testData.limit) || DEFAULT_TEST_DATA_LIMIT);
+  const searchMaxResults = parsePositiveInteger(args['search-max-results'], 200);
   const skipTestData = Boolean(args['skip-test-data']);
   const safeSharingEnabled = Boolean(args['safe-sharing']);
+  const scanIfsPathsEnabled = Boolean(args['scan-ifs-paths']);
+  const searchTerms = parseCsv(args['search-terms']);
+  const searchIgnorePatterns = parseCsv(args['search-ignore']);
+  const diagnosticPacks = parseCsv(args['diagnostic-packs']);
+  const diagnosticParameterString = typeof args['diagnostic-params'] === 'string' ? args['diagnostic-params'] : '';
   const reproducibility = normalizeReproducibilitySettings(Boolean(args.reproducible));
 
   if (testDataLimit === null) {
     console.error('Invalid option: --test-data-limit must be a positive integer');
+    process.exit(2);
+  }
+  if (searchMaxResults === null) {
+    console.error('Invalid option: --search-max-results must be a positive integer');
     process.exit(2);
   }
 
@@ -125,6 +160,9 @@ function runAnalyze(args) {
   logVerbose(`Safe sharing: ${safeSharingEnabled ? 'enabled' : 'disabled'}`);
   logVerbose(`Reproducible mode: ${reproducibility.enabled ? 'enabled' : 'disabled'}`);
   logVerbose(`Test data extraction: ${skipTestData ? 'disabled' : `enabled (limit ${testDataLimit})`}`);
+  logVerbose(`IFS path scan: ${scanIfsPathsEnabled ? 'enabled' : 'disabled'}`);
+  logVerbose(`Search terms: ${searchTerms.length > 0 ? searchTerms.join(', ') : 'none'}`);
+  logVerbose(`Diagnostic packs: ${diagnosticPacks.length > 0 ? diagnosticPacks.join(', ') : 'none'}`);
   if (guidedMode) {
     logVerbose(`Workflow mode: ${guidedMode.name}`);
     logVerbose(`Workflow prompt templates: ${promptTemplates.length > 0 ? promptTemplates.join(', ') : 'none'}`);
@@ -161,6 +199,13 @@ function runAnalyze(args) {
       workflowModeSettings: guidedMode,
       promptTemplates,
       workflowPreset,
+      scanIfsPathsEnabled,
+      searchTerms,
+      searchIgnorePatterns,
+      searchMaxResults,
+      diagnosticPacks,
+      diagnosticParameterString,
+      ibmiConfig: config.ibmi,
       reproducibility,
       logVerbose,
     });
@@ -184,6 +229,14 @@ function runAnalyze(args) {
         reproducibility,
         guidedMode,
         workflowPreset,
+        investigation: {
+          scanIfsPathsEnabled,
+          searchTerms,
+          searchIgnorePatterns,
+          searchMaxResults,
+          diagnosticPacks,
+          diagnosticParameterString,
+        },
       },
       result,
       previousManifest,
@@ -217,6 +270,14 @@ function runAnalyze(args) {
         reproducibility,
         guidedMode,
         workflowPreset,
+        investigation: {
+          scanIfsPathsEnabled,
+          searchTerms,
+          searchIgnorePatterns,
+          searchMaxResults,
+          diagnosticPacks,
+          diagnosticParameterString,
+        },
       },
       error,
       previousManifest,
@@ -234,6 +295,12 @@ function runAnalyze(args) {
   }
   if (safeSharingEnabled) {
     console.log(`Safe-sharing artifacts: ${path.join(outputProgramDir, 'safe-sharing')}`);
+  }
+  if (searchTerms.length > 0) {
+    console.log(`Search terms: ${searchTerms.join(', ')}`);
+  }
+  if (diagnosticPacks.length > 0) {
+    console.log(`Diagnostic packs: ${diagnosticPacks.join(', ')}`);
   }
   console.log(`Source files scanned: ${(result.scanSummary.sourceFiles || []).length}`);
   if (result.optimizationReport.enabled) {

--- a/src/config/runtimeConfig.js
+++ b/src/config/runtimeConfig.js
@@ -172,6 +172,11 @@ function validateAnalyzeConfig(config) {
   }
   assertOptionalString(config.outputRoot, 'analyze.outputRoot');
   assertStringArray(config.extensions, 'analyze.extensions');
+  if (config.ibmi !== null && config.ibmi !== undefined) {
+    assertOptionalString(config.ibmi.host, 'analyze.ibmi.host');
+    assertOptionalString(config.ibmi.user, 'analyze.ibmi.user');
+    assertOptionalString(config.ibmi.password, 'analyze.ibmi.password');
+  }
   if (config.contextOptimizer) {
     validateContextOptimizerConfig(config.contextOptimizer, 'analyze.contextOptimizer');
   }
@@ -308,6 +313,7 @@ function applyDbEnvOverrides(dbConfig, env) {
 function resolveAnalyzeConfig(args, { cwd = process.cwd(), env = process.env } = {}) {
   const profiles = loadProfiles({ cwd });
   const profile = resolveProfile(profiles, args.profile);
+  const fetchProfile = profile ? (profile.fetch || {}) : {};
 
   const extensions = args.extensions
     ? parseCsv(args.extensions, DEFAULT_EXTENSIONS)
@@ -318,6 +324,11 @@ function resolveAnalyzeConfig(args, { cwd = process.cwd(), env = process.env } =
     outputRoot: args.out || args.output || (profile && profile.outputRoot) || 'output',
     extensions,
     db: applyDbEnvOverrides((profile && profile.db) || null, env),
+    ibmi: {
+      host: args.host || env.ZEUS_FETCH_HOST || fetchProfile.host || null,
+      user: args.user || env.ZEUS_FETCH_USER || fetchProfile.user || null,
+      password: args.password || env.ZEUS_FETCH_PASSWORD || fetchProfile.password || null,
+    },
     contextOptimizer: readContextOptimizerConfig(profiles, profile),
     testData: readTestDataConfig(profiles, profile),
   };

--- a/src/context/canonicalAnalysisModel.js
+++ b/src/context/canonicalAnalysisModel.js
@@ -1350,6 +1350,53 @@ function defaultSourceTypeAnalysis() {
   };
 }
 
+function defaultIfsPathReport() {
+  return {
+    enabled: false,
+    summary: {
+      uniquePathCount: 0,
+      evidenceCount: 0,
+      fileCount: 0,
+      familyCounts: {},
+    },
+    paths: [],
+    notes: [],
+  };
+}
+
+function defaultSearchResults() {
+  return {
+    enabled: false,
+    terms: [],
+    ignorePatterns: [],
+    summary: {
+      termCount: 0,
+      scannedFileCount: 0,
+      ignoredFileCount: 0,
+      matchCount: 0,
+      truncated: false,
+      categoryCounts: {},
+    },
+    matches: [],
+    notes: [],
+  };
+}
+
+function defaultDiagnosticPackReport() {
+  return {
+    enabled: false,
+    packs: [],
+    summary: {
+      packCount: 0,
+      succeededPackCount: 0,
+      failedPackCount: 0,
+      skippedPackCount: 0,
+      stepCount: 0,
+    },
+    notes: [],
+  };
+}
+
 function buildCanonicalAnalysisModel({
   program,
   sourceRoot,
@@ -1478,6 +1525,9 @@ function buildCanonicalAnalysisModel({
       sourceNormalization: defaultSourceNormalization(),
       sourceTypeAnalysis: defaultSourceTypeAnalysis(),
       sourceCatalog: null,
+      ifsPaths: defaultIfsPathReport(),
+      searchResults: defaultSearchResults(),
+      diagnosticPacks: defaultDiagnosticPackReport(),
       db2Metadata: null,
       testData: null,
     },
@@ -1512,6 +1562,9 @@ function enrichCanonicalAnalysisModel(model, updates = {}) {
       ...(updates.sourceNormalization ? { sourceNormalization: mergeObject(model.enrichments.sourceNormalization, updates.sourceNormalization) } : {}),
       ...(updates.sourceTypeAnalysis ? { sourceTypeAnalysis: mergeObject(model.enrichments.sourceTypeAnalysis, updates.sourceTypeAnalysis) } : {}),
       ...(updates.sourceCatalog !== undefined ? { sourceCatalog: updates.sourceCatalog } : {}),
+      ...(updates.ifsPaths !== undefined ? { ifsPaths: mergeObject(model.enrichments.ifsPaths, updates.ifsPaths) } : {}),
+      ...(updates.searchResults !== undefined ? { searchResults: mergeObject(model.enrichments.searchResults, updates.searchResults) } : {}),
+      ...(updates.diagnosticPacks !== undefined ? { diagnosticPacks: mergeObject(model.enrichments.diagnosticPacks, updates.diagnosticPacks) } : {}),
       ...(updates.db2Metadata !== undefined ? { db2Metadata: updates.db2Metadata } : {}),
       ...(updates.testData !== undefined ? { testData: updates.testData } : {}),
     },
@@ -1651,7 +1704,10 @@ module.exports = {
   defaultCrossProgramSummary,
   defaultBindingAnalysis,
   defaultGraphSummary,
+  defaultIfsPathReport,
+  defaultDiagnosticPackReport,
   defaultNativeFileUsage,
+  defaultSearchResults,
   defaultSqlAnalysis,
   enrichCanonicalAnalysisModel,
   summarizeSqlStatements,

--- a/src/context/contextBuilder.js
+++ b/src/context/contextBuilder.js
@@ -16,8 +16,11 @@ const {
   buildCanonicalAnalysisModel,
   defaultBindingAnalysis,
   defaultCrossProgramSummary,
+  defaultDiagnosticPackReport,
   defaultGraphSummary,
+  defaultIfsPathReport,
   defaultNativeFileUsage,
+  defaultSearchResults,
   defaultSqlAnalysis,
   summarizeSqlStatements,
 } = require('./canonicalAnalysisModel');
@@ -204,6 +207,15 @@ function projectContextFromCanonicalAnalysis(canonicalAnalysis) {
         objectUsages: [],
         ddsFiles: [],
       },
+    ifsPaths: canonicalAnalysis.enrichments && canonicalAnalysis.enrichments.ifsPaths
+      ? canonicalAnalysis.enrichments.ifsPaths
+      : defaultIfsPathReport(),
+    searchResults: canonicalAnalysis.enrichments && canonicalAnalysis.enrichments.searchResults
+      ? canonicalAnalysis.enrichments.searchResults
+      : defaultSearchResults(),
+    diagnosticPacks: canonicalAnalysis.enrichments && canonicalAnalysis.enrichments.diagnosticPacks
+      ? canonicalAnalysis.enrichments.diagnosticPacks
+      : defaultDiagnosticPackReport(),
     db2Metadata: canonicalAnalysis.enrichments ? canonicalAnalysis.enrichments.db2Metadata : null,
     testData: canonicalAnalysis.enrichments ? canonicalAnalysis.enrichments.testData : null,
     aiContext: canonicalAnalysis.enrichments && canonicalAnalysis.enrichments.aiContext

--- a/src/investigation/diagnosticPackRegistry.js
+++ b/src/investigation/diagnosticPackRegistry.js
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+const DIAGNOSTIC_PACK_REGISTRY = Object.freeze({
+  'table-investigation': Object.freeze({
+    name: 'table-investigation',
+    title: 'Table Investigation',
+    description: 'Inspect table identity, schema shape, and related object statistics with read-only queries.',
+    parameters: Object.freeze([
+      Object.freeze({ name: 'table', required: true, description: 'Table or file name to inspect.' }),
+      Object.freeze({ name: 'schema', required: false, description: 'Optional schema or library filter.' }),
+    ]),
+    steps: Object.freeze([
+      Object.freeze({
+        id: 'catalog-table',
+        title: 'Catalog table record',
+        kind: 'catalog',
+        maxRows: 20,
+        query: [
+          'SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, SYSTEM_TABLE_SCHEMA, SYSTEM_TABLE_NAME',
+          'FROM QSYS2.SYSTABLES',
+          'WHERE TABLE_NAME = UPPER(\'${table}\')',
+          '  AND (\'${schema}\' = \'\' OR TABLE_SCHEMA = UPPER(\'${schema}\') OR SYSTEM_TABLE_SCHEMA = UPPER(\'${schema}\'))',
+          'ORDER BY TABLE_SCHEMA, TABLE_NAME',
+        ].join(' '),
+      }),
+      Object.freeze({
+        id: 'catalog-columns',
+        title: 'Catalog column overview',
+        kind: 'catalog',
+        maxRows: 50,
+        query: [
+          'SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, IS_NULLABLE',
+          'FROM QSYS2.SYSCOLUMNS',
+          'WHERE TABLE_NAME = UPPER(\'${table}\')',
+          '  AND (\'${schema}\' = \'\' OR TABLE_SCHEMA = UPPER(\'${schema}\'))',
+          'ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION',
+        ].join(' '),
+      }),
+    ]),
+  }),
+  'program-investigation': Object.freeze({
+    name: 'program-investigation',
+    title: 'Program Investigation',
+    description: 'Inspect program object identity and related object statistics through safe read-only steps.',
+    parameters: Object.freeze([
+      Object.freeze({ name: 'program', required: true, description: 'Program name to inspect.' }),
+      Object.freeze({ name: 'library', required: false, description: 'Optional library filter.' }),
+    ]),
+    steps: Object.freeze([
+      Object.freeze({
+        id: 'object-statistics',
+        title: 'Program object statistics',
+        kind: 'catalog',
+        maxRows: 20,
+        query: [
+          'SELECT OBJNAME, OBJLONGNAME, OBJTYPE, OBJATTRIBUTE, OBJOWNER, OBJLIB',
+          'FROM TABLE(QSYS2.OBJECT_STATISTICS(OBJECT_SCHEMA => CASE WHEN \'${library}\' = \'\' THEN \'*ALL\' ELSE UPPER(\'${library}\') END,',
+          'OBJECT_NAME => UPPER(\'${program}\'), OBJECT_TYPE_LIST => \'*PGM\'))',
+          'ORDER BY OBJLIB, OBJNAME',
+        ].join(' '),
+      }),
+      Object.freeze({
+        id: 'display-object-description',
+        title: 'Program object description command',
+        kind: 'command',
+        command: 'DSPOBJD OBJ(${library}/${program}) OBJTYPE(*PGM) DETAIL(*BASIC)',
+      }),
+    ]),
+  }),
+  'object-investigation': Object.freeze({
+    name: 'object-investigation',
+    title: 'Object Investigation',
+    description: 'Inspect a generic IBM i object through catalog and read-only CL steps.',
+    parameters: Object.freeze([
+      Object.freeze({ name: 'object', required: true, description: 'Object name to inspect.' }),
+      Object.freeze({ name: 'library', required: false, description: 'Optional object library.' }),
+      Object.freeze({ name: 'objectType', required: false, description: 'Optional IBM i object type, for example *FILE or *PGM.' }),
+    ]),
+    steps: Object.freeze([
+      Object.freeze({
+        id: 'object-statistics',
+        title: 'Generic object statistics',
+        kind: 'catalog',
+        maxRows: 20,
+        query: [
+          'SELECT OBJNAME, OBJLONGNAME, OBJTYPE, OBJATTRIBUTE, OBJTEXT, OBJOWNER, OBJLIB',
+          'FROM TABLE(QSYS2.OBJECT_STATISTICS(OBJECT_SCHEMA => CASE WHEN \'${library}\' = \'\' THEN \'*ALL\' ELSE UPPER(\'${library}\') END,',
+          'OBJECT_NAME => UPPER(\'${object}\'), OBJECT_TYPE_LIST => CASE WHEN \'${objectType}\' = \'\' THEN \'*ALL\' ELSE UPPER(\'${objectType}\') END))',
+          'ORDER BY OBJLIB, OBJTYPE, OBJNAME',
+        ].join(' '),
+      }),
+      Object.freeze({
+        id: 'display-object-description',
+        title: 'Object description command',
+        kind: 'command',
+        command: 'DSPOBJD OBJ(${library}/${object}) OBJTYPE(${objectType}) DETAIL(*SERVICE)',
+      }),
+    ]),
+  }),
+});
+
+function normalizeDiagnosticPackName(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function listDiagnosticPacks() {
+  return Object.values(DIAGNOSTIC_PACK_REGISTRY);
+}
+
+function getDiagnosticPack(packName) {
+  const normalized = normalizeDiagnosticPackName(packName);
+  const pack = DIAGNOSTIC_PACK_REGISTRY[normalized];
+  if (!pack) {
+    throw new Error(`Unknown diagnostic pack: ${packName}`);
+  }
+  return pack;
+}
+
+module.exports = {
+  DIAGNOSTIC_PACK_REGISTRY,
+  getDiagnosticPack,
+  listDiagnosticPacks,
+  normalizeDiagnosticPackName,
+};

--- a/src/investigation/diagnosticPackRunner.js
+++ b/src/investigation/diagnosticPackRunner.js
@@ -1,0 +1,466 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+const { buildJdbcUrl, isDbConfigured, resolveDefaultSchema } = require('../db2/db2Config');
+const { runClCommand, runJavaHelper } = require('../fetch/jt400CommandRunner');
+const { getDiagnosticPack } = require('./diagnosticPackRegistry');
+const {
+  buildReproducibilityMetadata,
+  hashNormalizedValue,
+  normalizeReproducibilitySettings,
+  resolveTimestamp,
+} = require('../reproducibility/reproducibility');
+
+const DIAGNOSTIC_PACK_REPORT_SCHEMA_VERSION = 1;
+const DIAGNOSTIC_PACK_MANIFEST_SCHEMA_VERSION = 1;
+const ALLOWED_COMMAND_PREFIXES = ['DSPOBJD', 'DSPFD', 'DSPPGMREF', 'DSPSRVPGM', 'DSPDBR'];
+const FORBIDDEN_SQL_PATTERN = /\b(INSERT|UPDATE|DELETE|MERGE|ALTER|DROP|CREATE|TRUNCATE|CALL|GRANT|REVOKE)\b/i;
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizePackNames(value) {
+  return Array.from(new Set(asArray(value)
+    .map((entry) => String(entry || '').trim())
+    .filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function parseDiagnosticParameterString(value) {
+  return String(value || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .reduce((result, entry) => {
+      const splitIndex = entry.indexOf('=');
+      if (splitIndex <= 0) {
+        return result;
+      }
+      const key = entry.slice(0, splitIndex).trim();
+      const rawValue = entry.slice(splitIndex + 1).trim();
+      if (!key) {
+        return result;
+      }
+      result[key] = rawValue;
+      return result;
+    }, {});
+}
+
+function resolvePackParameters(pack, parameterValues) {
+  const provided = parameterValues && typeof parameterValues === 'object' ? parameterValues : {};
+  const resolved = {};
+  const errors = [];
+
+  for (const parameter of asArray(pack.parameters)) {
+    const value = String(provided[parameter.name] || '').trim();
+    resolved[parameter.name] = value;
+    if (parameter.required && !value) {
+      errors.push(`Missing required diagnostic pack parameter "${parameter.name}" for ${pack.name}.`);
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(resolved, 'library') && !resolved.library) {
+    resolved.library = '*LIBL';
+  }
+  if (Object.prototype.hasOwnProperty.call(resolved, 'objectType') && !resolved.objectType) {
+    resolved.objectType = '*ALL';
+  }
+
+  return {
+    resolved,
+    errors,
+  };
+}
+
+function applyTemplate(template, parameters) {
+  return String(template || '').replace(/\$\{([^}]+)\}/g, (_, key) => String(parameters[key] || '').trim());
+}
+
+function validateReadOnlySql(query) {
+  const normalized = String(query || '').trim();
+  if (!normalized) {
+    throw new Error('Diagnostic SQL step is empty.');
+  }
+  if (!/^(SELECT|WITH)\b/i.test(normalized)) {
+    throw new Error('Diagnostic SQL step must start with SELECT or WITH.');
+  }
+  if (FORBIDDEN_SQL_PATTERN.test(normalized)) {
+    throw new Error('Diagnostic SQL step contains a non-read-only keyword.');
+  }
+}
+
+function validateReadOnlyCommand(command) {
+  const normalized = String(command || '').trim().toUpperCase();
+  if (!normalized) {
+    throw new Error('Diagnostic command step is empty.');
+  }
+  const prefix = normalized.split(/\s+/, 1)[0];
+  if (!ALLOWED_COMMAND_PREFIXES.includes(prefix)) {
+    throw new Error(`Diagnostic command step is not in the read-only allowlist: ${prefix}`);
+  }
+}
+
+function parseSqlStepResult(stdout) {
+  const content = String(stdout || '').trim();
+  if (!content) {
+    return {
+      columns: [],
+      rows: [],
+      rowCount: 0,
+    };
+  }
+  return JSON.parse(content);
+}
+
+function defaultExecutors() {
+  return {
+    sql: ({ dbConfig, query, maxRows }) => {
+      const jdbcUrl = buildJdbcUrl(dbConfig, resolveDefaultSchema(dbConfig));
+      const result = runJavaHelper('Db2DiagnosticQueryRunner', [
+        jdbcUrl,
+        String(dbConfig.user),
+        String(dbConfig.password),
+        query,
+        String(maxRows || 50),
+      ]);
+      if (result.status !== 0) {
+        throw new Error((result.stderr || '').trim() || 'Diagnostic SQL helper failed.');
+      }
+      return parseSqlStepResult(result.stdout);
+    },
+    command: ({ ibmiConfig, command, verbose }) => runClCommand({
+      host: ibmiConfig.host,
+      user: ibmiConfig.user,
+      password: ibmiConfig.password,
+      command,
+      verbose,
+    }),
+  };
+}
+
+function summarizeStepOutput(step, output) {
+  if (step.kind === 'command') {
+    return {
+      messageCount: asArray(output && output.messages).length,
+      ok: output && output.ok === true,
+    };
+  }
+  return {
+    rowCount: Number(output && output.rowCount) || asArray(output && output.rows).length,
+    columnCount: asArray(output && output.columns).length,
+  };
+}
+
+function executeStep(step, parameters, runtime, executors) {
+  if (step.kind === 'command') {
+    const command = applyTemplate(step.command, parameters);
+    validateReadOnlyCommand(command);
+    if (!runtime.ibmiConfigured) {
+      return {
+        kind: step.kind,
+        status: 'skipped',
+        reason: 'IBM i host credentials were not configured for command diagnostics.',
+        command,
+        output: null,
+      };
+    }
+    const output = executors.command({
+      ibmiConfig: runtime.ibmiConfig,
+      command,
+      verbose: runtime.verbose,
+    });
+    return {
+      kind: step.kind,
+      status: output && output.ok === true ? 'succeeded' : 'failed',
+      command,
+      output: {
+        ok: output && output.ok === true,
+        messages: asArray(output && output.messages),
+        exitCode: Number(output && output.exitCode) || 0,
+      },
+    };
+  }
+
+  const query = applyTemplate(step.query, parameters);
+  validateReadOnlySql(query);
+  if (!runtime.dbConfigured) {
+    return {
+      kind: step.kind,
+      status: 'skipped',
+      reason: 'DB2 credentials were not configured for SQL diagnostics.',
+      query,
+      output: null,
+    };
+  }
+  const output = executors.sql({
+    dbConfig: runtime.dbConfig,
+    query,
+    maxRows: Number(step.maxRows) || 50,
+  });
+  return {
+    kind: step.kind,
+    status: 'succeeded',
+    query,
+    output: {
+      columns: asArray(output && output.columns),
+      rows: asArray(output && output.rows),
+      rowCount: Number(output && output.rowCount) || asArray(output && output.rows).length,
+    },
+  };
+}
+
+function buildPackReport(pack, parameterValues, stepResults) {
+  return {
+    name: pack.name,
+    title: pack.title,
+    description: pack.description,
+    parameters: parameterValues,
+    steps: stepResults.map((step) => ({
+      id: step.id,
+      title: step.title,
+      kind: step.kind,
+      status: step.status,
+      ...(step.query ? { query: step.query } : {}),
+      ...(step.command ? { command: step.command } : {}),
+      ...(step.reason ? { reason: step.reason } : {}),
+      ...(step.output ? { output: step.output } : {}),
+      outputSummary: summarizeStepOutput(step, step.output),
+    })),
+    summary: {
+      stepCount: stepResults.length,
+      succeededStepCount: stepResults.filter((step) => step.status === 'succeeded').length,
+      failedStepCount: stepResults.filter((step) => step.status === 'failed').length,
+      skippedStepCount: stepResults.filter((step) => step.status === 'skipped').length,
+    },
+  };
+}
+
+function buildDiagnosticPackManifest(report, reproducibility) {
+  const reproducibilitySettings = normalizeReproducibilitySettings(reproducibility);
+  const manifest = {
+    schemaVersion: DIAGNOSTIC_PACK_MANIFEST_SCHEMA_VERSION,
+    kind: 'diagnostic-query-pack-manifest',
+    generatedAt: resolveTimestamp(reproducibilitySettings),
+    enabled: Boolean(report && report.enabled),
+    summary: report ? report.summary : {
+      packCount: 0,
+      succeededPackCount: 0,
+      failedPackCount: 0,
+      skippedPackCount: 0,
+      stepCount: 0,
+    },
+    packs: asArray(report && report.packs).map((pack) => ({
+      name: pack.name,
+      title: pack.title,
+      summary: pack.summary,
+    })),
+  };
+
+  manifest.reproducibility = buildReproducibilityMetadata(
+    reproducibilitySettings,
+    hashNormalizedValue({
+      enabled: manifest.enabled,
+      summary: manifest.summary,
+      packs: manifest.packs,
+    }),
+  );
+  return manifest;
+}
+
+function runDiagnosticPacks(options = {}) {
+  const packNames = normalizePackNames(options.packNames);
+  const parameterValues = parseDiagnosticParameterString(options.parameterString);
+  const reproducibility = normalizeReproducibilitySettings(options.reproducibility);
+
+  if (packNames.length === 0) {
+    const emptyReport = {
+      schemaVersion: DIAGNOSTIC_PACK_REPORT_SCHEMA_VERSION,
+      kind: 'diagnostic-query-pack-report',
+      enabled: false,
+      packs: [],
+      summary: {
+        packCount: 0,
+        succeededPackCount: 0,
+        failedPackCount: 0,
+        skippedPackCount: 0,
+        stepCount: 0,
+      },
+      notes: [],
+    };
+    return {
+      report: emptyReport,
+      manifest: buildDiagnosticPackManifest(emptyReport, reproducibility),
+      notes: [],
+    };
+  }
+
+  const runtime = {
+    dbConfig: options.dbConfig || null,
+    ibmiConfig: options.ibmiConfig || null,
+    dbConfigured: isDbConfigured(options.dbConfig),
+    ibmiConfigured: Boolean(
+      options.ibmiConfig
+      && String(options.ibmiConfig.host || '').trim()
+      && String(options.ibmiConfig.user || '').trim()
+      && options.ibmiConfig.password !== undefined
+      && options.ibmiConfig.password !== null
+    ),
+    verbose: Boolean(options.verbose),
+  };
+  const executors = {
+    ...defaultExecutors(),
+    ...(options.executors || {}),
+  };
+
+  const packs = [];
+  const notes = [];
+
+  for (const packName of packNames) {
+    const pack = getDiagnosticPack(packName);
+    const parameterResolution = resolvePackParameters(pack, parameterValues);
+    if (parameterResolution.errors.length > 0) {
+      packs.push({
+        name: pack.name,
+        title: pack.title,
+        description: pack.description,
+        parameters: parameterResolution.resolved,
+        steps: [],
+        summary: {
+          stepCount: 0,
+          succeededStepCount: 0,
+          failedStepCount: 0,
+          skippedStepCount: 0,
+        },
+        error: parameterResolution.errors.join(' '),
+      });
+      notes.push(parameterResolution.errors.join(' '));
+      continue;
+    }
+
+    const stepResults = [];
+    let packFailed = false;
+    for (const step of asArray(pack.steps)) {
+      try {
+        const executed = executeStep(step, parameterResolution.resolved, runtime, executors);
+        stepResults.push({
+          id: step.id,
+          title: step.title,
+          ...executed,
+        });
+        if (executed.status === 'failed') {
+          packFailed = true;
+        }
+      } catch (error) {
+        packFailed = true;
+        stepResults.push({
+          id: step.id,
+          title: step.title,
+          kind: step.kind,
+          status: 'failed',
+          reason: error.message,
+          output: null,
+        });
+      }
+    }
+
+    const report = buildPackReport(pack, parameterResolution.resolved, stepResults);
+    if (packFailed) {
+      notes.push(`Diagnostic pack ${pack.name} completed with at least one failed step.`);
+    }
+    packs.push(report);
+  }
+
+  const report = {
+    schemaVersion: DIAGNOSTIC_PACK_REPORT_SCHEMA_VERSION,
+    kind: 'diagnostic-query-pack-report',
+    enabled: true,
+    generatedAt: resolveTimestamp(reproducibility),
+    packs,
+    summary: {
+      packCount: packs.length,
+      succeededPackCount: packs.filter((pack) => !pack.error && pack.summary.failedStepCount === 0 && pack.summary.skippedStepCount < pack.summary.stepCount).length,
+      failedPackCount: packs.filter((pack) => pack.error || pack.summary.failedStepCount > 0).length,
+      skippedPackCount: packs.filter((pack) => pack.summary.stepCount > 0 && pack.summary.skippedStepCount === pack.summary.stepCount).length,
+      stepCount: packs.reduce((sum, pack) => sum + pack.summary.stepCount, 0),
+    },
+    notes,
+  };
+
+  return {
+    report,
+    manifest: buildDiagnosticPackManifest(report, reproducibility),
+    notes,
+  };
+}
+
+function renderDiagnosticPackMarkdown(report) {
+  const lines = [
+    '# Diagnostic Query Packs',
+    '',
+  ];
+
+  if (!report || !report.enabled) {
+    lines.push('No diagnostic packs were selected for this run.');
+    lines.push('');
+    return `${lines.join('\n')}\n`;
+  }
+
+  lines.push(`Packs: ${report.summary.packCount}`);
+  lines.push(`Steps: ${report.summary.stepCount}`);
+  lines.push(`Failed Packs: ${report.summary.failedPackCount}`);
+  lines.push('');
+
+  for (const pack of asArray(report.packs)) {
+    lines.push(`## ${pack.name}`);
+    lines.push(pack.description || '');
+    lines.push('');
+    if (pack.error) {
+      lines.push(`Error: ${pack.error}`);
+      lines.push('');
+      continue;
+    }
+    lines.push(`Parameters: ${Object.entries(pack.parameters || {}).map(([key, value]) => `${key}=${value}`).join(', ') || 'none'}`);
+    lines.push('');
+    for (const step of asArray(pack.steps)) {
+      lines.push(`### ${step.id}`);
+      lines.push(`- Kind: ${step.kind}`);
+      lines.push(`- Status: ${step.status}`);
+      if (step.reason) {
+        lines.push(`- Reason: ${step.reason}`);
+      }
+      if (step.outputSummary && Number.isFinite(step.outputSummary.rowCount)) {
+        lines.push(`- Rows: ${step.outputSummary.rowCount}`);
+      }
+      if (step.outputSummary && Number.isFinite(step.outputSummary.messageCount)) {
+        lines.push(`- Messages: ${step.outputSummary.messageCount}`);
+      }
+      lines.push('');
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+module.exports = {
+  ALLOWED_COMMAND_PREFIXES,
+  DIAGNOSTIC_PACK_MANIFEST_SCHEMA_VERSION,
+  DIAGNOSTIC_PACK_REPORT_SCHEMA_VERSION,
+  buildDiagnosticPackManifest,
+  parseDiagnosticParameterString,
+  renderDiagnosticPackMarkdown,
+  runDiagnosticPacks,
+  validateReadOnlyCommand,
+  validateReadOnlySql,
+};

--- a/src/investigation/fullTextSearch.js
+++ b/src/investigation/fullTextSearch.js
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+const FULL_TEXT_SEARCH_SCHEMA_VERSION = 1;
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizePath(value) {
+  return String(value || '').trim().replace(/\\/g, '/');
+}
+
+function normalizeTerms(value) {
+  return Array.from(new Set(asArray(value)
+    .map((entry) => String(entry || '').trim())
+    .filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function normalizeIgnorePatterns(value) {
+  return Array.from(new Set(asArray(value)
+    .map((entry) => normalizePath(entry).toLowerCase())
+    .filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function shouldIgnore(relativePath, ignorePatterns) {
+  const normalized = normalizePath(relativePath).toLowerCase();
+  return ignorePatterns.some((pattern) => normalized.includes(pattern));
+}
+
+function buildSearchResult(term, relativePath, metadata, line, context) {
+  const sourceInfo = metadata || {};
+  return {
+    term,
+    sourcePath: normalizePath(relativePath),
+    sourceCategory: sourceInfo.provenance && sourceInfo.provenance.origin === 'imported' ? 'IMPORTED' : 'LOCAL',
+    sourceType: sourceInfo.sourceType || '',
+    line: Number(line) || 1,
+    context: String(context || '').trim(),
+  };
+}
+
+function searchLinesForTerm(term, relativePath, metadata, content) {
+  const lowerTerm = String(term || '').toLowerCase();
+  const lines = String(content || '').split('\n');
+  const matches = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.toLowerCase().includes(lowerTerm)) {
+      continue;
+    }
+    matches.push(buildSearchResult(term, relativePath, metadata, index + 1, line));
+  }
+
+  return matches;
+}
+
+function summarizeMatches(matches) {
+  const byCategory = {};
+  for (const match of matches) {
+    byCategory[match.sourceCategory] = Number(byCategory[match.sourceCategory] || 0) + 1;
+  }
+  return Object.keys(byCategory)
+    .sort((a, b) => a.localeCompare(b))
+    .reduce((result, key) => {
+      result[key] = byCategory[key];
+      return result;
+    }, {});
+}
+
+function runFullTextSearch(sourceTextByRelativePath, sourceFileMetadata, options = {}) {
+  const terms = normalizeTerms(options.terms);
+  const ignorePatterns = normalizeIgnorePatterns(options.ignorePatterns);
+  const maxResults = Number.isInteger(options.maxResults) && options.maxResults > 0
+    ? options.maxResults
+    : 200;
+
+  if (terms.length === 0) {
+    return {
+      schemaVersion: FULL_TEXT_SEARCH_SCHEMA_VERSION,
+      kind: 'full-text-search-results',
+      enabled: false,
+      terms: [],
+      ignorePatterns,
+      summary: {
+        termCount: 0,
+        scannedFileCount: 0,
+        ignoredFileCount: 0,
+        matchCount: 0,
+        truncated: false,
+        categoryCounts: {},
+      },
+      matches: [],
+      notes: [],
+    };
+  }
+
+  const entries = sourceTextByRelativePath instanceof Map
+    ? Array.from(sourceTextByRelativePath.entries()).sort((a, b) => a[0].localeCompare(b[0]))
+    : [];
+  const metadataByPath = sourceFileMetadata instanceof Map ? sourceFileMetadata : new Map();
+  const matches = [];
+  let ignoredFileCount = 0;
+  let truncated = false;
+
+  for (const [relativePath, content] of entries) {
+    if (shouldIgnore(relativePath, ignorePatterns)) {
+      ignoredFileCount += 1;
+      continue;
+    }
+    const metadata = metadataByPath.get(relativePath) || null;
+    for (const term of terms) {
+      matches.push(...searchLinesForTerm(term, relativePath, metadata, content));
+      if (matches.length >= maxResults) {
+        truncated = true;
+        break;
+      }
+    }
+    if (truncated) {
+      break;
+    }
+  }
+
+  const sortedMatches = matches
+    .slice(0, maxResults)
+    .sort((a, b) => {
+      if (a.term !== b.term) return a.term.localeCompare(b.term);
+      if (a.sourceCategory !== b.sourceCategory) return a.sourceCategory.localeCompare(b.sourceCategory);
+      if (a.sourcePath !== b.sourcePath) return a.sourcePath.localeCompare(b.sourcePath);
+      return a.line - b.line;
+    });
+
+  return {
+    schemaVersion: FULL_TEXT_SEARCH_SCHEMA_VERSION,
+    kind: 'full-text-search-results',
+    enabled: true,
+    terms,
+    ignorePatterns,
+    summary: {
+      termCount: terms.length,
+      scannedFileCount: entries.length - ignoredFileCount,
+      ignoredFileCount,
+      matchCount: sortedMatches.length,
+      truncated,
+      categoryCounts: summarizeMatches(sortedMatches),
+    },
+    matches: sortedMatches,
+    notes: truncated ? [`Search results were truncated at ${maxResults} matches.`] : [],
+  };
+}
+
+function renderFullTextSearchMarkdown(results) {
+  const lines = [
+    '# Full-Text Search Results',
+    '',
+  ];
+
+  if (!results || !results.enabled) {
+    lines.push('No search terms were configured for this run.');
+    lines.push('');
+    return `${lines.join('\n')}\n`;
+  }
+
+  lines.push(`Terms: ${results.terms.join(', ')}`);
+  lines.push(`Matches: ${results.summary.matchCount}`);
+  lines.push(`Scanned Files: ${results.summary.scannedFileCount}`);
+  lines.push(`Ignored Files: ${results.summary.ignoredFileCount}`);
+  lines.push(`Truncated: ${results.summary.truncated ? 'yes' : 'no'}`);
+  lines.push('');
+
+  if (results.ignorePatterns.length > 0) {
+    lines.push('## Ignore Rules');
+    for (const pattern of results.ignorePatterns) {
+      lines.push(`- ${pattern}`);
+    }
+    lines.push('');
+  }
+
+  if (results.matches.length === 0) {
+    lines.push('No matches were found.');
+    lines.push('');
+    return `${lines.join('\n')}\n`;
+  }
+
+  let currentTerm = null;
+  for (const match of results.matches) {
+    if (match.term !== currentTerm) {
+      currentTerm = match.term;
+      lines.push(`## Term: ${currentTerm}`);
+    }
+    lines.push(`- [${match.sourceCategory}] ${match.sourcePath}:${match.line} ${match.context}`);
+  }
+  lines.push('');
+
+  return `${lines.join('\n')}\n`;
+}
+
+module.exports = {
+  FULL_TEXT_SEARCH_SCHEMA_VERSION,
+  renderFullTextSearchMarkdown,
+  runFullTextSearch,
+};

--- a/src/investigation/ifsPathScanner.js
+++ b/src/investigation/ifsPathScanner.js
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+const IFS_PATH_REPORT_SCHEMA_VERSION = 1;
+const PATH_PATTERN = /(^|[^A-Z0-9_])((?:\/[A-Z0-9._$#@%+-]+)+)/ig;
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizePath(value) {
+  return String(value || '').trim().replace(/\\/g, '/');
+}
+
+function classifyPathFamily(pathValue) {
+  const normalized = normalizePath(pathValue).toUpperCase();
+  if (normalized.startsWith('/QSYS.LIB/')) return 'QSYS_LIB';
+  if (normalized.startsWith('/QDLS/')) return 'QDLS';
+  if (normalized.startsWith('/HOME/')) return 'HOME';
+  if (normalized.startsWith('/TMP/') || normalized === '/TMP') return 'TEMP';
+  if (normalized.startsWith('/WWW/')) return 'WEB';
+  return 'IFS';
+}
+
+function buildEvidence(file, line, text) {
+  return {
+    file: normalizePath(file),
+    line: Number(line) || 1,
+    text: String(text || '').trim(),
+  };
+}
+
+function collectFilePaths(relativePath, content) {
+  const lines = String(content || '').split('\n');
+  const findings = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    let match = PATH_PATTERN.exec(line);
+    while (match) {
+      const candidate = normalizePath(match[2]);
+      if (candidate.length >= 2 && /\/[A-Z0-9]/i.test(candidate)) {
+        findings.push({
+          path: candidate,
+          family: classifyPathFamily(candidate),
+          evidence: buildEvidence(relativePath, index + 1, line),
+        });
+      }
+      match = PATH_PATTERN.exec(line);
+    }
+    PATH_PATTERN.lastIndex = 0;
+  }
+
+  return findings;
+}
+
+function summarizeFamilies(paths) {
+  const counts = {};
+  for (const entry of asArray(paths)) {
+    counts[entry.family] = Number(counts[entry.family] || 0) + 1;
+  }
+  return Object.keys(counts)
+    .sort((a, b) => a.localeCompare(b))
+    .reduce((result, key) => {
+      result[key] = counts[key];
+      return result;
+    }, {});
+}
+
+function scanIfsPaths(sourceTextByRelativePath, options = {}) {
+  const enabled = Boolean(options.enabled);
+  if (!enabled) {
+    return {
+      schemaVersion: IFS_PATH_REPORT_SCHEMA_VERSION,
+      kind: 'ifs-path-report',
+      enabled: false,
+      summary: {
+        uniquePathCount: 0,
+        evidenceCount: 0,
+        fileCount: 0,
+        familyCounts: {},
+      },
+      paths: [],
+      notes: [],
+    };
+  }
+
+  const findings = [];
+  const entries = sourceTextByRelativePath instanceof Map
+    ? Array.from(sourceTextByRelativePath.entries()).sort((a, b) => a[0].localeCompare(b[0]))
+    : [];
+
+  for (const [relativePath, content] of entries) {
+    findings.push(...collectFilePaths(relativePath, content));
+  }
+
+  const grouped = new Map();
+  for (const finding of findings) {
+    if (!grouped.has(finding.path)) {
+      grouped.set(finding.path, {
+        path: finding.path,
+        family: finding.family,
+        evidence: [],
+      });
+    }
+    const target = grouped.get(finding.path);
+    const evidenceKey = JSON.stringify(finding.evidence);
+    const exists = target.evidence.some((entry) => JSON.stringify(entry) === evidenceKey);
+    if (!exists) {
+      target.evidence.push(finding.evidence);
+    }
+  }
+
+  const paths = Array.from(grouped.values())
+    .map((entry) => ({
+      path: entry.path,
+      family: entry.family,
+      evidence: [...entry.evidence].sort((a, b) => {
+        if (a.file !== b.file) return a.file.localeCompare(b.file);
+        return a.line - b.line;
+      }),
+    }))
+    .sort((a, b) => {
+      if (a.family !== b.family) return a.family.localeCompare(b.family);
+      return a.path.localeCompare(b.path);
+    });
+
+  return {
+    schemaVersion: IFS_PATH_REPORT_SCHEMA_VERSION,
+    kind: 'ifs-path-report',
+    enabled: true,
+    summary: {
+      uniquePathCount: paths.length,
+      evidenceCount: paths.reduce((sum, entry) => sum + entry.evidence.length, 0),
+      fileCount: new Set(paths.flatMap((entry) => entry.evidence.map((evidence) => evidence.file))).size,
+      familyCounts: summarizeFamilies(paths),
+    },
+    paths,
+    notes: [],
+  };
+}
+
+function renderIfsPathMarkdown(report) {
+  const lines = [
+    '# IFS Path Usage',
+    '',
+    `Enabled: ${report && report.enabled ? 'yes' : 'no'}`,
+    '',
+  ];
+
+  if (!report || !report.enabled) {
+    lines.push('IFS path scanning was not enabled for this run.');
+    lines.push('');
+    return `${lines.join('\n')}\n`;
+  }
+
+  lines.push(`Unique Paths: ${report.summary.uniquePathCount}`);
+  lines.push(`Evidence Locations: ${report.summary.evidenceCount}`);
+  lines.push(`Files With Matches: ${report.summary.fileCount}`);
+  lines.push('');
+
+  const familyKeys = Object.keys(report.summary.familyCounts || {});
+  if (familyKeys.length > 0) {
+    lines.push('## Families');
+    for (const key of familyKeys) {
+      lines.push(`- ${key}: ${report.summary.familyCounts[key]}`);
+    }
+    lines.push('');
+  }
+
+  if (asArray(report.paths).length === 0) {
+    lines.push('No likely IFS paths were detected.');
+    lines.push('');
+    return `${lines.join('\n')}\n`;
+  }
+
+  for (const entry of report.paths) {
+    lines.push(`## ${entry.path}`);
+    lines.push(`Family: ${entry.family}`);
+    lines.push('');
+    for (const evidence of entry.evidence || []) {
+      lines.push(`- ${evidence.file}:${evidence.line} ${evidence.text}`);
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+module.exports = {
+  IFS_PATH_REPORT_SCHEMA_VERSION,
+  classifyPathFamily,
+  renderIfsPathMarkdown,
+  scanIfsPaths,
+};

--- a/src/prompt/promptBuilder.js
+++ b/src/prompt/promptBuilder.js
@@ -144,6 +144,21 @@ function formatDb2Hint(db2Metadata, workflow) {
   return '';
 }
 
+function formatIfsPaths(ifsPaths) {
+  return asBulletList((ifsPaths || []).slice(0, 10), (entry) => `${entry.path} (${entry.family || 'IFS'})`);
+}
+
+function formatSearchResults(searchFindings) {
+  return asBulletList((searchFindings || []).slice(0, 10), (entry) => `[${entry.term}] ${entry.sourcePath}:${entry.line} ${entry.context}`);
+}
+
+function formatDiagnosticFindings(diagnosticPacks) {
+  return asBulletList((diagnosticPacks || []).slice(0, 8), (entry) => {
+    const summary = entry.summary || {};
+    return `${entry.name}: ${summary.succeededStepCount || 0} succeeded, ${summary.failedStepCount || 0} failed, ${summary.skippedStepCount || 0} skipped`;
+  });
+}
+
 function getPathValue(value, dottedPath) {
   return String(dottedPath || '')
     .split('.')
@@ -241,6 +256,9 @@ function buildTemplateData(context, sourceSnippet, contract) {
     uncertaintyMarkers: '- None detected',
     evidencePackSummary: 'No evidence packs available.',
     contractBudget: formatBudgetHint(contract, promptEstimate),
+    ifsPaths: formatIfsPaths((context.ifsPaths && context.ifsPaths.paths) || []),
+    searchResults: formatSearchResults((context.searchResults && context.searchResults.matches) || []),
+    diagnosticFindings: formatDiagnosticFindings((context.diagnosticPacks && context.diagnosticPacks.packs) || []),
   };
 }
 
@@ -290,6 +308,9 @@ function buildTemplateDataFromProjection(aiProjection, contract) {
     uncertaintyMarkers: asBulletList((workflow && workflow.uncertaintyMarkers) || []),
     evidencePackSummary: formatEvidencePackSummary(workflow),
     contractBudget: formatBudgetHint(contract, Number(workflow && workflow.estimatedTokens) || 0),
+    ifsPaths: formatIfsPaths(workflow && workflow.ifsPaths),
+    searchResults: formatSearchResults(workflow && workflow.searchFindings),
+    diagnosticFindings: formatDiagnosticFindings(workflow && workflow.diagnosticPacks),
   };
 }
 

--- a/src/prompt/promptRegistry.js
+++ b/src/prompt/promptRegistry.js
@@ -116,6 +116,81 @@ const PROMPT_REGISTRY = Object.freeze({
       maxTokens: 2400,
     }),
   }),
+  'architecture-review': Object.freeze({
+    name: 'architecture-review',
+    version: 1,
+    templateFile: 'architecture-review',
+    workflow: 'documentation',
+    outputFileName: 'ai_prompt_architecture_review.md',
+    requiredInputs: Object.freeze([
+      Object.freeze({ path: 'kind', equals: 'ai-knowledge-projection' }),
+      Object.freeze({ path: 'program', type: 'string', nonEmpty: true }),
+      Object.freeze({ path: 'workflows.documentation.summary', type: 'string', nonEmpty: true }),
+      Object.freeze({ path: 'workflows.documentation.programCalls', type: 'array' }),
+      Object.freeze({ path: 'workflows.documentation.tables', type: 'array' }),
+      Object.freeze({ path: 'workflows.documentation.evidenceHighlights', type: 'array' }),
+    ]),
+    preferredOutputShape: Object.freeze([
+      'Structural boundaries and primary dependencies',
+      'Operational hotspots and IBM i constraints',
+      'Architecture risks and unresolved edges',
+      'Recommended follow-up investigation',
+    ]),
+    budget: Object.freeze({
+      targetTokens: 1500,
+      maxTokens: 2300,
+    }),
+  }),
+  'refactoring-plan': Object.freeze({
+    name: 'refactoring-plan',
+    version: 1,
+    templateFile: 'refactoring-plan',
+    workflow: 'documentation',
+    outputFileName: 'ai_prompt_refactoring_plan.md',
+    requiredInputs: Object.freeze([
+      Object.freeze({ path: 'kind', equals: 'ai-knowledge-projection' }),
+      Object.freeze({ path: 'program', type: 'string', nonEmpty: true }),
+      Object.freeze({ path: 'workflows.documentation.summary', type: 'string', nonEmpty: true }),
+      Object.freeze({ path: 'workflows.documentation.tables', type: 'array' }),
+      Object.freeze({ path: 'workflows.documentation.programCalls', type: 'array' }),
+      Object.freeze({ path: 'workflows.documentation.nativeFiles', type: 'array' }),
+    ]),
+    preferredOutputShape: Object.freeze([
+      'Small safe refactoring candidates',
+      'Dependency-aware sequencing',
+      'High-risk blockers and validation checks',
+      'Concrete next change step',
+    ]),
+    budget: Object.freeze({
+      targetTokens: 1500,
+      maxTokens: 2400,
+    }),
+  }),
+  'test-generation': Object.freeze({
+    name: 'test-generation',
+    version: 1,
+    templateFile: 'test-generation',
+    workflow: 'documentation',
+    outputFileName: 'ai_prompt_test_generation.md',
+    requiredInputs: Object.freeze([
+      Object.freeze({ path: 'kind', equals: 'ai-knowledge-projection' }),
+      Object.freeze({ path: 'program', type: 'string', nonEmpty: true }),
+      Object.freeze({ path: 'workflows.documentation.summary', type: 'string', nonEmpty: true }),
+      Object.freeze({ path: 'workflows.documentation.sqlStatements', type: 'array' }),
+      Object.freeze({ path: 'workflows.documentation.tables', type: 'array' }),
+      Object.freeze({ path: 'workflows.documentation.evidenceHighlights', type: 'array' }),
+    ]),
+    preferredOutputShape: Object.freeze([
+      'Test scenarios and coverage priorities',
+      'Data and dependency setup hints',
+      'Edge cases and failure paths',
+      'Suggested assertions and fixtures',
+    ]),
+    budget: Object.freeze({
+      targetTokens: 1500,
+      maxTokens: 2400,
+    }),
+  }),
 });
 
 function getPromptContract(templateName) {

--- a/src/prompt/templates/architecture-review.md
+++ b/src/prompt/templates/architecture-review.md
@@ -1,0 +1,38 @@
+# Architecture Review Prompt
+
+Program: `{{program}}`
+
+## Summary
+{{summary}}
+
+## Tables
+{{tables}}
+
+## Program Calls
+{{programCalls}}
+
+## Native Files
+{{nativeFiles}}
+
+## IFS Paths
+{{ifsPaths}}
+
+## Search Findings
+{{searchResults}}
+
+## Diagnostic Packs
+{{diagnosticFindings}}
+
+## Dependency Graph
+{{dependencyGraphSummary}}
+
+## Evidence Highlights
+```text
+{{sourceSnippet}}
+```
+
+Produce an architecture review covering:
+- structural boundaries and dominant dependencies
+- IBM i specific operational constraints
+- unresolved edges or hotspots that weaken confidence
+- the next investigation step justified by the cited evidence

--- a/src/prompt/templates/refactoring-plan.md
+++ b/src/prompt/templates/refactoring-plan.md
@@ -1,0 +1,35 @@
+# Refactoring Plan Prompt
+
+Program: `{{program}}`
+
+## Summary
+{{summary}}
+
+## Tables
+{{tables}}
+
+## Program Calls
+{{programCalls}}
+
+## Native Files
+{{nativeFiles}}
+
+## SQL Statements
+{{sqlStatements}}
+
+## Diagnostic Packs
+{{diagnosticFindings}}
+
+## Risk Markers
+{{riskMarkers}}
+
+## Evidence Highlights
+```text
+{{sourceSnippet}}
+```
+
+Produce a pragmatic refactoring plan covering:
+- the smallest safe refactoring candidates
+- sequencing constraints created by data access and dependencies
+- IBM i behaviors that must not regress
+- concrete verification steps before and after the first change

--- a/src/prompt/templates/test-generation.md
+++ b/src/prompt/templates/test-generation.md
@@ -1,0 +1,32 @@
+# Test Generation Prompt
+
+Program: `{{program}}`
+
+## Summary
+{{summary}}
+
+## Tables
+{{tables}}
+
+## SQL Statements
+{{sqlStatements}}
+
+## Search Findings
+{{searchResults}}
+
+## Diagnostic Packs
+{{diagnosticFindings}}
+
+## Test Data
+{{testDataHint}}
+
+## Evidence Highlights
+```text
+{{sourceSnippet}}
+```
+
+Produce test-generation guidance covering:
+- highest-priority scenarios and edge cases
+- data setup and fixture needs
+- dependency seams that need stubbing or isolation
+- assertions tied directly to the cited evidence

--- a/src/report/markdownReport.js
+++ b/src/report/markdownReport.js
@@ -177,6 +177,42 @@ function bindingAnalysisSection(bindingAnalysis) {
   return `## Binding Analysis\n- Modules: ${summary.moduleCount || 0}\n- NoMain Modules: ${summary.noMainModuleCount || 0}\n- Service Programs: ${summary.serviceProgramCount || 0}\n- Binder Sources: ${summary.binderSourceCount || 0}\n- Binding Directories: ${summary.bindingDirectoryCount || 0}\n- Bound Modules: ${summary.boundModuleCount || 0}\n- Unresolved Bindings: ${summary.unresolvedModuleCount || 0}\n- Exported Symbols: ${summary.exportCount || 0}\n\n### Modules\n${detailLines}\n\n### Service Programs\n${serviceProgramLines}\n`;
 }
 
+function ifsPathSection(ifsPaths) {
+  const summary = (ifsPaths && ifsPaths.summary) || {};
+  const paths = (ifsPaths && ifsPaths.paths) || [];
+  if (!ifsPaths || !ifsPaths.enabled) {
+    return '## IFS Path Usage\nIFS path scanning was not enabled for this run.\n';
+  }
+  const detailLines = paths.length > 0
+    ? paths.map((entry) => `- ${entry.path} [${entry.family}]`).join('\n')
+    : '- None detected';
+  return `## IFS Path Usage\n- Unique Paths: ${summary.uniquePathCount || 0}\n- Evidence Locations: ${summary.evidenceCount || 0}\n- Files With Matches: ${summary.fileCount || 0}\n\n${detailLines}\n`;
+}
+
+function searchResultsSection(searchResults) {
+  const summary = (searchResults && searchResults.summary) || {};
+  const matches = (searchResults && searchResults.matches) || [];
+  if (!searchResults || !searchResults.enabled) {
+    return '## Full-Text Search\nNo search terms were configured for this run.\n';
+  }
+  const detailLines = matches.length > 0
+    ? matches.slice(0, 20).map((entry) => `- [${entry.term}] ${entry.sourcePath}:${entry.line} ${entry.context}`).join('\n')
+    : '- None detected';
+  return `## Full-Text Search\n- Terms: ${(searchResults.terms || []).join(', ')}\n- Matches: ${summary.matchCount || 0}\n- Scanned Files: ${summary.scannedFileCount || 0}\n- Ignored Files: ${summary.ignoredFileCount || 0}\n- Truncated: ${summary.truncated ? 'Yes' : 'No'}\n\n${detailLines}\n`;
+}
+
+function diagnosticPackSection(diagnosticPacks) {
+  const summary = (diagnosticPacks && diagnosticPacks.summary) || {};
+  const packs = (diagnosticPacks && diagnosticPacks.packs) || [];
+  if (!diagnosticPacks || !diagnosticPacks.enabled) {
+    return '## Diagnostic Query Packs\nNo diagnostic packs were selected for this run.\n';
+  }
+  const detailLines = packs.length > 0
+    ? packs.map((entry) => `- ${entry.name}: ${entry.summary.succeededStepCount || 0} succeeded, ${entry.summary.failedStepCount || 0} failed, ${entry.summary.skippedStepCount || 0} skipped`).join('\n')
+    : '- None detected';
+  return `## Diagnostic Query Packs\n- Packs: ${summary.packCount || 0}\n- Steps: ${summary.stepCount || 0}\n- Failed Packs: ${summary.failedPackCount || 0}\n- Skipped Packs: ${summary.skippedPackCount || 0}\n\n${detailLines}\n`;
+}
+
 function generateMarkdownReport(context, tokenReport) {
   const summary = context.summary || {};
   const dependencies = context.dependencies || {};
@@ -188,6 +224,9 @@ function generateMarkdownReport(context, tokenReport) {
   const nativeFileUsage = context.nativeFileUsage || {};
   const sourceNormalization = context.sourceNormalization || {};
   const sourceTypeAnalysis = context.sourceTypeAnalysis || {};
+  const ifsPaths = context.ifsPaths || {};
+  const searchResults = context.searchResults || {};
+  const diagnosticPacks = context.diagnosticPacks || {};
   const db2Metadata = context.db2Metadata || {};
   const testData = context.testData || {};
   const unresolvedPrograms = crossProgramGraph.unresolvedPrograms || [];
@@ -218,7 +257,7 @@ function generateMarkdownReport(context, tokenReport) {
     : `## Test Data Extract\nTest data extraction was skipped because ${testData.reason || 'no DB2 connection configuration was available'}.\n`;
   const procedureSection = `## Procedure Semantics\n- Procedures: ${(procedureAnalysis.summary && procedureAnalysis.summary.procedureCount) || 0}\n- Prototypes: ${(procedureAnalysis.summary && procedureAnalysis.summary.prototypeCount) || 0}\n- Procedure Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.procedureCallCount) || 0}\n- Internal Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.internalCallCount) || 0}\n- External Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.externalCallCount) || 0}\n- Dynamic Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.dynamicCallCount) || 0}\n- Unresolved Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.unresolvedCallCount) || 0}\n`;
 
-  return `# Zeus RPG Analysis Report\n\n## Overview\n- Program: ${context.program}\n- Scanned At: ${context.scannedAt}\n- Source Root: ${context.sourceRoot}\n- Source File Count: ${summary.sourceFileCount || 0}\n- Table Count: ${summary.tableCount || 0}\n- Program Call Count: ${summary.programCallCount || 0}\n- Copy Member Count: ${summary.copyMemberCount || 0}\n- SQL Statement Count: ${summary.sqlStatementCount || 0}\n${summary.text ? `- Summary: ${summary.text}\n` : ''}\n${optimizationSection(tokenReport)}\n## Source Files\n${sectionList(context.sourceFiles)}\n\n${sourceNormalizationSection(sourceNormalization)}\n${sourceTypeAnalysisSection(sourceTypeAnalysis)}\n## Tables\n${sectionList(dependencies.tables)}\n\n## Program Calls\n${sectionList(dependencies.programCalls)}\n\n## Copy Members\n${sectionList(dependencies.copyMembers)}\n\n${procedureSection}\n${bindingAnalysisSection(bindingAnalysis)}\n${nativeFileUsageSection(nativeFileUsage)}\n${sqlSection(sql)}\n${db2Section}\n${testDataSection}\n## Dependency Graph\nDependency graph generated for ${context.program}.\n\n- Nodes: ${graph.nodeCount || 0}\n- Edges: ${graph.edgeCount || 0}\n- Tables: ${graph.tableCount || 0}\n- Programs Called: ${graph.programCallCount || 0}\n- Copy Members: ${graph.copyMemberCount || 0}\n- Modules: ${graph.moduleCount || 0}\n- Service Programs: ${graph.serviceProgramCount || 0}\n- Binding Directories: ${graph.bindingDirectoryCount || 0}\n- Bind Relationships: ${graph.bindEdgeCount || 0}\n\nSee files:\n- ${(graph.files && graph.files.json) || 'dependency-graph.json'}\n- ${(graph.files && graph.files.mermaid) || 'dependency-graph.mmd'}\n- ${(graph.files && graph.files.markdown) || 'dependency-graph.md'}\n\n## Cross Program Dependency Graph\nA recursive program dependency graph was generated for ${context.program}.\n\n- Programs discovered: ${crossProgramGraph.programCount || 0}\n- Ambiguous program calls: ${ambiguousPrograms.length}\n- Ambiguous list: ${ambiguousText}\n- Unresolved program calls: ${unresolvedPrograms.length}\n- Unresolved list: ${unresolvedText}\n\nSee:\n- ${(crossProgramGraph.files && crossProgramGraph.files.json) || 'program-call-tree.json'}\n- ${(crossProgramGraph.files && crossProgramGraph.files.mermaid) || 'program-call-tree.mmd'}\n- ${(crossProgramGraph.files && crossProgramGraph.files.markdown) || 'program-call-tree.md'}\n\n## Impact Analysis\nImpact analysis can identify affected programs if a component changes.\n\nSee:\n- impact-analysis.json\n- impact-analysis.md\n\n## Interactive Architecture Viewer\nAn interactive architecture visualization has been generated.\n\nOpen:\n- architecture.html\n\nin your browser to explore program dependencies visually.\n\n## Architecture\n- See architecture-report.md for a full architecture overview.\n\n## Next Steps\n- Validate detected dependencies with the application design and naming standards.\n- Use canonical-analysis.json as the semantic source and context.json or optimized-context.json as prompt-ready projections.\n- Enrich with DB metadata and sample test data when available to improve table-level reasoning.\n- Create a portable bundle with \`zeus bundle --program ${context.program}\`.\n`;
+  return `# Zeus RPG Analysis Report\n\n## Overview\n- Program: ${context.program}\n- Scanned At: ${context.scannedAt}\n- Source Root: ${context.sourceRoot}\n- Source File Count: ${summary.sourceFileCount || 0}\n- Table Count: ${summary.tableCount || 0}\n- Program Call Count: ${summary.programCallCount || 0}\n- Copy Member Count: ${summary.copyMemberCount || 0}\n- SQL Statement Count: ${summary.sqlStatementCount || 0}\n${summary.text ? `- Summary: ${summary.text}\n` : ''}\n${optimizationSection(tokenReport)}\n## Source Files\n${sectionList(context.sourceFiles)}\n\n${sourceNormalizationSection(sourceNormalization)}\n${sourceTypeAnalysisSection(sourceTypeAnalysis)}\n${ifsPathSection(ifsPaths)}\n${searchResultsSection(searchResults)}\n${diagnosticPackSection(diagnosticPacks)}\n## Tables\n${sectionList(dependencies.tables)}\n\n## Program Calls\n${sectionList(dependencies.programCalls)}\n\n## Copy Members\n${sectionList(dependencies.copyMembers)}\n\n${procedureSection}\n${bindingAnalysisSection(bindingAnalysis)}\n${nativeFileUsageSection(nativeFileUsage)}\n${sqlSection(sql)}\n${db2Section}\n${testDataSection}\n## Dependency Graph\nDependency graph generated for ${context.program}.\n\n- Nodes: ${graph.nodeCount || 0}\n- Edges: ${graph.edgeCount || 0}\n- Tables: ${graph.tableCount || 0}\n- Programs Called: ${graph.programCallCount || 0}\n- Copy Members: ${graph.copyMemberCount || 0}\n- Modules: ${graph.moduleCount || 0}\n- Service Programs: ${graph.serviceProgramCount || 0}\n- Binding Directories: ${graph.bindingDirectoryCount || 0}\n- Bind Relationships: ${graph.bindEdgeCount || 0}\n\nSee files:\n- ${(graph.files && graph.files.json) || 'dependency-graph.json'}\n- ${(graph.files && graph.files.mermaid) || 'dependency-graph.mmd'}\n- ${(graph.files && graph.files.markdown) || 'dependency-graph.md'}\n\n## Cross Program Dependency Graph\nA recursive program dependency graph was generated for ${context.program}.\n\n- Programs discovered: ${crossProgramGraph.programCount || 0}\n- Ambiguous program calls: ${ambiguousPrograms.length}\n- Ambiguous list: ${ambiguousText}\n- Unresolved program calls: ${unresolvedPrograms.length}\n- Unresolved list: ${unresolvedText}\n\nSee:\n- ${(crossProgramGraph.files && crossProgramGraph.files.json) || 'program-call-tree.json'}\n- ${(crossProgramGraph.files && crossProgramGraph.files.mermaid) || 'program-call-tree.mmd'}\n- ${(crossProgramGraph.files && crossProgramGraph.files.markdown) || 'program-call-tree.md'}\n\n## Impact Analysis\nImpact analysis can identify affected programs if a component changes.\n\nSee:\n- impact-analysis.json\n- impact-analysis.md\n\n## Interactive Architecture Viewer\nAn interactive architecture visualization has been generated.\n\nOpen:\n- architecture.html\n\nin your browser to explore program dependencies visually.\n\n## Architecture\n- See architecture-report.md for a full architecture overview.\n\n## Next Steps\n- Validate detected dependencies with the application design and naming standards.\n- Use canonical-analysis.json as the semantic source and context.json or optimized-context.json as prompt-ready projections.\n- Enrich with DB metadata, search results, and sample test data when available to improve reasoning.\n- Create a portable bundle with \`zeus bundle --program ${context.program}\`.\n`;
 }
 
 module.exports = {

--- a/src/workflow/analysisIndex.js
+++ b/src/workflow/analysisIndex.js
@@ -132,6 +132,16 @@ function buildNextActions(mode, program) {
         'Open ai_prompt_modernization.md to review candidates, blockers, and suggested first steps.',
         'Use architecture-report.md and canonical-analysis.json to validate extraction boundaries and integration risks.',
       ];
+    case 'refactoring':
+      return [
+        'Open ai_prompt_refactoring_plan.md for the smallest safe change slices and validation steps.',
+        'Use ai_prompt_architecture_review.md and dependency-graph.md to confirm the proposed scope is actually isolated.',
+      ];
+    case 'test-generation':
+      return [
+        'Open ai_prompt_test_generation.md to review scenarios, fixture hints, and assertion ideas.',
+        'Cross-check the suggested tests against report.md and ai_prompt_documentation.md before implementing them.',
+      ];
     case 'impact':
       return [
         `Run zeus impact --target <name> --program ${programName} to compute reverse dependency blast radius.`,

--- a/src/workflow/workflowModeRegistry.js
+++ b/src/workflow/workflowModeRegistry.js
@@ -20,7 +20,7 @@ const WORKFLOW_MODE_REGISTRY = Object.freeze({
     name: 'architecture',
     title: 'Architecture Review',
     description: 'Focus on dependency structure, semantic relationships, and architecture-facing documentation artifacts.',
-    promptTemplates: Object.freeze(['documentation']),
+    promptTemplates: Object.freeze(['documentation', 'architecture-review']),
     autoOptimizeContext: true,
     primaryArtifacts: Object.freeze([
       'analysis-index.json',
@@ -29,6 +29,7 @@ const WORKFLOW_MODE_REGISTRY = Object.freeze({
       'dependency-graph.md',
       'program-call-tree.md',
       'ai_prompt_documentation.md',
+      'ai_prompt_architecture_review.md',
     ]),
     reviewWorkflow: freezeReviewWorkflow({
       intendedAudience: [
@@ -196,13 +197,14 @@ const WORKFLOW_MODE_REGISTRY = Object.freeze({
     name: 'modernization',
     title: 'Modernization',
     description: 'Highlight extraction boundaries, change blockers, and evidence-backed modernization candidates.',
-    promptTemplates: Object.freeze(['documentation', 'modernization']),
+    promptTemplates: Object.freeze(['documentation', 'architecture-review', 'modernization']),
     autoOptimizeContext: true,
     primaryArtifacts: Object.freeze([
       'analysis-index.json',
       'canonical-analysis.json',
       'architecture-report.md',
       'ai_prompt_documentation.md',
+      'ai_prompt_architecture_review.md',
       'ai_prompt_modernization.md',
     ]),
     reviewWorkflow: freezeReviewWorkflow({
@@ -234,6 +236,95 @@ const WORKFLOW_MODE_REGISTRY = Object.freeze({
         { path: 'architecture-report.md', purpose: 'Architecture narrative for reviewing seams and dependencies.' },
         { path: 'canonical-analysis.json', purpose: 'Semantic source of truth for validating modernization claims.' },
         { path: 'ai_prompt_documentation.md', purpose: 'Supporting documentation prompt for reviewer context.' },
+      ],
+    }),
+  }),
+  refactoring: Object.freeze({
+    name: 'refactoring',
+    title: 'Refactoring',
+    description: 'Focus on small safe change seams, dependency-aware sequencing, and verification guidance.',
+    promptTemplates: Object.freeze(['architecture-review', 'refactoring-plan']),
+    autoOptimizeContext: true,
+    primaryArtifacts: Object.freeze([
+      'analysis-index.json',
+      'canonical-analysis.json',
+      'architecture-report.md',
+      'dependency-graph.md',
+      'ai_prompt_architecture_review.md',
+      'ai_prompt_refactoring_plan.md',
+    ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'Developers planning local improvements',
+        'Technical leads sequencing safer refactors',
+        'Reviewers validating change boundaries before implementation',
+      ],
+      keyQuestionsAnswered: [
+        'Which refactoring candidates are small enough to execute safely now?',
+        'Which dependencies or IBM i behaviors constrain sequencing?',
+        'Which evidence should reviewers inspect before approving the first change?',
+      ],
+      expectedDecisions: [
+        'Choose the first refactoring slice and the verification plan around it.',
+        'Decide whether blockers require more architecture or runtime investigation first.',
+      ],
+      interpretationGuidance: [
+        'Prefer ai_prompt_refactoring_plan.md for sequencing guidance and ai_prompt_architecture_review.md for boundary validation.',
+        'Treat mutating file I/O, unresolved calls, and dynamic SQL as indicators that refactoring scope should stay narrow until validated.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and selected root program.',
+        'Canonical semantic analysis, architecture evidence, and dependency graph artifacts.',
+        'Refactoring and architecture prompt packs grounded in the same shared context model.',
+      ],
+      recommendedOutputs: [
+        { path: 'ai_prompt_refactoring_plan.md', purpose: 'Primary refactoring plan with sequencing and validation guidance.' },
+        { path: 'ai_prompt_architecture_review.md', purpose: 'Supporting architecture prompt for boundary checks.' },
+        { path: 'dependency-graph.md', purpose: 'Readable dependency structure used to limit change scope.' },
+      ],
+    }),
+  }),
+  'test-generation': Object.freeze({
+    name: 'test-generation',
+    title: 'Test Generation',
+    description: 'Package scenario, data-setup, and assertion guidance for evidence-backed test planning.',
+    promptTemplates: Object.freeze(['documentation', 'test-generation']),
+    autoOptimizeContext: true,
+    primaryArtifacts: Object.freeze([
+      'analysis-index.json',
+      'ai-knowledge.json',
+      'report.md',
+      'ai_prompt_documentation.md',
+      'ai_prompt_test_generation.md',
+    ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'Developers expanding regression coverage',
+        'QA engineers translating IBM i behavior into test scenarios',
+        'Reviewers planning fixtures and assertions before implementation',
+      ],
+      keyQuestionsAnswered: [
+        'Which scenarios and edge cases deserve the first automated tests?',
+        'Which dependencies, tables, or SQL paths drive fixture needs?',
+        'Which generated artifacts best support evidence-backed test planning?',
+      ],
+      expectedDecisions: [
+        'Choose the first test scenarios and fixture boundaries to implement.',
+        'Decide whether additional data or diagnostic evidence is needed before writing tests.',
+      ],
+      interpretationGuidance: [
+        'Use ai_prompt_test_generation.md for scenario design and ai_prompt_documentation.md for broader program context.',
+        'Treat test-data and diagnostic-pack outputs as setup hints, not proof that runtime behavior is fully covered.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and selected root program.',
+        'Prompt-ready AI knowledge projection with tables, SQL, evidence highlights, and optional diagnostic outputs.',
+        'Documentation and test-generation prompt packs that consume the shared context model.',
+      ],
+      recommendedOutputs: [
+        { path: 'ai_prompt_test_generation.md', purpose: 'Primary test-generation prompt with scenarios, fixtures, and assertions.' },
+        { path: 'ai_prompt_documentation.md', purpose: 'Supporting documentation prompt for system context.' },
+        { path: 'report.md', purpose: 'Human-readable summary for manual validation of the proposed tests.' },
       ],
     }),
   }),

--- a/src/workflow/workflowPresetRegistry.js
+++ b/src/workflow/workflowPresetRegistry.js
@@ -30,6 +30,7 @@ const WORKFLOW_PRESET_REGISTRY = Object.freeze({
       'program-call-tree.md',
       'architecture.html',
       'ai_prompt_documentation.md',
+      'ai_prompt_architecture_review.md',
     ]),
     reviewWorkflow: freezeReviewWorkflow({
       intendedAudience: [
@@ -61,6 +62,7 @@ const WORKFLOW_PRESET_REGISTRY = Object.freeze({
         { path: 'program-call-tree.md', purpose: 'Readable cross-program dependency path summary.' },
         { path: 'architecture.html', purpose: 'Interactive graph view for live review sessions.' },
         { path: 'ai_prompt_documentation.md', purpose: 'AI-assisted explanation of the architecture packet.' },
+        { path: 'ai_prompt_architecture_review.md', purpose: 'Architecture-specific prompt for structural review and follow-up questions.' },
       ],
     }),
   }),
@@ -78,6 +80,7 @@ const WORKFLOW_PRESET_REGISTRY = Object.freeze({
       'report.md',
       'program-call-tree.md',
       'ai_prompt_documentation.md',
+      'ai_prompt_architecture_review.md',
       'ai_prompt_modernization.md',
     ]),
     reviewWorkflow: freezeReviewWorkflow({
@@ -109,6 +112,7 @@ const WORKFLOW_PRESET_REGISTRY = Object.freeze({
         { path: 'architecture-report.md', purpose: 'Narrative architecture evidence for modernization discussions.' },
         { path: 'program-call-tree.md', purpose: 'Call-chain context for change-boundary reasoning.' },
         { path: 'ai_prompt_documentation.md', purpose: 'Supporting documentation prompt for reviewer orientation.' },
+        { path: 'ai_prompt_architecture_review.md', purpose: 'Supporting architecture prompt for reviewing structural blockers and seams.' },
       ],
     }),
   }),
@@ -204,6 +208,96 @@ const WORKFLOW_PRESET_REGISTRY = Object.freeze({
         { path: 'ai_prompt_error_analysis.md', purpose: 'Supporting risk evidence prompt for suspicious SQL and error paths.' },
         { path: 'dependency-graph.md', purpose: 'Readable dependency structure for review discussion.' },
         { path: 'program-call-tree.md', purpose: 'Readable cross-program blast-radius context.' },
+      ],
+    }),
+  }),
+  'refactoring-review': Object.freeze({
+    name: 'refactoring-review',
+    title: 'Refactoring Review',
+    description: 'Bundle architecture and refactoring prompts with dependency evidence for small-scope change planning.',
+    analyzeMode: 'refactoring',
+    bundleArtifacts: Object.freeze([
+      'analyze-run-manifest.json',
+      'analysis-index.json',
+      'canonical-analysis.json',
+      'ai-knowledge.json',
+      'architecture-report.md',
+      'dependency-graph.md',
+      'ai_prompt_architecture_review.md',
+      'ai_prompt_refactoring_plan.md',
+    ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'Developers planning low-risk refactors',
+        'Technical leads reviewing sequencing and blockers',
+        'Reviewers validating the first change slice before implementation',
+      ],
+      keyQuestionsAnswered: [
+        'Which refactoring slice is small enough to start now?',
+        'Which dependencies or IBM i behaviors constrain sequencing?',
+        'Which outputs should be shared before approving the first change?',
+      ],
+      expectedDecisions: [
+        'Choose the first refactoring slice and its validation plan.',
+        'Decide whether more investigation is needed before changing code.',
+      ],
+      interpretationGuidance: [
+        'Use ai_prompt_refactoring_plan.md for change sequencing and ai_prompt_architecture_review.md for boundary checks.',
+        'Keep scope narrow when unresolved calls, dynamic SQL, or mutating file I/O remain in the evidence set.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and root program selection.',
+        'Canonical analysis, dependency artifacts, and the refactoring-focused prompt packs.',
+        'A shareable bundle that keeps architecture context and refactoring guidance together.',
+      ],
+      recommendedOutputs: [
+        { path: 'ai_prompt_refactoring_plan.md', purpose: 'Primary refactoring guidance with sequencing and safety checks.' },
+        { path: 'ai_prompt_architecture_review.md', purpose: 'Supporting architecture prompt for boundary validation.' },
+        { path: 'dependency-graph.md', purpose: 'Readable dependency map used to constrain change scope.' },
+      ],
+    }),
+  }),
+  'test-generation-review': Object.freeze({
+    name: 'test-generation-review',
+    title: 'Test Generation Review',
+    description: 'Bundle documentation and test-generation prompts with evidence for scenario and fixture planning.',
+    analyzeMode: 'test-generation',
+    bundleArtifacts: Object.freeze([
+      'analyze-run-manifest.json',
+      'analysis-index.json',
+      'ai-knowledge.json',
+      'report.md',
+      'ai_prompt_documentation.md',
+      'ai_prompt_test_generation.md',
+    ]),
+    reviewWorkflow: freezeReviewWorkflow({
+      intendedAudience: [
+        'Developers adding regression coverage',
+        'QA engineers translating IBM i logic into tests',
+        'Reviewers planning fixtures and assertion strategy',
+      ],
+      keyQuestionsAnswered: [
+        'Which scenarios deserve the first automated tests?',
+        'Which tables, SQL paths, or dependencies shape fixture design?',
+        'Which outputs make the test-planning packet shareable?',
+      ],
+      expectedDecisions: [
+        'Choose the first test scenarios and fixture boundaries to implement.',
+        'Decide whether more runtime or catalog evidence is needed before writing tests.',
+      ],
+      interpretationGuidance: [
+        'Use ai_prompt_test_generation.md for scenarios and assertions, then confirm assumptions against report.md and ai_prompt_documentation.md.',
+        'Treat extracted sample rows and diagnostic outputs as setup hints, not complete runtime coverage.',
+      ],
+      requiredInputs: [
+        'A local IBM i source tree and root program selection.',
+        'Prompt-ready AI knowledge projection with tables, SQL, and evidence highlights.',
+        'A shareable bundle targeted at test-scenario and fixture planning.',
+      ],
+      recommendedOutputs: [
+        { path: 'ai_prompt_test_generation.md', purpose: 'Primary prompt for scenario, fixture, and assertion planning.' },
+        { path: 'ai_prompt_documentation.md', purpose: 'Supporting prompt for program context and flow.' },
+        { path: 'report.md', purpose: 'Human-readable summary for validating proposed coverage.' },
       ],
     }),
   }),

--- a/tests/analyze-run-manifest.test.js
+++ b/tests/analyze-run-manifest.test.js
@@ -48,7 +48,7 @@ test('buildAnalyzeRunManifest creates a stable success manifest with artifact me
         extensions: ['.rpgle'],
         guidedMode: {
           name: 'modernization',
-          promptTemplates: ['documentation', 'modernization'],
+          promptTemplates: ['documentation', 'architecture-review', 'modernization'],
           effectiveOptimizeContext: true,
           reviewWorkflow: {
             intendedAudience: ['Modernization leads'],
@@ -65,7 +65,7 @@ test('buildAnalyzeRunManifest creates a stable success manifest with artifact me
           name: 'modernization-review',
           title: 'Modernization Review',
           analyzeMode: 'modernization',
-          promptTemplates: ['documentation', 'modernization'],
+          promptTemplates: ['documentation', 'architecture-review', 'modernization'],
           workflowKeys: ['documentation'],
           bundleArtifacts: ['analyze-run-manifest.json', 'ai_prompt_modernization.md'],
           reviewWorkflow: {
@@ -78,6 +78,14 @@ test('buildAnalyzeRunManifest creates a stable success manifest with artifact me
               { path: 'ai_prompt_modernization.md', purpose: 'Primary modernization bundle output.' },
             ],
           },
+        },
+        investigation: {
+          scanIfsPathsEnabled: true,
+          searchTerms: ['ORDERS'],
+          searchIgnorePatterns: ['legacy/'],
+          searchMaxResults: 25,
+          diagnosticPacks: ['table-investigation'],
+          diagnosticParameterString: 'table=ORDERS',
         },
       },
       result: {
@@ -166,10 +174,13 @@ test('buildAnalyzeRunManifest creates a stable success manifest with artifact me
     assert.equal(manifest.inputs.importManifest.sourceLib, 'APPLIB');
     assert.equal(manifest.inputs.importManifest.traceableFileCount, 1);
     assert.equal(manifest.inputs.options.guidedMode.name, 'modernization');
-    assert.deepEqual(manifest.inputs.options.guidedMode.promptTemplates, ['documentation', 'modernization']);
+    assert.deepEqual(manifest.inputs.options.guidedMode.promptTemplates, ['documentation', 'architecture-review', 'modernization']);
     assert.match(manifest.inputs.options.guidedMode.reviewWorkflow.intendedAudience.join('\n'), /Modernization leads/);
     assert.equal(manifest.inputs.options.workflowPreset.name, 'modernization-review');
     assert.match(manifest.inputs.options.workflowPreset.reviewWorkflow.expectedDecisions.join('\n'), /pilot change/i);
+    assert.equal(manifest.inputs.options.investigation.scanIfsPathsEnabled, true);
+    assert.deepEqual(manifest.inputs.options.investigation.searchTerms, ['ORDERS']);
+    assert.deepEqual(manifest.inputs.options.investigation.diagnosticPacks, ['table-investigation']);
     assert.equal(manifest.artifacts.length, 2);
     assert.equal(manifest.artifacts[0].exists, true);
     assert.ok(typeof manifest.artifacts[0].sha256 === 'string' && manifest.artifacts[0].sha256.length > 0);

--- a/tests/diagnostic-pack-runner.test.js
+++ b/tests/diagnostic-pack-runner.test.js
@@ -1,0 +1,56 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  parseDiagnosticParameterString,
+  runDiagnosticPacks,
+  validateReadOnlyCommand,
+  validateReadOnlySql,
+} = require('../src/investigation/diagnosticPackRunner');
+
+test('diagnostic pack runner executes SQL and command steps through injected executors', () => {
+  const executed = [];
+  const result = runDiagnosticPacks({
+    packNames: ['table-investigation', 'program-investigation'],
+    parameterString: 'table=ORDERS,program=ORDERPGM,library=APPLIB',
+    dbConfig: { host: 'ibmi.example.com', user: 'USER', password: 'SECRET', defaultSchema: 'APPLIB' },
+    ibmiConfig: { host: 'ibmi.example.com', user: 'USER', password: 'SECRET' },
+    executors: {
+      sql: ({ query }) => {
+        executed.push({ kind: 'sql', query });
+        return {
+          columns: ['NAME'],
+          rows: [{ NAME: 'VALUE' }],
+          rowCount: 1,
+        };
+      },
+      command: ({ command }) => {
+        executed.push({ kind: 'command', command });
+        return {
+          ok: true,
+          messages: ['CPF0000 completed'],
+          exitCode: 0,
+        };
+      },
+    },
+  });
+
+  assert.equal(result.report.enabled, true);
+  assert.equal(result.report.summary.packCount, 2);
+  assert.equal(result.report.summary.failedPackCount, 0);
+  assert.ok(executed.some((entry) => entry.kind === 'sql' && /QSYS2\.SYSTABLES/i.test(entry.query)));
+  assert.ok(executed.some((entry) => entry.kind === 'command' && /DSPOBJD/i.test(entry.command)));
+  assert.equal(result.manifest.kind, 'diagnostic-query-pack-manifest');
+});
+
+test('diagnostic parameter parsing is deterministic', () => {
+  assert.deepEqual(parseDiagnosticParameterString('table=ORDERS, library = APPLIB ,invalid'), {
+    table: 'ORDERS',
+    library: 'APPLIB',
+  });
+});
+
+test('diagnostic runner rejects unsafe SQL and commands', () => {
+  assert.throws(() => validateReadOnlySql('update orders set status = 1'), /select or with|read-only/i);
+  assert.throws(() => validateReadOnlyCommand('DLTOBJ OBJ(APPLIB/ORDERS) OBJTYPE(*FILE)'), /allowlist/i);
+});

--- a/tests/investigation-workflows.test.js
+++ b/tests/investigation-workflows.test.js
@@ -1,0 +1,87 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'cli', 'zeus.js');
+const fixtureRoot = path.join(__dirname, 'fixtures', 'v1-smoke', 'src');
+
+function runCli(args, cwd) {
+  return execFileSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('analyze can emit IFS path, full-text search, and diagnostic pack artifacts', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-investigation-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const outputRoot = path.join(tempRoot, 'output');
+
+  fs.cpSync(fixtureRoot, sourceRoot, { recursive: true });
+  fs.appendFileSync(
+    path.join(sourceRoot, 'ORDERPGM.sqlrpgle'),
+    "\n// Investigation fixtures\nDCL-S HomePath VARCHAR(256) INZ('/home/order/docs/order.json');\n",
+    'utf8',
+  );
+
+  try {
+    runCli([
+      'analyze',
+      '--source',
+      sourceRoot,
+      '--program',
+      'ORDERPGM',
+      '--out',
+      outputRoot,
+      '--scan-ifs-paths',
+      '--search-terms',
+      'INVPGM,/home/order',
+      '--diagnostic-packs',
+      'table-investigation',
+      '--diagnostic-params',
+      'table=ORDERS',
+    ], projectRoot);
+
+    const programOutputDir = path.join(outputRoot, 'ORDERPGM');
+    assert.equal(fs.existsSync(path.join(programOutputDir, 'ifs-paths.json')), true);
+    assert.equal(fs.existsSync(path.join(programOutputDir, 'search-results.json')), true);
+    assert.equal(fs.existsSync(path.join(programOutputDir, 'diagnostic-query-packs.json')), true);
+    assert.equal(fs.existsSync(path.join(programOutputDir, 'diagnostic-query-pack-manifest.json')), true);
+
+    const ifsPaths = readJson(path.join(programOutputDir, 'ifs-paths.json'));
+    assert.equal(ifsPaths.enabled, true);
+    assert.ok(ifsPaths.paths.some((entry) => entry.path === '/home/order/docs/order.json'));
+
+    const searchResults = readJson(path.join(programOutputDir, 'search-results.json'));
+    assert.equal(searchResults.enabled, true);
+    assert.ok(searchResults.matches.some((entry) => entry.term === 'INVPGM'));
+    assert.ok(searchResults.matches.some((entry) => entry.term === '/home/order'));
+
+    const diagnosticPacks = readJson(path.join(programOutputDir, 'diagnostic-query-packs.json'));
+    assert.equal(diagnosticPacks.enabled, true);
+    assert.equal(diagnosticPacks.summary.packCount, 1);
+    assert.equal(diagnosticPacks.packs[0].name, 'table-investigation');
+    assert.equal(diagnosticPacks.packs[0].summary.skippedStepCount, 2);
+
+    const report = fs.readFileSync(path.join(programOutputDir, 'report.md'), 'utf8');
+    assert.match(report, /## IFS Path Usage/);
+    assert.match(report, /## Full-Text Search/);
+    assert.match(report, /## Diagnostic Query Packs/);
+
+    const manifest = readJson(path.join(programOutputDir, 'analyze-run-manifest.json'));
+    assert.equal(manifest.inputs.options.investigation.scanIfsPathsEnabled, true);
+    assert.deepEqual(manifest.inputs.options.investigation.searchTerms, ['/home/order', 'INVPGM']);
+    assert.deepEqual(manifest.inputs.options.investigation.diagnosticPacks, ['table-investigation']);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/prompt-packs.test.js
+++ b/tests/prompt-packs.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'cli', 'zeus.js');
+const fixtureRoot = path.join(__dirname, 'fixtures', 'v1-smoke', 'src');
+
+function runCli(args, cwd) {
+  return execFileSync(process.execPath, [cliPath, ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+test('refactoring and test-generation prompt packs are emitted through guided modes and presets', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-prompt-packs-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const outputRoot = path.join(tempRoot, 'output');
+  const bundleRoot = path.join(tempRoot, 'bundles');
+
+  fs.cpSync(fixtureRoot, sourceRoot, { recursive: true });
+
+  try {
+    runCli([
+      'analyze',
+      '--source',
+      sourceRoot,
+      '--program',
+      'ORDERPGM',
+      '--out',
+      outputRoot,
+      '--mode',
+      'refactoring',
+    ], projectRoot);
+
+    const refactoringDir = path.join(outputRoot, 'ORDERPGM');
+    assert.equal(fs.existsSync(path.join(refactoringDir, 'ai_prompt_architecture_review.md')), true);
+    assert.equal(fs.existsSync(path.join(refactoringDir, 'ai_prompt_refactoring_plan.md')), true);
+
+    runCli([
+      'workflow',
+      '--preset',
+      'test-generation-review',
+      '--source',
+      sourceRoot,
+      '--program',
+      'ORDERPGM',
+      '--out',
+      outputRoot,
+      '--bundle-output',
+      bundleRoot,
+    ], projectRoot);
+
+    const workflowDir = path.join(outputRoot, 'ORDERPGM');
+    assert.equal(fs.existsSync(path.join(workflowDir, 'ai_prompt_test_generation.md')), true);
+    const workflowManifest = JSON.parse(fs.readFileSync(path.join(workflowDir, 'workflow-run-manifest.json'), 'utf8'));
+    assert.equal(workflowManifest.preset.name, 'test-generation-review');
+    assert.equal(workflowManifest.preset.analyzeMode, 'test-generation');
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/task-oriented-analysis-index.test.js
+++ b/tests/task-oriented-analysis-index.test.js
@@ -26,6 +26,8 @@ test('analyze --list-modes exposes guided workflow presets', () => {
   assert.match(output, /Supported analyze workflow modes:/);
   assert.match(output, /- architecture:/);
   assert.match(output, /- modernization:/);
+  assert.match(output, /- refactoring:/);
+  assert.match(output, /- test-generation:/);
   assert.match(output, /- impact:/);
   assert.match(output, /intended audience:/);
   assert.match(output, /expected decisions:/);
@@ -55,6 +57,7 @@ test('guided analyze mode writes task index, selected mode metadata, and mode-sp
     assert.equal(fs.existsSync(path.join(programOutputDir, 'optimized-context.json')), true);
     assert.equal(fs.existsSync(path.join(programOutputDir, 'analysis-index.json')), true);
     assert.equal(fs.existsSync(path.join(programOutputDir, 'ai_prompt_documentation.md')), true);
+    assert.equal(fs.existsSync(path.join(programOutputDir, 'ai_prompt_architecture_review.md')), true);
     assert.equal(fs.existsSync(path.join(programOutputDir, 'ai_prompt_modernization.md')), true);
     assert.equal(fs.existsSync(path.join(programOutputDir, 'ai_prompt_error_analysis.md')), false);
 
@@ -75,7 +78,7 @@ test('guided analyze mode writes task index, selected mode metadata, and mode-sp
 
     const manifest = readJson(path.join(programOutputDir, 'analyze-run-manifest.json'));
     assert.equal(manifest.inputs.options.guidedMode.name, 'modernization');
-    assert.deepEqual(manifest.inputs.options.guidedMode.promptTemplates, ['documentation', 'modernization']);
+    assert.deepEqual(manifest.inputs.options.guidedMode.promptTemplates, ['documentation', 'architecture-review', 'modernization']);
     assert.equal(manifest.inputs.options.guidedMode.effectiveOptimizeContext, true);
     assert.match(manifest.inputs.options.guidedMode.reviewWorkflow.expectedDecisions.join('\n'), /pilot extraction candidate/i);
   } finally {

--- a/tests/v1-smoke.test.js
+++ b/tests/v1-smoke.test.js
@@ -154,11 +154,14 @@ test('V1 smoke flow generates analysis artifacts and bundle outputs', () => {
     assert.equal(analyzeManifest.tool.command, 'analyze');
     assert.equal(analyzeManifest.run.status, 'succeeded');
     assert.equal(analyzeManifest.inputs.program, 'ORDERPGM');
-    assert.equal(analyzeManifest.summary.stageCount, 6);
+    assert.equal(analyzeManifest.summary.stageCount, 8);
     assert.ok(analyzeManifest.summary.generatedArtifactCount >= 13);
     assert.equal(analyzeManifest.inputs.sourceSnapshot.fileCount, 2);
     assert.equal(analyzeManifest.inputs.options.guidedMode, null);
+    assert.equal(analyzeManifest.inputs.options.investigation.scanIfsPathsEnabled, false);
     assert.ok(analyzeManifest.stages.some((stage) => stage.id === 'collect-scan'));
+    assert.ok(analyzeManifest.stages.some((stage) => stage.id === 'investigate-sources'));
+    assert.ok(analyzeManifest.stages.some((stage) => stage.id === 'run-diagnostic-packs'));
     assert.ok(analyzeManifest.stages.some((stage) => stage.id === 'write-artifacts'));
     assert.ok(analyzeManifest.artifacts.some((artifact) => artifact.path === 'context.json'));
     assert.ok(analyzeManifest.artifacts.some((artifact) => artifact.path === 'analysis-index.json'));

--- a/tests/workflow-presets.test.js
+++ b/tests/workflow-presets.test.js
@@ -29,6 +29,8 @@ test('workflow --list-presets exposes named guided workflow bundles', () => {
   assert.match(output, /- modernization-review:/);
   assert.match(output, /- onboarding:/);
   assert.match(output, /- dependency-risk:/);
+  assert.match(output, /- refactoring-review:/);
+  assert.match(output, /- test-generation-review:/);
   assert.match(output, /intended audience:/);
   assert.match(output, /expected decisions:/);
 });
@@ -67,7 +69,7 @@ test('workflow preset runs analyze plus bundle and records preset metadata in ma
     assert.equal(analyzeManifest.inputs.options.workflowPreset.name, 'modernization-review');
     assert.deepEqual(
       analyzeManifest.inputs.options.workflowPreset.promptTemplates,
-      ['documentation', 'modernization'],
+      ['documentation', 'architecture-review', 'modernization'],
     );
     assert.match(
       analyzeManifest.inputs.options.workflowPreset.reviewWorkflow.expectedDecisions.join('\n'),
@@ -88,18 +90,21 @@ test('workflow preset runs analyze plus bundle and records preset metadata in ma
     assert.equal(bundleManifest.workflowPreset.analyzeMode, 'modernization');
     assert.match(bundleManifest.workflowPreset.reviewWorkflow.expectedDecisions.join('\n'), /pilot modernization target/i);
     assert.ok(bundleManifest.files.includes('ai_prompt_modernization.md'));
+    assert.ok(bundleManifest.files.includes('ai_prompt_architecture_review.md'));
     assert.ok(bundleManifest.files.includes('architecture-report.md'));
     assert.equal(bundleManifest.files.includes('context.json'), false);
     assert.equal(fs.existsSync(bundlePath), true);
 
     const zip = new AdmZip(bundlePath);
     const entryNames = zip.getEntries().map((entry) => entry.entryName).sort();
+    assert.ok(entryNames.includes('ai_prompt_architecture_review.md'));
     assert.ok(entryNames.includes('ai_prompt_modernization.md'));
     assert.ok(entryNames.includes('architecture-report.md'));
     assert.equal(entryNames.includes('context.json'), false);
     const readme = zip.readAsText('README.txt');
     assert.match(readme, /Workflow preset: modernization-review/);
     assert.match(readme, /Expected decisions:/);
+    assert.match(readme, /ai_prompt_architecture_review\.md:/);
     assert.match(readme, /ai_prompt_modernization\.md:/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add opt-in IFS path scanning, full-text search artifacts, and structured read-only diagnostic query packs to the analyze pipeline
- add specialized architecture, refactoring, and test-generation prompt packs with new guided modes and workflow presets
- document the new workflow contracts and expand automated coverage for manifests, prompts, and investigation outputs

## Validation
- npm test
- node cli/zeus.js
- node cli/zeus.js analyze --list-diagnostic-packs
- node cli/zeus.js workflow --list-presets

Closes #49
Closes #89
Closes #90
Closes #91