### PR TITLE
feat(db2): add IBM i catalog identity and external object enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,14 +577,18 @@ To add a new template:
 
 Exported metadata includes:
 
-- table name
+- SQL name and system name
 - schema or library
+- object type and descriptive text
+- estimated row count when catalog statistics are available
 - column names
 - column types
 - length, precision, and scale when JDBC metadata provides them
 - nullable flag
 - primary key flag
-- imported foreign keys when available
+- imported foreign keys, including delete and update rules when available
+- trigger metadata and derived-object relationships when IBM i catalog views are available
+- catalog-resolved external program, service-program, and module classifications for unresolved calls when available
 
 Generated files in `output/<program>/` when export succeeds:
 
@@ -594,6 +598,7 @@ Generated files in `output/<program>/` when export succeeds:
 `context.json` also includes a compact `db2Metadata` block with file references and exported table count.
 
 When DB2 metadata export succeeds, that compact summary also records source-linked table matches, unresolved or ambiguous catalog matches, and evidence counts that tie schema results back to SQL or native file usage.
+Program-call and procedure-call projections also carry `resolutionSource` metadata so downstream reports and prompts can distinguish source-resolved references from catalog-resolved external objects.
 
 Required configuration:
 

--- a/docs/ai-knowledge-projection.md
+++ b/docs/ai-knowledge-projection.md
@@ -27,10 +27,12 @@ Current `entities` blocks include:
 
 - `tables`
 - `programCalls`
+- `procedureCalls`
 - `copyMembers`
 - `sqlStatements`
 - `nativeFiles`
 - `db2Tables`
+- `externalObjects`
 - `ifsPaths`
 - `searchFindings`
 - `diagnosticPacks`
@@ -47,11 +49,23 @@ Each section is prompt-oriented and may carry:
 `db2Tables` is a prompt-facing projection of the compact `context.db2Metadata.tables` summary. It keeps DB2 catalog rows tied to source-backed evidence with:
 
 - `requestedName`
+- `displayName`
 - `schema`
 - `table`
+- `systemSchema`
+- `systemName`
 - `matchStatus`
+- `matchedBy`
+- `lookupStrategy`
+- `objectType`
+- `estimatedRowCount`
 - structural counts such as `columnCount` and `foreignKeyCount`
+- review counts such as `triggerCount` and `derivedObjectCount`
 - evidence-backed `evidenceRefs`
+
+`programCalls` and `procedureCalls` also carry `resolutionSource` plus catalog classification fields when Zeus resolved an external reference through IBM i object metadata rather than local source.
+
+`externalObjects` is the prompt-facing projection of catalog-resolved IBM i programs, service programs, modules, or related objects that were linked to unresolved source references.
 
 ## Workflow Sections
 

--- a/docs/canonical-analysis-model.md
+++ b/docs/canonical-analysis-model.md
@@ -25,8 +25,12 @@ Top-level fields:
 - `entities.programs`
   - includes the root program plus scanned/called program owners discovered by the analyzer
   - `role` is `ROOT`, `SCANNED`, or `CALLED`
+  - called-program entities may now also carry `resolutionSource` and catalog classification when an unresolved external call is resolved through IBM i object metadata
 - `entities.tables`
   - deduplicated table dependencies including SQL-only tables
+  - source-backed table entities may now also carry `db2Identity` with SQL/system names, object type, descriptive text, row estimates, lookup strategy, and match status
+- `entities.db2Triggers`
+  - trigger entities resolved from IBM i catalog metadata for source-linked tables
 - `entities.nativeFiles`
   - deduplicated native file declarations with file kind, declared access, and keyed hints
 - `entities.modules`
@@ -45,6 +49,8 @@ Top-level fields:
   - declared prototypes with import/export hints and external names when present
 - `entities.procedureReferences`
   - synthetic targets for dynamic and unresolved procedure calls
+- `entities.externalObjects`
+  - catalog-resolved IBM i programs, service programs, modules, or related external objects linked to unresolved source references
 
 ## Relation Types
 
@@ -64,6 +70,10 @@ Top-level fields:
 - `SQL_REFERENCES_TABLE`: SQL statement to referenced table
 - `CALLS_PROCEDURE`: procedure/program owner to a local procedure, prototype, or explicit unresolved/dynamic reference
 - `ACCESSES_NATIVE_FILE`: procedure/program owner to a native file access site with opcode, access kind, and record-format hints
+- `HAS_TRIGGER`: table to DB2 trigger metadata resolved from IBM i catalogs
+- `DERIVES_OBJECT`: base table to derived DB2 object such as a view or logical file
+- `REFERENCES_TABLE`: DB2 foreign-key relation with delete/update rules when available
+- `RESOLVES_TO_EXTERNAL_OBJECT`: unresolved program/prototype/procedure-reference target to a catalog-resolved IBM i object
 
 ## Evidence Schema
 
@@ -146,7 +156,7 @@ Top-level `provenance.importManifest` also summarizes the import contract when p
 - `db2Metadata`
 - `testData`
 
-`db2Metadata` and `testData` remain compatibility enrichments rather than first-class semantic entities. When present, they should preserve explicit linkage back to canonical source evidence, SQL references, and native file usage so downstream AI/report projections can stay evidence-backed without reparsing DB2 artifacts.
+`db2Metadata` and `testData` remain compatibility enrichments for sharing and backward-compatible projections, but DB2 catalog enrichment now also patches canonical table identity, trigger entities, foreign-key relations, derived-object relations, and external-object resolution metadata directly into the semantic graph. Compatibility summaries should still preserve explicit linkage back to canonical source evidence, SQL references, and native file usage so downstream AI/report projections can stay evidence-backed without reparsing DB2 artifacts.
 
 `ifsPaths`, `searchResults`, and `diagnosticPacks` are also compatibility enrichments. They extend investigation and prompt workflows without changing the canonical entity graph, and they should remain deterministic, evidence-backed, and safe to bundle or redact.
 
@@ -199,6 +209,6 @@ This split keeps the semantic model stable while allowing prompt/report/viewer o
 - `context.json` remains the stable backward-compatible projection used by existing reports and prompt templates
 - `ai-knowledge.json` is the versioned prompt-ready AI projection derived from the canonical model
 - `optimized-context.json` remains a token-budgeted compatibility projection, now driven by salience-ranked workflow evidence packs
-- DB2 metadata and test-data exports may extend compatibility projections with source-linked summaries, unresolved matches, and bounded evidence counts without changing the canonical entity graph
+- DB2 metadata and test-data exports may extend compatibility projections with source-linked summaries, unresolved matches, catalog-resolved external objects, and bounded evidence counts while the canonical entity graph carries the first-class DB2 relations
 - `canonical-analysis.json` is the new internal truth model for future typed analyzers and AI knowledge projection
 - if a future change requires breaking the canonical schema, `schemaVersion` must be incremented explicitly

--- a/java/Db2ExternalObjectResolver.java
+++ b/java/Db2ExternalObjectResolver.java
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+public class Db2ExternalObjectResolver {
+    private static class ExternalObjectInfo {
+        String requestedName;
+        String schema;
+        String library;
+        String sqlName;
+        String systemName;
+        String objectType;
+        String sqlObjectType;
+        String textDescription;
+        String evidenceSource;
+        String matchedBy;
+    }
+
+    private static String escape(String value) {
+        if (value == null) return "";
+        return value
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r");
+    }
+
+    private static String normalizeIdentifier(String value) {
+        return value == null ? "" : value.trim().toUpperCase();
+    }
+
+    private static List<String> parseNames(String csv) {
+        List<String> names = new ArrayList<>();
+        if (csv == null || csv.trim().isEmpty()) {
+            return names;
+        }
+        String[] parts = csv.split(",");
+        for (String part : parts) {
+            String trimmed = part.trim();
+            if (!trimmed.isEmpty()) {
+                names.add(trimmed);
+            }
+        }
+        return names;
+    }
+
+    private static String encodeValue(String value) {
+        return value == null ? "null" : "\"" + escape(value) + "\"";
+    }
+
+    private static List<ExternalObjectInfo> resolveExternalObjects(Connection connection, String requestedName) throws SQLException {
+        List<ExternalObjectInfo> objects = new ArrayList<>();
+        String normalizedRequested = normalizeIdentifier(requestedName);
+        String sql = ""
+            + "SELECT OBJLONGSCHEMA, OBJLONGNAME, OBJLIB, OBJNAME, OBJTYPE, SQL_OBJECT_TYPE, OBJTEXT "
+            + "FROM TABLE(QSYS2.OBJECT_STATISTICS(OBJECT_SCHEMA => '*ALLUSR', OBJTYPELIST => 'PGM,SRVPGM,MODULE', OBJECT_NAME => ?)) "
+            + "WHERE UPPER(OBJNAME) = ? OR UPPER(COALESCE(OBJLONGNAME, OBJNAME)) = ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, requestedName);
+            statement.setString(2, normalizedRequested);
+            statement.setString(3, normalizedRequested);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    ExternalObjectInfo object = new ExternalObjectInfo();
+                    object.requestedName = normalizedRequested;
+                    object.schema = normalizeIdentifier(rs.getString("OBJLONGSCHEMA"));
+                    object.library = normalizeIdentifier(rs.getString("OBJLIB"));
+                    object.sqlName = normalizeIdentifier(rs.getString("OBJLONGNAME"));
+                    object.systemName = normalizeIdentifier(rs.getString("OBJNAME"));
+                    object.objectType = normalizeIdentifier(rs.getString("OBJTYPE"));
+                    object.sqlObjectType = normalizeIdentifier(rs.getString("SQL_OBJECT_TYPE"));
+                    object.textDescription = rs.getString("OBJTEXT");
+                    object.evidenceSource = "OBJECT_STATISTICS";
+                    object.matchedBy = normalizedRequested.equals(object.systemName) ? "SYSTEM_NAME" : "SQL_NAME";
+                    objects.add(object);
+                }
+            }
+        }
+
+        Collections.sort(objects, Comparator
+            .comparing((ExternalObjectInfo object) -> object.requestedName)
+            .thenComparing(object -> object.library)
+            .thenComparing(object -> object.systemName));
+        return objects;
+    }
+
+    private static void appendObjectJson(StringBuilder json, ExternalObjectInfo object) {
+        json.append("{")
+            .append("\"requestedName\":").append(encodeValue(object.requestedName)).append(",")
+            .append("\"schema\":").append(encodeValue(object.schema)).append(",")
+            .append("\"library\":").append(encodeValue(object.library)).append(",")
+            .append("\"sqlName\":").append(encodeValue(object.sqlName)).append(",")
+            .append("\"systemName\":").append(encodeValue(object.systemName)).append(",")
+            .append("\"objectType\":").append(encodeValue(object.objectType)).append(",")
+            .append("\"sqlObjectType\":").append(encodeValue(object.sqlObjectType)).append(",")
+            .append("\"textDescription\":").append(encodeValue(object.textDescription)).append(",")
+            .append("\"evidenceSource\":").append(encodeValue(object.evidenceSource)).append(",")
+            .append("\"matchedBy\":").append(encodeValue(object.matchedBy))
+            .append("}");
+    }
+
+    public static void main(String[] args) {
+        if (args.length < 4) {
+            System.err.println("Usage: java Db2ExternalObjectResolver <jdbcUrl> <user> <password> <name1,name2,...>");
+            System.exit(1);
+        }
+
+        String jdbcUrl = args[0];
+        String user = args[1];
+        String password = args[2];
+        List<String> requestedNames = parseNames(args[3]);
+
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, user, password)) {
+            List<ExternalObjectInfo> resolvedObjects = new ArrayList<>();
+            for (String requestedName : requestedNames) {
+                resolvedObjects.addAll(resolveExternalObjects(connection, requestedName));
+            }
+
+            StringBuilder json = new StringBuilder();
+            json.append("{\"objects\":[");
+            for (int i = 0; i < resolvedObjects.size(); i += 1) {
+                if (i > 0) {
+                    json.append(",");
+                }
+                appendObjectJson(json, resolvedObjects.get(i));
+            }
+            json.append("]}");
+            System.out.println(json.toString());
+        } catch (SQLException e) {
+            System.err.println("DB2 external object resolution failed: " + e.getMessage());
+            System.exit(2);
+        }
+    }
+}

--- a/java/Db2MetadataExporter.java
+++ b/java/Db2MetadataExporter.java
@@ -14,13 +14,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,13 +46,45 @@ public class Db2MetadataExporter {
         String referencesSchema;
         String referencesTable;
         String referencesColumn;
+        String constraintName;
+        String updateRule;
+        String deleteRule;
+    }
+
+    private static class TriggerInfo {
+        String schema;
+        String name;
+        String systemSchema;
+        String systemName;
+        String eventManipulation;
+        String actionTiming;
+        String actionOrientation;
+        String programName;
+        String programLibrary;
+    }
+
+    private static class DerivedObjectInfo {
+        String schema;
+        String name;
+        String systemSchema;
+        String systemName;
+        String objectType;
+        String textDescription;
     }
 
     private static class TableInfo {
         String schema;
         String table;
+        String systemSchema;
+        String systemName;
+        String objectType;
+        String textDescription;
+        Long estimatedRowCount;
+        String lookupStrategy;
         List<ColumnInfo> columns = new ArrayList<>();
         List<ForeignKeyInfo> foreignKeys = new ArrayList<>();
+        List<TriggerInfo> triggers = new ArrayList<>();
+        List<DerivedObjectInfo> derivedObjects = new ArrayList<>();
     }
 
     private static String escape(String value) {
@@ -82,6 +118,84 @@ public class Db2MetadataExporter {
             }
         }
         return tables;
+    }
+
+    private static String encodeValue(String value) {
+        return value == null ? "null" : "\"" + escape(value) + "\"";
+    }
+
+    private static String encodeNumber(Integer value) {
+        return value == null ? "null" : String.valueOf(value);
+    }
+
+    private static String encodeLong(Long value) {
+        return value == null ? "null" : String.valueOf(value);
+    }
+
+    private static boolean hasColumn(ResultSetMetaData metaData, String columnName) throws SQLException {
+        int columnCount = metaData.getColumnCount();
+        String normalized = normalizeIdentifier(columnName);
+        for (int index = 1; index <= columnCount; index += 1) {
+            if (normalizeIdentifier(metaData.getColumnLabel(index)).equals(normalized)
+                || normalizeIdentifier(metaData.getColumnName(index)).equals(normalized)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String getString(ResultSet rs, String columnName) throws SQLException {
+        ResultSetMetaData metaData = rs.getMetaData();
+        if (!hasColumn(metaData, columnName)) {
+            return null;
+        }
+        return rs.getString(columnName);
+    }
+
+    private static Long getLong(ResultSet rs, String columnName) throws SQLException {
+        ResultSetMetaData metaData = rs.getMetaData();
+        if (!hasColumn(metaData, columnName)) {
+            return null;
+        }
+        long value = rs.getLong(columnName);
+        return rs.wasNull() ? null : Long.valueOf(value);
+    }
+
+    private static String mapImportedRule(short value) {
+        switch (value) {
+            case DatabaseMetaData.importedKeyCascade:
+                return "CASCADE";
+            case DatabaseMetaData.importedKeyRestrict:
+                return "RESTRICT";
+            case DatabaseMetaData.importedKeySetNull:
+                return "SET NULL";
+            case DatabaseMetaData.importedKeySetDefault:
+                return "SET DEFAULT";
+            case DatabaseMetaData.importedKeyNoAction:
+                return "NO ACTION";
+            default:
+                return null;
+        }
+    }
+
+    private static String inferObjectType(String sqlObjectType, String attribute, String jdbcType) {
+        String normalizedSqlType = normalizeIdentifier(sqlObjectType);
+        String normalizedAttribute = normalizeIdentifier(attribute);
+        String normalizedJdbcType = normalizeIdentifier(jdbcType);
+
+        if ("LF".equals(normalizedAttribute)) {
+            return "LOGICAL_FILE";
+        }
+        if ("PF".equals(normalizedAttribute) && normalizedSqlType.isEmpty()) {
+            return "TABLE";
+        }
+        if (!normalizedSqlType.isEmpty()) {
+            return normalizedSqlType;
+        }
+        if (!normalizedJdbcType.isEmpty()) {
+            return normalizedJdbcType;
+        }
+        return "TABLE";
     }
 
     private static Set<String> loadPrimaryKeys(DatabaseMetaData metaData, String schema, String table) throws SQLException {
@@ -129,6 +243,9 @@ public class Db2MetadataExporter {
                 foreignKey.referencesSchema = normalizeIdentifier(rs.getString("PKTABLE_SCHEM"));
                 foreignKey.referencesTable = normalizeIdentifier(rs.getString("PKTABLE_NAME"));
                 foreignKey.referencesColumn = normalizeIdentifier(rs.getString("PKCOLUMN_NAME"));
+                foreignKey.constraintName = normalizeIdentifier(rs.getString("FK_NAME"));
+                foreignKey.updateRule = mapImportedRule(rs.getShort("UPDATE_RULE"));
+                foreignKey.deleteRule = mapImportedRule(rs.getShort("DELETE_RULE"));
 
                 String key = foreignKey.column + "|" + foreignKey.referencesSchema + "|" + foreignKey.referencesTable + "|" + foreignKey.referencesColumn;
                 if (!byKey.containsKey(key)) {
@@ -146,22 +263,185 @@ public class Db2MetadataExporter {
         return foreignKeys;
     }
 
-    private static TableInfo loadTableInfo(DatabaseMetaData metaData, String schema, String table) throws SQLException {
-        TableInfo tableInfo = new TableInfo();
-        tableInfo.schema = normalizeIdentifier(schema);
-        tableInfo.table = normalizeIdentifier(table);
-        Set<String> primaryKeys = loadPrimaryKeys(metaData, schema, table);
-        tableInfo.columns = loadColumns(metaData, schema, table, primaryKeys);
-        tableInfo.foreignKeys = loadForeignKeys(metaData, schema, table);
+    private static Long loadEstimatedRowCount(Connection connection, TableInfo tableInfo) {
+        String sql = "SELECT SUM(NUMBER_ROWS) AS ESTIMATED_ROW_COUNT FROM QSYS2.SYSPARTITIONSTAT WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, tableInfo.schema);
+            statement.setString(2, tableInfo.table);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return getLong(rs, "ESTIMATED_ROW_COUNT");
+                }
+            }
+        } catch (SQLException ignored) {
+            return null;
+        }
+        return null;
+    }
+
+    private static List<TriggerInfo> loadTriggers(Connection connection, TableInfo tableInfo) {
+        List<TriggerInfo> triggers = new ArrayList<>();
+        String sql = ""
+            + "SELECT TRIGGER_SCHEMA, TRIGGER_NAME, EVENT_MANIPULATION, ACTION_TIMING, ACTION_ORIENTATION "
+            + "FROM QSYS2.SYSTRIGGERS "
+            + "WHERE EVENT_OBJECT_SCHEMA = ? AND EVENT_OBJECT_TABLE = ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, tableInfo.schema);
+            statement.setString(2, tableInfo.table);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    TriggerInfo trigger = new TriggerInfo();
+                    trigger.schema = normalizeIdentifier(getString(rs, "TRIGGER_SCHEMA"));
+                    trigger.name = normalizeIdentifier(getString(rs, "TRIGGER_NAME"));
+                    trigger.eventManipulation = normalizeIdentifier(getString(rs, "EVENT_MANIPULATION"));
+                    trigger.actionTiming = normalizeIdentifier(getString(rs, "ACTION_TIMING"));
+                    trigger.actionOrientation = normalizeIdentifier(getString(rs, "ACTION_ORIENTATION"));
+                    triggers.add(trigger);
+                }
+            }
+        } catch (SQLException ignored) {
+            return triggers;
+        }
+
+        Collections.sort(triggers, Comparator
+            .comparing((TriggerInfo trigger) -> trigger.schema)
+            .thenComparing(trigger -> trigger.name));
+        return triggers;
+    }
+
+    private static List<DerivedObjectInfo> loadDerivedObjects(Connection connection, TableInfo tableInfo) {
+        List<DerivedObjectInfo> derivedObjects = new ArrayList<>();
+        String sql = ""
+            + "SELECT VIEW_SCHEMA, VIEW_NAME, SYSTEM_VIEW_SCHEMA, SYSTEM_VIEW_NAME, TABLE_TYPE "
+            + "FROM QSYS2.SYSVIEWDEP "
+            + "WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, tableInfo.schema);
+            statement.setString(2, tableInfo.table);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    DerivedObjectInfo derivedObject = new DerivedObjectInfo();
+                    derivedObject.schema = normalizeIdentifier(getString(rs, "VIEW_SCHEMA"));
+                    derivedObject.name = normalizeIdentifier(getString(rs, "VIEW_NAME"));
+                    derivedObject.systemSchema = normalizeIdentifier(getString(rs, "SYSTEM_VIEW_SCHEMA"));
+                    derivedObject.systemName = normalizeIdentifier(getString(rs, "SYSTEM_VIEW_NAME"));
+                    derivedObject.objectType = inferObjectType(getString(rs, "OBJECT_TYPE"), getString(rs, "TABLE_TYPE"), "VIEW");
+                    derivedObjects.add(derivedObject);
+                }
+            }
+        } catch (SQLException ignored) {
+            return derivedObjects;
+        }
+
+        Collections.sort(derivedObjects, Comparator
+            .comparing((DerivedObjectInfo derivedObject) -> derivedObject.schema)
+            .thenComparing(derivedObject -> derivedObject.name));
+        return derivedObjects;
+    }
+
+    private static TableInfo copyTableInfo(TableInfo source) {
+        TableInfo target = new TableInfo();
+        target.schema = source.schema;
+        target.table = source.table;
+        target.systemSchema = source.systemSchema;
+        target.systemName = source.systemName;
+        target.objectType = source.objectType;
+        target.textDescription = source.textDescription;
+        target.lookupStrategy = source.lookupStrategy;
+        return target;
+    }
+
+    private static List<TableInfo> findTablesViaCatalog(Connection connection, String requestedTable, String defaultSchema) {
+        List<TableInfo> matches = new ArrayList<>();
+        String normalizedRequested = normalizeIdentifier(requestedTable);
+        String[] schemaCandidates = defaultSchema == null || defaultSchema.isEmpty()
+            ? new String[]{"*ALLUSR"}
+            : new String[]{defaultSchema, "*ALLUSR"};
+
+        String sql = ""
+            + "SELECT OBJLONGSCHEMA, OBJLONGNAME, OBJLIB, OBJNAME, SQL_OBJECT_TYPE, OBJATTRIBUTE, OBJTEXT "
+            + "FROM TABLE(QSYS2.OBJECT_STATISTICS(OBJECT_SCHEMA => ?, OBJTYPELIST => '*FILE', OBJECT_NAME => ?)) "
+            + "WHERE UPPER(COALESCE(OBJLONGNAME, OBJNAME)) = ? OR UPPER(OBJNAME) = ?";
+
+        for (String schemaCandidate : schemaCandidates) {
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                statement.setString(1, schemaCandidate);
+                statement.setString(2, requestedTable);
+                statement.setString(3, normalizedRequested);
+                statement.setString(4, normalizedRequested);
+                try (ResultSet rs = statement.executeQuery()) {
+                    while (rs.next()) {
+                        TableInfo tableInfo = new TableInfo();
+                        tableInfo.schema = normalizeIdentifier(getString(rs, "OBJLONGSCHEMA"));
+                        tableInfo.table = normalizeIdentifier(getString(rs, "OBJLONGNAME"));
+                        tableInfo.systemSchema = normalizeIdentifier(getString(rs, "OBJLIB"));
+                        tableInfo.systemName = normalizeIdentifier(getString(rs, "OBJNAME"));
+                        tableInfo.objectType = inferObjectType(getString(rs, "SQL_OBJECT_TYPE"), getString(rs, "OBJATTRIBUTE"), "");
+                        tableInfo.textDescription = getString(rs, "OBJTEXT");
+                        tableInfo.lookupStrategy = "IBM_I_CATALOG";
+                        if (tableInfo.table.isEmpty()) {
+                            tableInfo.table = tableInfo.systemName;
+                        }
+                        if (tableInfo.schema.isEmpty()) {
+                            tableInfo.schema = tableInfo.systemSchema;
+                        }
+                        matches.add(tableInfo);
+                    }
+                }
+            } catch (SQLException ignored) {
+                return new ArrayList<>();
+            }
+
+            if (!matches.isEmpty()) {
+                return matches;
+            }
+        }
+
+        return matches;
+    }
+
+    private static List<TableInfo> findTablesViaJdbc(DatabaseMetaData metaData, String requestedTable, String defaultSchema) throws SQLException {
+        List<TableInfo> matches = new ArrayList<>();
+        String schemaPattern = defaultSchema;
+        String normalizedTable = normalizeIdentifier(requestedTable);
+
+        if (requestedTable.contains(".")) {
+            String[] parts = requestedTable.split("\\.", 2);
+            schemaPattern = normalizeSchemaArg(parts[0]);
+            normalizedTable = normalizeIdentifier(parts[1]);
+        } else if (requestedTable.contains("/")) {
+            String[] parts = requestedTable.split("/", 2);
+            schemaPattern = normalizeSchemaArg(parts[0]);
+            normalizedTable = normalizeIdentifier(parts[1]);
+        }
+
+        try (ResultSet rs = metaData.getTables(null, schemaPattern, normalizedTable, new String[]{"TABLE", "VIEW", "ALIAS"})) {
+            while (rs.next()) {
+                TableInfo tableInfo = new TableInfo();
+                tableInfo.schema = normalizeIdentifier(rs.getString("TABLE_SCHEM"));
+                tableInfo.table = normalizeIdentifier(rs.getString("TABLE_NAME"));
+                tableInfo.systemSchema = tableInfo.schema;
+                tableInfo.systemName = tableInfo.table;
+                tableInfo.objectType = inferObjectType(null, null, rs.getString("TABLE_TYPE"));
+                tableInfo.lookupStrategy = "JDBC_METADATA";
+                matches.add(tableInfo);
+            }
+        }
+
+        return matches;
+    }
+
+    private static TableInfo enrichTableInfo(Connection connection, DatabaseMetaData metaData, TableInfo seed) throws SQLException {
+        TableInfo tableInfo = copyTableInfo(seed);
+        Set<String> primaryKeys = loadPrimaryKeys(metaData, tableInfo.schema, tableInfo.table);
+        tableInfo.columns = loadColumns(metaData, tableInfo.schema, tableInfo.table, primaryKeys);
+        tableInfo.foreignKeys = loadForeignKeys(metaData, tableInfo.schema, tableInfo.table);
+        tableInfo.estimatedRowCount = loadEstimatedRowCount(connection, tableInfo);
+        tableInfo.triggers = loadTriggers(connection, tableInfo);
+        tableInfo.derivedObjects = loadDerivedObjects(connection, tableInfo);
         return tableInfo;
-    }
-
-    private static String encodeValue(String value) {
-        return value == null ? "null" : "\"" + escape(value) + "\"";
-    }
-
-    private static String encodeNumber(Integer value) {
-        return value == null ? "null" : String.valueOf(value);
     }
 
     private static void appendColumnJson(StringBuilder json, ColumnInfo column) {
@@ -181,7 +461,35 @@ public class Db2MetadataExporter {
             .append("\"column\":").append(encodeValue(foreignKey.column)).append(",")
             .append("\"referencesSchema\":").append(encodeValue(foreignKey.referencesSchema)).append(",")
             .append("\"referencesTable\":").append(encodeValue(foreignKey.referencesTable)).append(",")
-            .append("\"referencesColumn\":").append(encodeValue(foreignKey.referencesColumn))
+            .append("\"referencesColumn\":").append(encodeValue(foreignKey.referencesColumn)).append(",")
+            .append("\"constraintName\":").append(encodeValue(foreignKey.constraintName)).append(",")
+            .append("\"updateRule\":").append(encodeValue(foreignKey.updateRule)).append(",")
+            .append("\"deleteRule\":").append(encodeValue(foreignKey.deleteRule))
+            .append("}");
+    }
+
+    private static void appendTriggerJson(StringBuilder json, TriggerInfo trigger) {
+        json.append("{")
+            .append("\"schema\":").append(encodeValue(trigger.schema)).append(",")
+            .append("\"name\":").append(encodeValue(trigger.name)).append(",")
+            .append("\"systemSchema\":").append(encodeValue(trigger.systemSchema)).append(",")
+            .append("\"systemName\":").append(encodeValue(trigger.systemName)).append(",")
+            .append("\"eventManipulation\":").append(encodeValue(trigger.eventManipulation)).append(",")
+            .append("\"actionTiming\":").append(encodeValue(trigger.actionTiming)).append(",")
+            .append("\"actionOrientation\":").append(encodeValue(trigger.actionOrientation)).append(",")
+            .append("\"programName\":").append(encodeValue(trigger.programName)).append(",")
+            .append("\"programLibrary\":").append(encodeValue(trigger.programLibrary))
+            .append("}");
+    }
+
+    private static void appendDerivedObjectJson(StringBuilder json, DerivedObjectInfo derivedObject) {
+        json.append("{")
+            .append("\"schema\":").append(encodeValue(derivedObject.schema)).append(",")
+            .append("\"name\":").append(encodeValue(derivedObject.name)).append(",")
+            .append("\"systemSchema\":").append(encodeValue(derivedObject.systemSchema)).append(",")
+            .append("\"systemName\":").append(encodeValue(derivedObject.systemName)).append(",")
+            .append("\"objectType\":").append(encodeValue(derivedObject.objectType)).append(",")
+            .append("\"textDescription\":").append(encodeValue(derivedObject.textDescription))
             .append("}");
     }
 
@@ -189,6 +497,12 @@ public class Db2MetadataExporter {
         json.append("{")
             .append("\"schema\":").append(encodeValue(table.schema)).append(",")
             .append("\"table\":").append(encodeValue(table.table)).append(",")
+            .append("\"systemSchema\":").append(encodeValue(table.systemSchema)).append(",")
+            .append("\"systemName\":").append(encodeValue(table.systemName)).append(",")
+            .append("\"objectType\":").append(encodeValue(table.objectType)).append(",")
+            .append("\"textDescription\":").append(encodeValue(table.textDescription)).append(",")
+            .append("\"estimatedRowCount\":").append(encodeLong(table.estimatedRowCount)).append(",")
+            .append("\"lookupStrategy\":").append(encodeValue(table.lookupStrategy)).append(",")
             .append("\"columns\":[");
 
         for (int i = 0; i < table.columns.size(); i += 1) {
@@ -204,6 +518,22 @@ public class Db2MetadataExporter {
                 json.append(",");
             }
             appendForeignKeyJson(json, table.foreignKeys.get(i));
+        }
+
+        json.append("],\"triggers\":[");
+        for (int i = 0; i < table.triggers.size(); i += 1) {
+            if (i > 0) {
+                json.append(",");
+            }
+            appendTriggerJson(json, table.triggers.get(i));
+        }
+
+        json.append("],\"derivedObjects\":[");
+        for (int i = 0; i < table.derivedObjects.size(); i += 1) {
+            if (i > 0) {
+                json.append(",");
+            }
+            appendDerivedObjectJson(json, table.derivedObjects.get(i));
         }
         json.append("]}");
     }
@@ -225,45 +555,27 @@ public class Db2MetadataExporter {
             List<TableInfo> tableInfos = new ArrayList<>();
 
             if (requestedTables.isEmpty()) {
-                try (ResultSet rs = metaData.getTables(null, defaultSchema, "%", new String[]{"TABLE"})) {
-                    while (rs.next()) {
-                        tableInfos.add(loadTableInfo(
-                            metaData,
-                            normalizeSchemaArg(rs.getString("TABLE_SCHEM")),
-                            normalizeIdentifier(rs.getString("TABLE_NAME"))
-                        ));
-                    }
+                List<TableInfo> jdbcTables = findTablesViaJdbc(metaData, "%", defaultSchema);
+                for (TableInfo seed : jdbcTables) {
+                    tableInfos.add(enrichTableInfo(connection, metaData, seed));
                 }
             } else {
                 for (String requestedTable : requestedTables) {
-                    String schemaPattern = defaultSchema;
-                    String normalizedTable = normalizeIdentifier(requestedTable);
-
-                    if (requestedTable.contains(".")) {
-                        String[] parts = requestedTable.split("\\.", 2);
-                        schemaPattern = normalizeSchemaArg(parts[0]);
-                        normalizedTable = normalizeIdentifier(parts[1]);
-                    } else if (requestedTable.contains("/")) {
-                        String[] parts = requestedTable.split("/", 2);
-                        schemaPattern = normalizeSchemaArg(parts[0]);
-                        normalizedTable = normalizeIdentifier(parts[1]);
+                    List<TableInfo> seeds = findTablesViaCatalog(connection, requestedTable, defaultSchema);
+                    if (seeds.isEmpty()) {
+                        seeds = findTablesViaJdbc(metaData, requestedTable, defaultSchema);
                     }
 
-                    try (ResultSet rs = metaData.getTables(null, schemaPattern, normalizedTable, new String[]{"TABLE"})) {
-                        while (rs.next()) {
-                            tableInfos.add(loadTableInfo(
-                                metaData,
-                                normalizeSchemaArg(rs.getString("TABLE_SCHEM")),
-                                normalizeIdentifier(rs.getString("TABLE_NAME"))
-                            ));
-                        }
+                    for (TableInfo seed : seeds) {
+                        tableInfos.add(enrichTableInfo(connection, metaData, seed));
                     }
                 }
             }
 
             Collections.sort(tableInfos, Comparator
-                .comparing((TableInfo table) -> table.schema)
-                .thenComparing(table -> table.table));
+                .comparing((TableInfo table) -> table.table)
+                .thenComparing(table -> table.schema)
+                .thenComparing(table -> table.systemName));
 
             StringBuilder json = new StringBuilder();
             json.append("{\"tables\":[");

--- a/src/ai/knowledgeProjection.js
+++ b/src/ai/knowledgeProjection.js
@@ -188,25 +188,43 @@ function projectCopyMembers(context) {
 }
 
 function projectProgramCallRelations(canonicalAnalysis, evidenceIndex) {
+  const programEntitiesByName = new Map(asArray(canonicalAnalysis && canonicalAnalysis.entities && canonicalAnalysis.entities.programs)
+    .map((entry) => [entry.name, entry]));
   return asArray(canonicalAnalysis && canonicalAnalysis.relations)
     .filter((relation) => relation.type === 'CALLS_PROGRAM')
     .map((relation) => ({
       name: String(relation.to || '').replace(/^PROGRAM:/, ''),
       kind: relation.attributes && relation.attributes.callKind ? relation.attributes.callKind : 'PROGRAM',
+      resolutionSource: (programEntitiesByName.get(String(relation.to || '').replace(/^PROGRAM:/, '')) || {}).resolutionSource || 'UNRESOLVED',
+      catalogObjectType: (programEntitiesByName.get(String(relation.to || '').replace(/^PROGRAM:/, '')) || {}).catalogObjectType || null,
+      catalogLibrary: (programEntitiesByName.get(String(relation.to || '').replace(/^PROGRAM:/, '')) || {}).catalogLibrary || null,
+      catalogSchema: (programEntitiesByName.get(String(relation.to || '').replace(/^PROGRAM:/, '')) || {}).catalogSchema || null,
       evidenceRefs: evidenceRefsFor(evidenceIndex, relation.evidence),
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function projectProcedureCalls(canonicalAnalysis, evidenceIndex) {
+  const targetEntities = new Map([
+    ...asArray(canonicalAnalysis && canonicalAnalysis.entities && canonicalAnalysis.entities.prototypes).map((entry) => [entry.id, entry]),
+    ...asArray(canonicalAnalysis && canonicalAnalysis.entities && canonicalAnalysis.entities.procedureReferences).map((entry) => [entry.id, entry]),
+    ...asArray(canonicalAnalysis && canonicalAnalysis.entities && canonicalAnalysis.entities.procedures).map((entry) => [entry.id, entry]),
+  ]);
   return asArray(canonicalAnalysis && canonicalAnalysis.relations)
     .filter((relation) => relation.type === 'CALLS_PROCEDURE')
-    .map((relation) => ({
-      target: relation.attributes && relation.attributes.targetName ? relation.attributes.targetName : String(relation.to || ''),
-      resolution: relation.attributes && relation.attributes.resolution ? relation.attributes.resolution : 'UNKNOWN',
-      targetKind: relation.attributes && relation.attributes.targetKind ? relation.attributes.targetKind : 'UNKNOWN',
-      evidenceRefs: evidenceRefsFor(evidenceIndex, relation.evidence),
-    }))
+    .map((relation) => {
+      const targetEntity = targetEntities.get(String(relation.to || ''));
+      return {
+        target: relation.attributes && relation.attributes.targetName ? relation.attributes.targetName : String(relation.to || ''),
+        resolution: relation.attributes && relation.attributes.resolution ? relation.attributes.resolution : 'UNKNOWN',
+        targetKind: relation.attributes && relation.attributes.targetKind ? relation.attributes.targetKind : 'UNKNOWN',
+        resolutionSource: targetEntity && targetEntity.resolutionSource ? targetEntity.resolutionSource : 'SOURCE',
+        catalogObjectType: targetEntity && targetEntity.catalogObjectType ? targetEntity.catalogObjectType : null,
+        catalogLibrary: targetEntity && targetEntity.catalogLibrary ? targetEntity.catalogLibrary : null,
+        catalogSchema: targetEntity && targetEntity.catalogSchema ? targetEntity.catalogSchema : null,
+        evidenceRefs: evidenceRefsFor(evidenceIndex, relation.evidence),
+      };
+    })
     .sort((a, b) => {
       if (a.resolution !== b.resolution) return a.resolution.localeCompare(b.resolution);
       return a.target.localeCompare(b.target);
@@ -277,11 +295,21 @@ function projectDb2Tables(context, evidenceIndex) {
   return asArray(context && context.db2Metadata && context.db2Metadata.tables)
     .map((entry) => ({
       requestedName: entry.requestedName,
+      displayName: entry.displayName || entry.table || entry.systemName,
       schema: entry.schema,
       table: entry.table,
+      systemSchema: entry.systemSchema || null,
+      systemName: entry.systemName || null,
       matchStatus: entry.matchStatus || 'resolved',
+      matchedBy: entry.matchedBy || null,
+      lookupStrategy: entry.lookupStrategy || null,
+      objectType: entry.objectType || 'TABLE',
+      textDescription: entry.textDescription || null,
+      estimatedRowCount: Number.isFinite(Number(entry.estimatedRowCount)) ? Number(entry.estimatedRowCount) : null,
       columnCount: Number(entry.columnCount) || 0,
       foreignKeyCount: Number(entry.foreignKeyCount) || 0,
+      triggerCount: Number(entry.triggerCount) || 0,
+      derivedObjectCount: Number(entry.derivedObjectCount) || 0,
       sourceEvidenceCount: Number(entry.sourceEvidenceCount) || 0,
       sqlReferenceCount: Number(entry.sqlReferenceCount) || 0,
       nativeFileCount: Number(entry.nativeFileCount) || 0,
@@ -290,6 +318,27 @@ function projectDb2Tables(context, evidenceIndex) {
     .sort((a, b) => {
       if (a.table !== b.table) return a.table.localeCompare(b.table);
       return a.schema.localeCompare(b.schema);
+    });
+}
+
+function projectExternalObjects(canonicalAnalysis) {
+  return asArray(canonicalAnalysis && canonicalAnalysis.entities && canonicalAnalysis.entities.externalObjects)
+    .map((entry) => ({
+      name: entry.name,
+      requestedName: entry.requestedName || entry.name,
+      schema: entry.schema || null,
+      library: entry.library || null,
+      sqlName: entry.sqlName || null,
+      systemName: entry.systemName || null,
+      objectType: entry.objectType || 'OBJECT',
+      sqlObjectType: entry.sqlObjectType || null,
+      textDescription: entry.textDescription || null,
+      evidenceSource: entry.evidenceSource || 'OBJECT_STATISTICS',
+      matchedBy: entry.matchedBy || null,
+    }))
+    .sort((a, b) => {
+      if (a.requestedName !== b.requestedName) return a.requestedName.localeCompare(b.requestedName);
+      return a.name.localeCompare(b.name);
     });
 }
 
@@ -379,10 +428,12 @@ function buildWorkflow(name, context, projection, payload = {}) {
     summary: context && context.summary ? context.summary.text : '',
     tables: cloneEntityList(payload.tables && payload.tables.length > 0 ? payload.tables : projection.entities.tables),
     programCalls: cloneEntityList(payload.programCalls && payload.programCalls.length > 0 ? payload.programCalls : projection.entities.programCalls),
+    procedureCalls: cloneEntityList(payload.procedureCalls && payload.procedureCalls.length > 0 ? payload.procedureCalls : projection.entities.procedureCalls),
     copyMembers: cloneEntityList(payload.copyMembers && payload.copyMembers.length > 0 ? payload.copyMembers : projection.entities.copyMembers),
     sqlStatements: cloneEntityList(payload.sqlStatements),
     nativeFiles: cloneEntityList(payload.nativeFiles && payload.nativeFiles.length > 0 ? payload.nativeFiles : projection.entities.nativeFiles),
     db2Tables: cloneEntityList(payload.db2Tables && payload.db2Tables.length > 0 ? payload.db2Tables : projection.entities.db2Tables),
+    externalObjects: cloneEntityList(payload.externalObjects && payload.externalObjects.length > 0 ? payload.externalObjects : projection.entities.externalObjects),
     ifsPaths: cloneEntityList(payload.ifsPaths && payload.ifsPaths.length > 0 ? payload.ifsPaths : projection.entities.ifsPaths),
     searchFindings: cloneEntityList(payload.searchFindings && payload.searchFindings.length > 0 ? payload.searchFindings : projection.entities.searchFindings),
     diagnosticPacks: cloneEntityList(payload.diagnosticPacks && payload.diagnosticPacks.length > 0 ? payload.diagnosticPacks : projection.entities.diagnosticPacks),
@@ -561,6 +612,7 @@ function buildAiKnowledgeProjection({ canonicalAnalysis, context, optimizedConte
       sqlStatements,
       nativeFiles: projectNativeFiles(context, canonicalAnalysis, evidenceIndex),
       db2Tables: projectDb2Tables(context, evidenceIndex),
+      externalObjects: projectExternalObjects(canonicalAnalysis),
       ifsPaths: projectIfsPaths(context, evidenceIndex),
       searchFindings: projectSearchFindings(context),
       diagnosticPacks: projectDiagnosticPacks(context),

--- a/src/analyze/analyzePipeline.js
+++ b/src/analyze/analyzePipeline.js
@@ -442,6 +442,8 @@ function exportDb2Stage(state) {
   });
 
   const nextCanonicalAnalysis = enrichCanonicalAnalysisModel(canonicalAnalysis, {
+    entities: db2Export.canonicalUpdates && db2Export.canonicalUpdates.entities ? db2Export.canonicalUpdates.entities : undefined,
+    relations: db2Export.canonicalUpdates && db2Export.canonicalUpdates.relations ? db2Export.canonicalUpdates.relations : undefined,
     db2Metadata: db2Export.summary,
     notes: db2Export.notes || [],
   });

--- a/src/context/canonicalAnalysisModel.js
+++ b/src/context/canonicalAnalysisModel.js
@@ -908,6 +908,9 @@ function buildProgramEntities(rootProgram, sourceFiles, programCalls, procedures
     role: programName === normalizeName(rootProgram)
       ? 'ROOT'
       : sourcePrograms.has(programName) || ownerPrograms.has(programName) ? 'SCANNED' : 'CALLED',
+    resolutionSource: programName === normalizeName(rootProgram) || sourcePrograms.has(programName) || ownerPrograms.has(programName)
+      ? 'SOURCE'
+      : 'UNRESOLVED',
   }));
 }
 
@@ -1482,6 +1485,7 @@ function buildCanonicalAnalysisModel({
     entities: {
       programs: buildProgramEntities(normalizedProgram, normalizedSourceFiles, programCalls, procedures, prototypes),
       tables: mergedTables,
+      db2Triggers: [],
       nativeFiles,
       modules,
       servicePrograms,
@@ -1491,6 +1495,7 @@ function buildCanonicalAnalysisModel({
       procedures,
       prototypes,
       procedureReferences,
+      externalObjects: [],
     },
     relations: buildRelations(
       normalizedProgram,
@@ -1547,10 +1552,66 @@ function mergeObject(baseValue, patchValue) {
   };
 }
 
+function mergeEntityCollections(baseEntities, updates) {
+  if (!updates || typeof updates !== 'object') {
+    return baseEntities;
+  }
+
+  const next = {
+    ...baseEntities,
+  };
+
+  for (const [collectionName, patchCollection] of Object.entries(updates)) {
+    if (!Array.isArray(patchCollection) || patchCollection.length === 0) {
+      continue;
+    }
+
+    const merged = new Map(
+      (Array.isArray(baseEntities && baseEntities[collectionName]) ? baseEntities[collectionName] : [])
+        .filter((entry) => entry && entry.id)
+        .map((entry) => [entry.id, entry]),
+    );
+
+    for (const entry of patchCollection) {
+      if (!entry || !entry.id) continue;
+      merged.set(entry.id, entry);
+    }
+
+    next[collectionName] = Array.from(merged.values()).sort((a, b) => String(a.id || '').localeCompare(String(b.id || '')));
+  }
+
+  return next;
+}
+
+function mergeRelations(baseRelations, patchRelations) {
+  if (!Array.isArray(patchRelations) || patchRelations.length === 0) {
+    return baseRelations;
+  }
+
+  const merged = new Map(
+    (Array.isArray(baseRelations) ? baseRelations : [])
+      .filter((entry) => entry && entry.id)
+      .map((entry) => [entry.id, entry]),
+  );
+
+  for (const relation of patchRelations) {
+    if (!relation || !relation.id) continue;
+    merged.set(relation.id, relation);
+  }
+
+  return Array.from(merged.values()).sort((a, b) => String(a.id || '').localeCompare(String(b.id || '')));
+}
+
 function enrichCanonicalAnalysisModel(model, updates = {}) {
   assertCanonicalAnalysisModel(model);
   const next = {
     ...model,
+    entities: updates.entities
+      ? mergeEntityCollections(model.entities, updates.entities)
+      : model.entities,
+    relations: updates.relations
+      ? mergeRelations(model.relations, updates.relations)
+      : model.relations,
     enrichments: {
       ...model.enrichments,
       ...(updates.summary ? { summary: mergeObject(model.enrichments.summary, updates.summary) } : {}),

--- a/src/context/contextBuilder.js
+++ b/src/context/contextBuilder.js
@@ -51,6 +51,12 @@ function projectDependencies(canonicalAnalysis) {
         name: entry.name,
         kind: entry.kind || 'PROGRAM',
         evidenceCount: Number(entry.evidenceCount) || 0,
+        resolutionSource: entry.resolutionSource || 'UNRESOLVED',
+        catalogObjectType: entry.catalogObjectType || null,
+        catalogLibrary: entry.catalogLibrary || null,
+        catalogSchema: entry.catalogSchema || null,
+        catalogSystemName: entry.catalogSystemName || null,
+        catalogSqlName: entry.catalogSqlName || null,
       }))),
     copyMembers: sortByName((entities.copyMembers || []).map((entry) => ({
       name: entry.name,
@@ -62,6 +68,11 @@ function projectDependencies(canonicalAnalysis) {
 function projectProcedureAnalysis(canonicalAnalysis) {
   const entities = canonicalAnalysis.entities || {};
   const relations = canonicalAnalysis.relations || [];
+  const procedureTargetById = new Map([
+    ...(entities.prototypes || []).map((entry) => [entry.id, entry]),
+    ...(entities.procedureReferences || []).map((entry) => [entry.id, entry]),
+    ...(entities.procedures || []).map((entry) => [entry.id, entry]),
+  ]);
   const procedures = sortByName((entities.procedures || []).map((entry) => ({
     name: entry.name,
     kind: entry.kind,
@@ -90,12 +101,19 @@ function projectProcedureAnalysis(canonicalAnalysis) {
       const from = String(entry.from || '');
       const to = String(entry.to || '');
       const caller = from.split(':').slice(-1)[0] || from;
+      const targetEntity = procedureTargetById.get(to);
       return {
         caller,
         target: String(entry.attributes && entry.attributes.targetName ? entry.attributes.targetName : (to.split(':').slice(-1)[0] || to)),
         resolution: entry.attributes && entry.attributes.resolution ? entry.attributes.resolution : 'UNKNOWN',
         targetKind: entry.attributes && entry.attributes.targetKind ? entry.attributes.targetKind : '',
         evidenceCount: Array.isArray(entry.evidence) ? entry.evidence.length : 0,
+        resolutionSource: targetEntity && targetEntity.resolutionSource ? targetEntity.resolutionSource : 'SOURCE',
+        catalogObjectType: targetEntity && targetEntity.catalogObjectType ? targetEntity.catalogObjectType : null,
+        catalogLibrary: targetEntity && targetEntity.catalogLibrary ? targetEntity.catalogLibrary : null,
+        catalogSchema: targetEntity && targetEntity.catalogSchema ? targetEntity.catalogSchema : null,
+        catalogSystemName: targetEntity && targetEntity.catalogSystemName ? targetEntity.catalogSystemName : null,
+        catalogSqlName: targetEntity && targetEntity.catalogSqlName ? targetEntity.catalogSqlName : null,
       };
     })
     .sort((a, b) => {
@@ -113,6 +131,7 @@ function projectProcedureAnalysis(canonicalAnalysis) {
       externalCallCount: calls.filter((entry) => entry.resolution === 'EXTERNAL').length,
       dynamicCallCount: calls.filter((entry) => entry.resolution === 'DYNAMIC').length,
       unresolvedCallCount: calls.filter((entry) => entry.resolution === 'UNRESOLVED').length,
+      catalogResolvedCallCount: calls.filter((entry) => entry.resolutionSource === 'CATALOG').length,
     },
     procedures,
     prototypes,

--- a/src/db2/catalogSemanticModel.js
+++ b/src/db2/catalogSemanticModel.js
@@ -1,0 +1,518 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const {
+  dedupeEvidence,
+  normalizeCatalogTable,
+  parseQualifiedIdentifier,
+} = require('./db2EvidenceLinker');
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeIdentifier(value) {
+  return String(value || '').trim().toUpperCase();
+}
+
+function uniqueSortedStrings(values) {
+  return Array.from(new Set(asArray(values).map((value) => String(value || '').trim()).filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function createEntityId(type, name) {
+  return `${normalizeIdentifier(type)}:${String(name || '').trim()}`;
+}
+
+function createRelationId(type, from, to) {
+  return `${normalizeIdentifier(type)}:${String(from || '')}->${String(to || '')}`;
+}
+
+function normalizeRule(value) {
+  const normalized = normalizeIdentifier(value);
+  if (!normalized) {
+    return null;
+  }
+  if (normalized === 'IMPORT_RULE_NO_ACTION' || normalized === 'NOACTION') {
+    return 'NO ACTION';
+  }
+  if (normalized === 'IMPORT_RULE_RESTRICT') {
+    return 'RESTRICT';
+  }
+  if (normalized === 'IMPORT_RULE_CASCADE') {
+    return 'CASCADE';
+  }
+  if (normalized === 'IMPORT_RULE_SET_NULL' || normalized === 'SETNULL') {
+    return 'SET NULL';
+  }
+  if (normalized === 'IMPORT_RULE_SET_DEFAULT' || normalized === 'SETDEFAULT') {
+    return 'SET DEFAULT';
+  }
+  return normalized.replace(/_/g, ' ');
+}
+
+function mergeEntityEvidence(existing, additional) {
+  return dedupeEvidence([
+    ...(existing && existing.evidence ? existing.evidence : []),
+    ...asArray(additional),
+  ]);
+}
+
+function buildTableEntityIndex(canonicalAnalysis) {
+  return new Map(asArray(canonicalAnalysis && canonicalAnalysis.entities && canonicalAnalysis.entities.tables)
+    .map((entry) => [normalizeIdentifier(entry && entry.name), entry]));
+}
+
+function buildGeneralEntityIndex(canonicalAnalysis) {
+  const index = new Map();
+  const entities = canonicalAnalysis && canonicalAnalysis.entities ? canonicalAnalysis.entities : {};
+  for (const collection of Object.values(entities)) {
+    if (!Array.isArray(collection)) continue;
+    for (const entity of collection) {
+      if (entity && entity.id) {
+        index.set(entity.id, entity);
+      }
+    }
+  }
+  return index;
+}
+
+function buildDb2Identity(link, table) {
+  const primaryMatch = asArray(link && link.matches)[0] || {};
+  const normalizedTable = normalizeCatalogTable(table);
+  return {
+    requestedName: normalizeIdentifier(link && link.requestedName),
+    matchStatus: String(link && link.matchStatus || 'unresolved'),
+    matchedBy: primaryMatch.matchType || null,
+    primaryDisplayName: normalizedTable.table || normalizedTable.systemName || normalizeIdentifier(link && link.requestedName),
+    schema: normalizedTable.schema,
+    sqlName: normalizedTable.table,
+    systemSchema: normalizedTable.systemSchema,
+    systemName: normalizedTable.systemName,
+    objectType: normalizedTable.objectType,
+    textDescription: String(normalizedTable.textDescription || '').trim() || null,
+    estimatedRowCount: Number.isFinite(Number(normalizedTable.estimatedRowCount)) ? Number(normalizedTable.estimatedRowCount) : null,
+    lookupStrategy: normalizedTable.lookupStrategy || primaryMatch.lookupStrategy || 'JDBC_METADATA',
+    triggerCount: asArray(normalizedTable.triggers).length,
+    derivedObjectCount: asArray(normalizedTable.derivedObjects).length,
+    foreignKeyCount: asArray(normalizedTable.foreignKeys).length,
+  };
+}
+
+function chooseCanonicalTableName(link, table, tableEntitiesByName) {
+  const candidates = uniqueSortedStrings([
+    link && link.requestedName,
+    table && table.table,
+    table && table.systemName,
+  ]);
+  for (const candidate of candidates) {
+    if (tableEntitiesByName.has(candidate)) {
+      return candidate;
+    }
+  }
+  return normalizeIdentifier((table && (table.table || table.systemName)) || (link && link.requestedName));
+}
+
+function normalizeTrigger(trigger) {
+  return {
+    schema: normalizeIdentifier(trigger && trigger.schema),
+    name: normalizeIdentifier(trigger && trigger.name),
+    systemSchema: normalizeIdentifier(trigger && trigger.systemSchema),
+    systemName: normalizeIdentifier(trigger && trigger.systemName),
+    eventManipulation: normalizeIdentifier(trigger && trigger.eventManipulation),
+    actionTiming: normalizeIdentifier(trigger && trigger.actionTiming),
+    actionOrientation: normalizeIdentifier(trigger && trigger.actionOrientation),
+    programName: normalizeIdentifier(trigger && trigger.programName),
+    programLibrary: normalizeIdentifier(trigger && trigger.programLibrary),
+  };
+}
+
+function normalizeDerivedObject(derivedObject) {
+  return {
+    schema: normalizeIdentifier(derivedObject && derivedObject.schema),
+    name: normalizeIdentifier(derivedObject && (derivedObject.name || derivedObject.table)),
+    systemSchema: normalizeIdentifier(derivedObject && derivedObject.systemSchema),
+    systemName: normalizeIdentifier(derivedObject && derivedObject.systemName),
+    objectType: normalizeIdentifier(derivedObject && derivedObject.objectType) || 'VIEW',
+    textDescription: String(derivedObject && derivedObject.textDescription || '').trim() || null,
+  };
+}
+
+function ensureTableEntity(entityMap, relationUpdates, name, patch = {}) {
+  const normalizedName = normalizeIdentifier(name);
+  if (!normalizedName) {
+    return null;
+  }
+
+  const id = createEntityId('TABLE', normalizedName);
+  if (!entityMap.has(id)) {
+    entityMap.set(id, {
+      id,
+      name: normalizedName,
+      kind: 'TABLE',
+      evidenceCount: 0,
+      evidence: [],
+      ...patch,
+    });
+  } else if (patch && Object.keys(patch).length > 0) {
+    entityMap.set(id, {
+      ...entityMap.get(id),
+      ...patch,
+    });
+  }
+
+  return entityMap.get(id);
+}
+
+function normalizeExternalObject(entry) {
+  return {
+    requestedName: normalizeIdentifier(entry && entry.requestedName),
+    schema: normalizeIdentifier(entry && (entry.schema || entry.sqlSchema || entry.library)),
+    library: normalizeIdentifier(entry && (entry.library || entry.systemSchema)),
+    sqlName: normalizeIdentifier(entry && (entry.sqlName || entry.longName)),
+    systemName: normalizeIdentifier(entry && (entry.systemName || entry.name)),
+    objectType: normalizeIdentifier(entry && entry.objectType),
+    sqlObjectType: normalizeIdentifier(entry && entry.sqlObjectType),
+    textDescription: String(entry && entry.textDescription || entry && entry.text || '').trim() || null,
+    evidenceSource: String(entry && entry.evidenceSource || 'OBJECT_STATISTICS').trim() || 'OBJECT_STATISTICS',
+    matchedBy: normalizeIdentifier(entry && entry.matchedBy) || 'SYSTEM_NAME',
+  };
+}
+
+function buildExternalCallRequests(canonicalAnalysis) {
+  const entities = canonicalAnalysis && canonicalAnalysis.entities ? canonicalAnalysis.entities : {};
+  const requests = [];
+
+  for (const program of asArray(entities.programs)) {
+    if (program.role !== 'CALLED') continue;
+    requests.push({
+      entityId: program.id,
+      entityType: 'PROGRAM',
+      requestedName: normalizeIdentifier(program.name),
+    });
+  }
+
+  for (const prototype of asArray(entities.prototypes)) {
+    if (!prototype.imported) continue;
+    requests.push({
+      entityId: prototype.id,
+      entityType: 'PROTOTYPE',
+      requestedName: normalizeIdentifier(prototype.externalName || prototype.name),
+    });
+  }
+
+  for (const reference of asArray(entities.procedureReferences)) {
+    requests.push({
+      entityId: reference.id,
+      entityType: 'PROCEDURE_REFERENCE',
+      requestedName: normalizeIdentifier(reference.name),
+    });
+  }
+
+  return requests
+    .filter((entry) => entry.requestedName)
+    .sort((a, b) => {
+      if (a.requestedName !== b.requestedName) return a.requestedName.localeCompare(b.requestedName);
+      if (a.entityType !== b.entityType) return a.entityType.localeCompare(b.entityType);
+      return a.entityId.localeCompare(b.entityId);
+    });
+}
+
+function isExternalObjectMatch(requestedName, externalObject) {
+  const requested = parseQualifiedIdentifier(requestedName);
+  const external = normalizeExternalObject(externalObject);
+  const aliases = uniqueSortedStrings([
+    external.requestedName,
+    external.sqlName,
+    external.systemName,
+    external.schema && external.sqlName ? `${external.schema}.${external.sqlName}` : '',
+    external.library && external.systemName ? `${external.library}/${external.systemName}` : '',
+  ]);
+
+  return aliases.includes(requested && requested.qualified)
+    || aliases.includes(requested && requested.name)
+    || aliases.includes(requested && requested.systemName);
+}
+
+function buildDb2CatalogSemanticUpdates({ canonicalAnalysis, tableLinks, exportedTables, externalObjects }) {
+  const tableEntitiesByName = buildTableEntityIndex(canonicalAnalysis);
+  const existingEntitiesById = buildGeneralEntityIndex(canonicalAnalysis);
+  const entityUpdates = {
+    tables: new Map(),
+    db2Triggers: new Map(),
+    externalObjects: new Map(),
+    programs: new Map(),
+    prototypes: new Map(),
+    procedureReferences: new Map(),
+  };
+  const relationUpdates = new Map();
+
+  const normalizedTables = asArray(exportedTables).map(normalizeCatalogTable);
+  const normalizedExternalObjects = asArray(externalObjects).map(normalizeExternalObject);
+
+  for (const link of asArray(tableLinks)) {
+    const match = asArray(link.matches)[0];
+    if (!match) {
+      const existing = tableEntitiesByName.get(normalizeIdentifier(link.requestedName));
+      if (existing) {
+        entityUpdates.tables.set(existing.id, {
+          ...existing,
+          db2Identity: {
+            requestedName: normalizeIdentifier(link.requestedName),
+            matchStatus: link.matchStatus,
+            matchedBy: null,
+            primaryDisplayName: normalizeIdentifier(link.requestedName),
+            schema: '',
+            sqlName: '',
+            systemSchema: '',
+            systemName: '',
+            objectType: null,
+            textDescription: null,
+            estimatedRowCount: null,
+            lookupStrategy: null,
+            triggerCount: 0,
+            derivedObjectCount: 0,
+            foreignKeyCount: 0,
+          },
+          evidence: mergeEntityEvidence(existing, link.sourceEvidence),
+          evidenceCount: mergeEntityEvidence(existing, link.sourceEvidence).length,
+        });
+      }
+      continue;
+    }
+
+    const matchedTable = normalizedTables.find((table) => (
+      table.schema === match.schema
+      && table.table === match.table
+      && table.systemSchema === match.systemSchema
+      && table.systemName === match.systemName
+    ));
+    if (!matchedTable) {
+      continue;
+    }
+
+    const canonicalTableName = chooseCanonicalTableName(link, matchedTable, tableEntitiesByName);
+    const existingTable = tableEntitiesByName.get(canonicalTableName) || existingEntitiesById.get(createEntityId('TABLE', canonicalTableName));
+    const tableEntityId = createEntityId('TABLE', canonicalTableName);
+    const mergedEvidence = mergeEntityEvidence(existingTable, [
+      ...asArray(link.sourceEvidence),
+      ...asArray(existingTable && existingTable.evidence),
+    ]);
+    entityUpdates.tables.set(tableEntityId, {
+      ...(existingTable || {
+        id: tableEntityId,
+        name: canonicalTableName,
+        kind: 'TABLE',
+      }),
+      evidence: mergedEvidence,
+      evidenceCount: mergedEvidence.length,
+      db2Identity: buildDb2Identity(link, matchedTable),
+    });
+
+    for (const trigger of asArray(matchedTable.triggers).map(normalizeTrigger)) {
+      const triggerName = uniqueSortedStrings([
+        trigger.name,
+        trigger.systemName,
+      ])[0];
+      if (!triggerName) continue;
+      const triggerEntityId = createEntityId('TRIGGER', `${trigger.schema || trigger.systemSchema}:${triggerName}`);
+      entityUpdates.db2Triggers.set(triggerEntityId, {
+        id: triggerEntityId,
+        name: triggerName,
+        schema: trigger.schema,
+        systemSchema: trigger.systemSchema,
+        systemName: trigger.systemName,
+        eventManipulation: trigger.eventManipulation,
+        actionTiming: trigger.actionTiming,
+        actionOrientation: trigger.actionOrientation,
+        programName: trigger.programName,
+        programLibrary: trigger.programLibrary,
+        evidenceCount: mergedEvidence.length,
+        evidence: mergedEvidence,
+      });
+      const relationId = createRelationId('HAS_TRIGGER', tableEntityId, triggerEntityId);
+      relationUpdates.set(relationId, {
+        id: relationId,
+        type: 'HAS_TRIGGER',
+        from: tableEntityId,
+        to: triggerEntityId,
+        evidence: mergedEvidence,
+        attributes: {
+          eventManipulation: trigger.eventManipulation,
+          actionTiming: trigger.actionTiming,
+          actionOrientation: trigger.actionOrientation,
+        },
+      });
+    }
+
+    for (const derivedObject of asArray(matchedTable.derivedObjects).map(normalizeDerivedObject)) {
+      const derivedTableName = normalizeIdentifier(derivedObject.name || derivedObject.systemName);
+      if (!derivedTableName) continue;
+      const derivedTable = ensureTableEntity(entityUpdates.tables, relationUpdates, derivedTableName, {
+        db2Identity: {
+          requestedName: derivedTableName,
+          matchStatus: 'derived',
+          matchedBy: 'CATALOG_RELATION',
+          primaryDisplayName: derivedObject.name || derivedObject.systemName,
+          schema: derivedObject.schema,
+          sqlName: derivedObject.name,
+          systemSchema: derivedObject.systemSchema,
+          systemName: derivedObject.systemName,
+          objectType: derivedObject.objectType,
+          textDescription: derivedObject.textDescription,
+          estimatedRowCount: null,
+          lookupStrategy: 'IBM_I_CATALOG',
+          triggerCount: 0,
+          derivedObjectCount: 0,
+          foreignKeyCount: 0,
+        },
+      });
+      if (!derivedTable) continue;
+      const relationId = createRelationId('DERIVES_OBJECT', tableEntityId, derivedTable.id);
+      relationUpdates.set(relationId, {
+        id: relationId,
+        type: 'DERIVES_OBJECT',
+        from: tableEntityId,
+        to: derivedTable.id,
+        evidence: mergedEvidence,
+        attributes: {
+          objectType: derivedObject.objectType,
+          resolutionSource: 'CATALOG',
+        },
+      });
+    }
+
+    for (const foreignKey of asArray(matchedTable.foreignKeys)) {
+      const referencedName = normalizeIdentifier(foreignKey && foreignKey.referencesTable);
+      if (!referencedName) continue;
+      const referencedEntity = ensureTableEntity(entityUpdates.tables, relationUpdates, referencedName, {
+        db2Identity: {
+          requestedName: referencedName,
+          matchStatus: 'referenced',
+          matchedBy: 'CATALOG_RELATION',
+          primaryDisplayName: referencedName,
+          schema: normalizeIdentifier(foreignKey.referencesSchema),
+          sqlName: referencedName,
+          systemSchema: '',
+          systemName: '',
+          objectType: 'TABLE',
+          textDescription: null,
+          estimatedRowCount: null,
+          lookupStrategy: 'IBM_I_CATALOG',
+          triggerCount: 0,
+          derivedObjectCount: 0,
+          foreignKeyCount: 0,
+        },
+      });
+      if (!referencedEntity) continue;
+      const relationId = `${createRelationId('REFERENCES_TABLE', tableEntityId, referencedEntity.id)}:${normalizeIdentifier(foreignKey.column)}:${normalizeIdentifier(foreignKey.referencesColumn)}`;
+      relationUpdates.set(relationId, {
+        id: relationId,
+        type: 'REFERENCES_TABLE',
+        from: tableEntityId,
+        to: referencedEntity.id,
+        evidence: mergedEvidence,
+        attributes: {
+          column: normalizeIdentifier(foreignKey.column),
+          referencesColumn: normalizeIdentifier(foreignKey.referencesColumn),
+          constraintName: normalizeIdentifier(foreignKey.constraintName),
+          updateRule: normalizeRule(foreignKey.updateRule),
+          deleteRule: normalizeRule(foreignKey.deleteRule),
+          resolutionSource: 'CATALOG',
+        },
+      });
+    }
+  }
+
+  const externalCallRequests = buildExternalCallRequests(canonicalAnalysis);
+  for (const request of externalCallRequests) {
+    const matches = normalizedExternalObjects.filter((entry) => isExternalObjectMatch(request.requestedName, entry));
+    if (matches.length !== 1) {
+      continue;
+    }
+
+    const match = matches[0];
+    const externalName = normalizeIdentifier(match.sqlName || match.systemName || request.requestedName);
+    const externalEntityId = createEntityId('EXTERNAL_OBJECT', `${match.library || match.schema}:${externalName}:${match.objectType || 'OBJECT'}`);
+    entityUpdates.externalObjects.set(externalEntityId, {
+      id: externalEntityId,
+      name: externalName,
+      requestedName: request.requestedName,
+      schema: match.schema,
+      library: match.library,
+      sqlName: match.sqlName,
+      systemName: match.systemName,
+      objectType: match.objectType,
+      sqlObjectType: match.sqlObjectType,
+      textDescription: match.textDescription,
+      evidenceSource: match.evidenceSource,
+      matchedBy: match.matchedBy,
+    });
+
+    const existingEntity = existingEntitiesById.get(request.entityId);
+    if (!existingEntity) {
+      continue;
+    }
+
+    const enrichedEntity = {
+      ...existingEntity,
+      resolutionSource: 'CATALOG',
+      catalogObjectType: match.objectType,
+      catalogLibrary: match.library,
+      catalogSchema: match.schema,
+      catalogSystemName: match.systemName,
+      catalogSqlName: match.sqlName,
+      catalogEvidenceSource: match.evidenceSource,
+      catalogMatchedBy: match.matchedBy,
+      catalogExternalObjectId: externalEntityId,
+    };
+
+    if (request.entityType === 'PROGRAM') {
+      entityUpdates.programs.set(request.entityId, enrichedEntity);
+    } else if (request.entityType === 'PROTOTYPE') {
+      entityUpdates.prototypes.set(request.entityId, enrichedEntity);
+    } else if (request.entityType === 'PROCEDURE_REFERENCE') {
+      entityUpdates.procedureReferences.set(request.entityId, enrichedEntity);
+    }
+
+    const relationId = createRelationId('RESOLVES_TO_EXTERNAL_OBJECT', request.entityId, externalEntityId);
+    relationUpdates.set(relationId, {
+      id: relationId,
+      type: 'RESOLVES_TO_EXTERNAL_OBJECT',
+      from: request.entityId,
+      to: externalEntityId,
+      evidence: asArray(existingEntity.evidence),
+      attributes: {
+        resolutionSource: 'CATALOG',
+        objectType: match.objectType,
+        matchedBy: match.matchedBy,
+        evidenceSource: match.evidenceSource,
+      },
+    });
+  }
+
+  return {
+    entities: Object.fromEntries(
+      Object.entries(entityUpdates)
+        .map(([key, value]) => [key, Array.from(value.values()).sort((a, b) => String(a.id || '').localeCompare(String(b.id || '')))])
+        .filter(([, value]) => value.length > 0),
+    ),
+    relations: Array.from(relationUpdates.values()).sort((a, b) => a.id.localeCompare(b.id)),
+  };
+}
+
+module.exports = {
+  buildDb2CatalogSemanticUpdates,
+  buildExternalCallRequests,
+  normalizeExternalObject,
+};

--- a/src/db2/db2EvidenceLinker.js
+++ b/src/db2/db2EvidenceLinker.js
@@ -19,6 +19,43 @@ function normalizeIdentifier(value) {
   return String(value || '').trim().toUpperCase();
 }
 
+function parseQualifiedIdentifier(value) {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    return null;
+  }
+
+  if (raw.includes('.')) {
+    const [schema, name] = raw.split('.', 2);
+    return {
+      qualified: normalizeIdentifier(raw.replace(/\//g, '.')),
+      schema: normalizeIdentifier(schema),
+      systemSchema: '',
+      name: normalizeIdentifier(name),
+      systemName: '',
+    };
+  }
+
+  if (raw.includes('/')) {
+    const [schema, name] = raw.split('/', 2);
+    return {
+      qualified: normalizeIdentifier(raw.replace(/\//g, '.')),
+      schema: '',
+      systemSchema: normalizeIdentifier(schema),
+      name: normalizeIdentifier(name),
+      systemName: normalizeIdentifier(name),
+    };
+  }
+
+  return {
+    qualified: normalizeIdentifier(raw),
+    schema: '',
+    systemSchema: '',
+    name: normalizeIdentifier(raw),
+    systemName: normalizeIdentifier(raw),
+  };
+}
+
 function uniqueSortedStrings(values) {
   return Array.from(new Set(asArray(values).map((value) => String(value || '').trim()).filter(Boolean)))
     .sort((a, b) => a.localeCompare(b));
@@ -78,12 +115,109 @@ function buildNativeFileSummary(contextFile, nativeFileEntity) {
   };
 }
 
+function normalizeCatalogLookupStrategy(value) {
+  const normalized = normalizeIdentifier(value);
+  return normalized || 'JDBC_METADATA';
+}
+
+function normalizeCatalogTable(table) {
+  const schema = normalizeIdentifier(table && (table.schema || table.sqlSchema));
+  const sqlName = normalizeIdentifier(table && (table.table || table.sqlName));
+  const systemSchema = normalizeIdentifier(table && table.systemSchema);
+  const systemName = normalizeIdentifier(table && table.systemName);
+  const objectType = normalizeIdentifier(table && table.objectType);
+  const lookupStrategy = normalizeCatalogLookupStrategy(table && table.lookupStrategy);
+
+  return {
+    ...table,
+    schema,
+    table: sqlName,
+    systemSchema,
+    systemName,
+    objectType: objectType || 'TABLE',
+    lookupStrategy,
+    aliases: uniqueSortedStrings([
+      sqlName,
+      systemName,
+      schema && sqlName ? `${schema}.${sqlName}` : '',
+      systemSchema && systemName ? `${systemSchema}/${systemName}` : '',
+      table && table.requestedName ? normalizeIdentifier(table.requestedName) : '',
+    ].filter(Boolean)),
+  };
+}
+
+function isRequestedTableMatch(requested, table) {
+  const normalizedRequested = parseQualifiedIdentifier(requested);
+  if (!normalizedRequested) {
+    return false;
+  }
+
+  const normalizedTable = normalizeCatalogTable(table);
+  if (normalizedRequested.schema && normalizedRequested.schema !== normalizedTable.schema) {
+    return false;
+  }
+  if (normalizedRequested.systemSchema && normalizedRequested.systemSchema !== normalizedTable.systemSchema) {
+    return false;
+  }
+
+  return normalizedTable.aliases.includes(normalizedRequested.qualified)
+    || normalizedTable.aliases.includes(normalizedRequested.name)
+    || normalizedTable.aliases.includes(normalizedRequested.systemName);
+}
+
+function resolveTableMatchType(requested, table) {
+  const normalizedRequested = parseQualifiedIdentifier(requested);
+  const normalizedTable = normalizeCatalogTable(table);
+  if (!normalizedRequested || !normalizedTable) {
+    return '';
+  }
+
+  if (normalizedRequested.schema && normalizedTable.schema && normalizedRequested.schema === normalizedTable.schema && normalizedRequested.name === normalizedTable.table) {
+    return 'SQL_QUALIFIED_NAME';
+  }
+  if (normalizedRequested.systemSchema && normalizedTable.systemSchema && normalizedRequested.systemSchema === normalizedTable.systemSchema && normalizedRequested.systemName === normalizedTable.systemName) {
+    return 'SYSTEM_QUALIFIED_NAME';
+  }
+  if (normalizedRequested.name && normalizedRequested.name === normalizedTable.table) {
+    return 'SQL_NAME';
+  }
+  if (normalizedRequested.systemName && normalizedRequested.systemName === normalizedTable.systemName) {
+    return 'SYSTEM_NAME';
+  }
+  return 'ALIAS';
+}
+
+function buildDb2TableLookupIndex(exportedTables) {
+  const aliasIndex = new Map();
+  const exactKeyIndex = new Map();
+
+  for (const rawTable of asArray(exportedTables)) {
+    const table = normalizeCatalogTable(rawTable);
+    for (const alias of table.aliases) {
+      if (!aliasIndex.has(alias)) {
+        aliasIndex.set(alias, []);
+      }
+      aliasIndex.get(alias).push(table);
+    }
+
+    if (table.schema && table.table) {
+      exactKeyIndex.set(`${table.schema}|${table.table}`, table);
+    }
+    if (table.systemSchema && table.systemName) {
+      exactKeyIndex.set(`${table.systemSchema}|${table.systemName}`, table);
+    }
+  }
+
+  return {
+    aliasIndex,
+    exactKeyIndex,
+  };
+}
+
 function buildDb2SourceLinkage({ requestedTables, exportedTables, canonicalAnalysis, context }) {
   const normalizedRequestedTables = uniqueSortedStrings(requestedTables);
-  const exported = asArray(exportedTables).map((table) => ({
-    schema: normalizeIdentifier(table && table.schema),
-    table: normalizeIdentifier(table && table.table),
-  }));
+  const exported = asArray(exportedTables).map(normalizeCatalogTable);
+  const lookupIndex = buildDb2TableLookupIndex(exported);
   const tableEntitiesByName = new Map(asArray(canonicalAnalysis && canonicalAnalysis.entities && canonicalAnalysis.entities.tables)
     .map((entry) => [normalizeIdentifier(entry && entry.name), entry]));
   const sqlStatements = asArray(canonicalAnalysis && canonicalAnalysis.entities && canonicalAnalysis.entities.sqlStatements);
@@ -93,7 +227,29 @@ function buildDb2SourceLinkage({ requestedTables, exportedTables, canonicalAnaly
     .map((entry) => [normalizeIdentifier(entry && entry.name), entry]));
 
   const tableLinks = normalizedRequestedTables.map((requestedName) => {
-    const matches = exported.filter((entry) => entry.table === requestedName);
+    const aliasMatches = lookupIndex.aliasIndex.get(parseQualifiedIdentifier(requestedName).qualified) || [];
+    const fallbackMatches = aliasMatches.length > 0
+      ? aliasMatches
+      : exported.filter((entry) => isRequestedTableMatch(requestedName, entry));
+    const matches = Array.from(new Map(fallbackMatches
+      .map((entry) => [
+        [
+          normalizeIdentifier(entry.schema),
+          normalizeIdentifier(entry.table),
+          normalizeIdentifier(entry.systemSchema),
+          normalizeIdentifier(entry.systemName),
+        ].join('|'),
+        {
+          schema: normalizeIdentifier(entry.schema),
+          table: normalizeIdentifier(entry.table),
+          systemSchema: normalizeIdentifier(entry.systemSchema),
+          systemName: normalizeIdentifier(entry.systemName),
+          objectType: normalizeIdentifier(entry.objectType || 'TABLE') || 'TABLE',
+          lookupStrategy: normalizeCatalogLookupStrategy(entry.lookupStrategy),
+          matchType: resolveTableMatchType(requestedName, entry),
+        },
+      ]))
+      .values());
     const matchStatus = matches.length === 0 ? 'unresolved' : matches.length === 1 ? 'resolved' : 'ambiguous';
     const tableEntity = tableEntitiesByName.get(requestedName);
     const sqlReferences = sqlStatements
@@ -123,6 +279,20 @@ function buildDb2SourceLinkage({ requestedTables, exportedTables, canonicalAnaly
         },
       });
     }
+    const fallbackMatchesByStrategy = matches.filter((entry) => entry.lookupStrategy !== 'IBM_I_CATALOG');
+    for (const match of fallbackMatchesByStrategy) {
+      diagnostics.push({
+        severity: 'info',
+        code: 'DB2_TABLE_LOOKUP_FALLBACK',
+        message: `DB2 metadata used ${match.lookupStrategy} fallback for source table ${requestedName}.`,
+        details: {
+          requestedTable: requestedName,
+          resolvedSchema: match.schema,
+          resolvedTable: match.table,
+          lookupStrategy: match.lookupStrategy,
+        },
+      });
+    }
     if (matchStatus === 'ambiguous') {
       diagnostics.push({
         severity: 'warning',
@@ -130,7 +300,7 @@ function buildDb2SourceLinkage({ requestedTables, exportedTables, canonicalAnaly
         message: `DB2 metadata resolved source table ${requestedName} to multiple schemas.`,
         details: {
           requestedTable: requestedName,
-          matchedSchemas: matches.map((entry) => entry.schema),
+          matchedSchemas: matches.map((entry) => entry.schema || entry.systemSchema),
         },
       });
     }
@@ -141,6 +311,11 @@ function buildDb2SourceLinkage({ requestedTables, exportedTables, canonicalAnaly
       matches: matches.map((entry) => ({
         schema: entry.schema,
         table: entry.table,
+        systemSchema: entry.systemSchema,
+        systemName: entry.systemName,
+        objectType: entry.objectType,
+        lookupStrategy: entry.lookupStrategy,
+        matchType: entry.matchType,
       })),
       sourceEvidence,
       sqlReferences,
@@ -153,6 +328,9 @@ function buildDb2SourceLinkage({ requestedTables, exportedTables, canonicalAnaly
   for (const link of tableLinks) {
     for (const match of link.matches) {
       linkByExactKey.set(`${match.schema}|${match.table}`, link);
+      if (match.systemSchema || match.systemName) {
+        linkByExactKey.set(`${match.systemSchema}|${match.systemName}`, link);
+      }
     }
   }
 
@@ -164,20 +342,32 @@ function buildDb2SourceLinkage({ requestedTables, exportedTables, canonicalAnaly
       .filter((entry) => entry.matchStatus === 'ambiguous')
       .map((entry) => ({
         requestedName: entry.requestedName,
-        matchedSchemas: entry.matches.map((match) => match.schema),
+        matchedSchemas: entry.matches.map((match) => match.schema || match.systemSchema),
       })),
     diagnostics: tableLinks.flatMap((entry) => entry.diagnostics),
   };
 }
 
 function buildCompactDb2TableLink(link, table) {
+  const normalizedTable = normalizeCatalogTable(table);
+  const primaryMatch = asArray(link.matches)[0] || {};
   return {
     requestedName: link.requestedName,
     matchStatus: link.matchStatus,
-    schema: normalizeIdentifier(table && table.schema),
-    table: normalizeIdentifier(table && table.table),
-    columnCount: asArray(table && table.columns).length,
-    foreignKeyCount: asArray(table && table.foreignKeys).length,
+    matchedBy: primaryMatch.matchType || null,
+    lookupStrategy: primaryMatch.lookupStrategy || normalizeCatalogLookupStrategy(normalizedTable.lookupStrategy),
+    displayName: normalizedTable.table || normalizedTable.systemName,
+    schema: normalizedTable.schema,
+    table: normalizedTable.table,
+    systemSchema: normalizedTable.systemSchema,
+    systemName: normalizedTable.systemName,
+    objectType: normalizedTable.objectType,
+    textDescription: String(normalizedTable.textDescription || '').trim() || null,
+    estimatedRowCount: Number.isFinite(Number(normalizedTable.estimatedRowCount)) ? Number(normalizedTable.estimatedRowCount) : null,
+    columnCount: asArray(normalizedTable.columns).length,
+    foreignKeyCount: asArray(normalizedTable.foreignKeys).length,
+    triggerCount: asArray(normalizedTable.triggers).length,
+    derivedObjectCount: asArray(normalizedTable.derivedObjects).length,
     sourceEvidenceCount: asArray(link.sourceEvidence).length,
     sqlReferenceCount: asArray(link.sqlReferences).length,
     nativeFileCount: asArray(link.nativeFiles).length,
@@ -186,11 +376,17 @@ function buildCompactDb2TableLink(link, table) {
 }
 
 function buildCompactTestDataLink(link, table) {
+  const normalizedTable = normalizeCatalogTable(table);
+  const primaryMatch = asArray(link.matches)[0] || {};
   return {
     requestedName: link.requestedName,
     matchStatus: link.matchStatus,
-    schema: normalizeIdentifier(table && table.schema),
-    table: normalizeIdentifier(table && table.table),
+    matchedBy: primaryMatch.matchType || null,
+    displayName: normalizedTable.table || normalizedTable.systemName,
+    schema: normalizedTable.schema,
+    table: normalizedTable.table,
+    systemSchema: normalizedTable.systemSchema,
+    systemName: normalizedTable.systemName,
     rowCount: Number(table && table.rowCount) || 0,
     status: String(table && table.status || ''),
     sourceEvidenceCount: asArray(link.sourceEvidence).length,
@@ -201,8 +397,12 @@ function buildCompactTestDataLink(link, table) {
 }
 
 module.exports = {
+  buildDb2TableLookupIndex,
   buildCompactTestDataLink,
   buildCompactDb2TableLink,
   buildDb2SourceLinkage,
   dedupeEvidence,
+  isRequestedTableMatch,
+  normalizeCatalogTable,
+  parseQualifiedIdentifier,
 };

--- a/src/db2/metadataExportService.js
+++ b/src/db2/metadataExportService.js
@@ -23,7 +23,13 @@ const {
 const {
   buildCompactDb2TableLink,
   buildDb2SourceLinkage,
+  normalizeCatalogTable,
 } = require('./db2EvidenceLinker');
+const {
+  buildDb2CatalogSemanticUpdates,
+  buildExternalCallRequests,
+  normalizeExternalObject,
+} = require('./catalogSemanticModel');
 
 const JSON_FILE = 'db2-metadata.json';
 const MARKDOWN_FILE = 'db2-metadata.md';
@@ -31,7 +37,7 @@ const MARKDOWN_FILE = 'db2-metadata.md';
 function parseJavaJson(stdout) {
   const content = String(stdout || '').trim();
   if (!content) {
-    return { tables: [] };
+    return {};
   }
   return JSON.parse(content);
 }
@@ -39,6 +45,7 @@ function parseJavaJson(stdout) {
 function normalizeColumn(column) {
   return {
     name: normalizeIdentifier(column && column.name),
+    systemName: normalizeIdentifier(column && column.systemName),
     type: normalizeIdentifier(column && column.type),
     length: Number.isFinite(Number(column && column.length)) ? Number(column.length) : null,
     precision: Number.isFinite(Number(column && column.precision)) ? Number(column.precision) : null,
@@ -54,14 +61,41 @@ function normalizeForeignKey(foreignKey) {
     referencesSchema: normalizeIdentifier(foreignKey && foreignKey.referencesSchema),
     referencesTable: normalizeIdentifier(foreignKey && foreignKey.referencesTable),
     referencesColumn: normalizeIdentifier(foreignKey && foreignKey.referencesColumn),
+    constraintName: normalizeIdentifier(foreignKey && foreignKey.constraintName),
+    updateRule: normalizeIdentifier(foreignKey && foreignKey.updateRule),
+    deleteRule: normalizeIdentifier(foreignKey && foreignKey.deleteRule),
   };
 }
 
-function normalizeTable(table) {
+function normalizeTrigger(trigger) {
+  return {
+    schema: normalizeIdentifier(trigger && trigger.schema),
+    name: normalizeIdentifier(trigger && trigger.name),
+    systemSchema: normalizeIdentifier(trigger && trigger.systemSchema),
+    systemName: normalizeIdentifier(trigger && trigger.systemName),
+    eventManipulation: normalizeIdentifier(trigger && trigger.eventManipulation),
+    actionTiming: normalizeIdentifier(trigger && trigger.actionTiming),
+    actionOrientation: normalizeIdentifier(trigger && trigger.actionOrientation),
+    programName: normalizeIdentifier(trigger && trigger.programName),
+    programLibrary: normalizeIdentifier(trigger && trigger.programLibrary),
+  };
+}
+
+function normalizeDerivedObject(derivedObject) {
+  return {
+    schema: normalizeIdentifier(derivedObject && derivedObject.schema),
+    name: normalizeIdentifier(derivedObject && (derivedObject.name || derivedObject.table)),
+    systemSchema: normalizeIdentifier(derivedObject && derivedObject.systemSchema),
+    systemName: normalizeIdentifier(derivedObject && derivedObject.systemName),
+    objectType: normalizeIdentifier(derivedObject && derivedObject.objectType) || 'VIEW',
+    textDescription: String(derivedObject && derivedObject.textDescription || '').trim() || null,
+  };
+}
+
+function normalizeRawTable(table) {
   const columns = (table && Array.isArray(table.columns) ? table.columns : [])
     .map(normalizeColumn)
     .filter((column) => column.name && column.type);
-
   const foreignKeys = (table && Array.isArray(table.foreignKeys) ? table.foreignKeys : [])
     .map(normalizeForeignKey)
     .filter((foreignKey) => foreignKey.column && foreignKey.referencesTable && foreignKey.referencesColumn)
@@ -71,35 +105,65 @@ function normalizeTable(table) {
       if (a.referencesTable !== b.referencesTable) return a.referencesTable.localeCompare(b.referencesTable);
       return a.referencesColumn.localeCompare(b.referencesColumn);
     });
+  const triggers = (table && Array.isArray(table.triggers) ? table.triggers : [])
+    .map(normalizeTrigger)
+    .filter((trigger) => trigger.name || trigger.systemName)
+    .sort((a, b) => {
+      const aName = a.name || a.systemName;
+      const bName = b.name || b.systemName;
+      if (a.schema !== b.schema) return a.schema.localeCompare(b.schema);
+      return aName.localeCompare(bName);
+    });
+  const derivedObjects = (table && Array.isArray(table.derivedObjects) ? table.derivedObjects : [])
+    .map(normalizeDerivedObject)
+    .filter((entry) => entry.name || entry.systemName)
+    .sort((a, b) => {
+      if (a.schema !== b.schema) return a.schema.localeCompare(b.schema);
+      const aName = a.name || a.systemName;
+      const bName = b.name || b.systemName;
+      return aName.localeCompare(bName);
+    });
 
-  const normalized = {
+  return normalizeCatalogTable({
+    ...table,
     schema: normalizeIdentifier(table && table.schema),
     table: normalizeIdentifier(table && table.table),
+    systemSchema: normalizeIdentifier(table && table.systemSchema),
+    systemName: normalizeIdentifier(table && table.systemName),
+    objectType: normalizeIdentifier(table && table.objectType) || 'TABLE',
+    textDescription: String(table && table.textDescription || '').trim() || null,
+    estimatedRowCount: Number.isFinite(Number(table && table.estimatedRowCount)) ? Number(table.estimatedRowCount) : null,
+    lookupStrategy: normalizeIdentifier(table && table.lookupStrategy) || 'JDBC_METADATA',
     columns,
-  };
-
-  if (foreignKeys.length > 0) {
-    normalized.foreignKeys = foreignKeys;
-  }
-
-  return normalized;
+    foreignKeys,
+    triggers,
+    derivedObjects,
+  });
 }
 
 function dedupeTables(tables) {
   const byKey = new Map();
 
   for (const table of tables) {
-    const normalized = normalizeTable(table);
-    if (!normalized.table) continue;
-    const key = `${normalized.schema}|${normalized.table}`;
+    const normalized = normalizeRawTable(table);
+    if (!normalized.table && !normalized.systemName) continue;
+    const key = [
+      normalized.schema,
+      normalized.table,
+      normalized.systemSchema,
+      normalized.systemName,
+    ].join('|');
     if (!byKey.has(key)) {
       byKey.set(key, normalized);
     }
   }
 
   return Array.from(byKey.values()).sort((a, b) => {
-    if (a.table !== b.table) return a.table.localeCompare(b.table);
-    return a.schema.localeCompare(b.schema);
+    const aName = a.table || a.systemName;
+    const bName = b.table || b.systemName;
+    if (aName !== bName) return aName.localeCompare(bName);
+    if (a.schema !== b.schema) return a.schema.localeCompare(b.schema);
+    return a.systemSchema.localeCompare(b.systemSchema);
   });
 }
 
@@ -111,6 +175,11 @@ function buildRequestedTableNames(dependencies) {
         .filter(Boolean),
     ),
   ).sort((a, b) => a.localeCompare(b));
+}
+
+function buildRequestedExternalObjectNames(canonicalAnalysis) {
+  return Array.from(new Set(buildExternalCallRequests(canonicalAnalysis).map((entry) => entry.requestedName)))
+    .sort((a, b) => a.localeCompare(b));
 }
 
 function renderLength(column) {
@@ -126,7 +195,11 @@ function renderLength(column) {
   return String(column.length);
 }
 
-function renderDb2MetadataMarkdown(program, tables) {
+function renderForeignKeyRule(rule) {
+  return rule ? ` (${rule})` : '';
+}
+
+function renderDb2MetadataMarkdown(program, tables, externalObjects, notes) {
   const lines = [
     '# DB2 Metadata',
     '',
@@ -134,18 +207,42 @@ function renderDb2MetadataMarkdown(program, tables) {
     '',
   ];
 
-  if (!tables || tables.length === 0) {
+  if (notes.length > 0) {
+    lines.push('Notes:');
+    for (const note of notes) {
+      lines.push(`- ${note}`);
+    }
+    lines.push('');
+  }
+
+  if ((!tables || tables.length === 0) && (!externalObjects || externalObjects.length === 0)) {
     lines.push('No DB2 metadata was exported.');
     lines.push('');
     return `${lines.join('\n')}\n`;
   }
 
-  for (const table of tables) {
-    lines.push(`## Table ${table.table}`);
+  for (const table of tables || []) {
+    lines.push(`## Table ${table.table || table.systemName}`);
     lines.push('');
     lines.push(`Schema: ${table.schema || '(unknown)'}`);
+    if (table.systemSchema || table.systemName) {
+      lines.push(`System Name: ${(table.systemSchema || table.schema || '(unknown)')}/${table.systemName || '(unknown)'}`);
+    }
+    lines.push(`Object Type: ${table.objectType || 'TABLE'}`);
+    if (table.textDescription) {
+      lines.push(`Text: ${table.textDescription}`);
+    }
+    if (table.estimatedRowCount !== null && table.estimatedRowCount !== undefined) {
+      lines.push(`Estimated Rows: ${table.estimatedRowCount}`);
+    }
+    if (table.lookupStrategy) {
+      lines.push(`Lookup Strategy: ${table.lookupStrategy}`);
+    }
     if (table.sourceLink) {
       lines.push(`Match Status: ${table.sourceLink.matchStatus}`);
+      if (table.sourceLink.matchedBy) {
+        lines.push(`Matched By: ${table.sourceLink.matchedBy}`);
+      }
       lines.push('');
       if ((table.sourceLink.sourceEvidence || []).length > 0) {
         lines.push('Source Evidence:');
@@ -175,18 +272,54 @@ function renderDb2MetadataMarkdown(program, tables) {
     } else {
       lines.push('');
     }
-    lines.push('| Column | Type | Length | Nullable | PK |');
-    lines.push('| --- | --- | --- | --- | --- |');
+
+    lines.push('| Column | System | Type | Length | Nullable | PK |');
+    lines.push('| --- | --- | --- | --- | --- | --- |');
     for (const column of table.columns || []) {
-      lines.push(`| ${column.name} | ${column.type} | ${renderLength(column)} | ${column.nullable ? 'Yes' : 'No'} | ${column.primaryKey ? 'Yes' : 'No'} |`);
+      lines.push(`| ${column.name} | ${column.systemName || ''} | ${column.type} | ${renderLength(column)} | ${column.nullable ? 'Yes' : 'No'} | ${column.primaryKey ? 'Yes' : 'No'} |`);
     }
+
     if ((table.foreignKeys || []).length > 0) {
       lines.push('');
       lines.push('Foreign Keys:');
       for (const foreignKey of table.foreignKeys) {
         const schemaPrefix = foreignKey.referencesSchema ? `${foreignKey.referencesSchema}.` : '';
-        lines.push(`- ${foreignKey.column} -> ${schemaPrefix}${foreignKey.referencesTable}.${foreignKey.referencesColumn}`);
+        lines.push(`- ${foreignKey.column} -> ${schemaPrefix}${foreignKey.referencesTable}.${foreignKey.referencesColumn}${renderForeignKeyRule(foreignKey.deleteRule || foreignKey.updateRule)}${foreignKey.deleteRule ? ` delete ${foreignKey.deleteRule}` : ''}${foreignKey.updateRule ? ` update ${foreignKey.updateRule}` : ''}`);
       }
+    }
+
+    if ((table.triggers || []).length > 0) {
+      lines.push('');
+      lines.push('Triggers:');
+      for (const trigger of table.triggers) {
+        lines.push(`- ${trigger.name || trigger.systemName} [${trigger.actionTiming || 'UNKNOWN'} ${trigger.eventManipulation || 'UNKNOWN'} ${trigger.actionOrientation || 'UNKNOWN'}]${trigger.programLibrary || trigger.programName ? ` via ${(trigger.programLibrary || '')}${trigger.programLibrary && trigger.programName ? '/' : ''}${trigger.programName || ''}` : ''}`);
+      }
+    }
+
+    if ((table.derivedObjects || []).length > 0) {
+      lines.push('');
+      lines.push('Derived Objects:');
+      for (const derivedObject of table.derivedObjects) {
+        const qualifiedName = derivedObject.schema && derivedObject.name
+          ? `${derivedObject.schema}.${derivedObject.name}`
+          : derivedObject.systemSchema && derivedObject.systemName
+            ? `${derivedObject.systemSchema}/${derivedObject.systemName}`
+            : derivedObject.name || derivedObject.systemName;
+        lines.push(`- ${qualifiedName} [${derivedObject.objectType || 'VIEW'}]${derivedObject.textDescription ? ` ${derivedObject.textDescription}` : ''}`);
+      }
+    }
+
+    lines.push('');
+  }
+
+  if ((externalObjects || []).length > 0) {
+    lines.push('## Catalog-Resolved External Objects');
+    lines.push('');
+    for (const externalObject of externalObjects) {
+      const library = externalObject.library || externalObject.schema || '(unknown)';
+      const name = externalObject.sqlName || externalObject.systemName || externalObject.requestedName;
+      const qualifier = externalObject.systemName ? `${library}/${externalObject.systemName}` : `${library}.${name}`;
+      lines.push(`- ${externalObject.requestedName}: ${qualifier} [${externalObject.objectType || 'OBJECT'}]${externalObject.sqlName && externalObject.sqlName !== externalObject.systemName ? ` SQL ${externalObject.sqlName}` : ''}${externalObject.textDescription ? ` ${externalObject.textDescription}` : ''}`);
     }
     lines.push('');
   }
@@ -199,96 +332,136 @@ function writeOutputs(outputDir, payload, markdown) {
   fs.writeFileSync(path.join(outputDir, MARKDOWN_FILE), markdown, 'utf8');
 }
 
-function exportDb2Metadata({ program, dependencies, dbConfig, outputDir, verbose, canonicalAnalysis, context }) {
-  const requestedTables = buildRequestedTableNames(dependencies);
-  const defaultSchema = resolveDefaultSchema(dbConfig);
-  const summary = {
+function createSkippedSummary(reason) {
+  return {
     status: 'skipped',
     file: JSON_FILE,
     markdownFile: MARKDOWN_FILE,
     tableCount: 0,
+    requestedTableCount: 0,
+    resolvedTableCount: 0,
+    unresolvedTableCount: 0,
+    ambiguousTableCount: 0,
+    triggerCount: 0,
+    derivedObjectCount: 0,
+    externalObjectCount: 0,
+    catalogResolvedProgramCount: 0,
+    catalogResolvedProcedureCount: 0,
+    fallbackLookupCount: 0,
+    reason,
   };
+}
+
+function runTableMetadataExport({ jdbcUrl, dbConfig, defaultSchema, requestedTables, verbose }) {
+  if (requestedTables.length === 0) {
+    return { tables: [] };
+  }
+
+  ensureJavaHelperCompiled('Db2MetadataExporter.java', 'Db2MetadataExporter');
+  if (verbose) {
+    console.log(`[verbose] Exporting DB2 metadata for ${requestedTables.length} tables`);
+  }
+
+  const result = runJavaHelper('Db2MetadataExporter', [
+    jdbcUrl,
+    String(dbConfig.user),
+    String(dbConfig.password),
+    defaultSchema,
+    requestedTables.join(','),
+  ]);
+
+  if (result.status !== 0) {
+    const errorText = (result.stderr || '').trim() || 'unknown DB2 metadata error';
+    throw new Error(errorText);
+  }
+
+  return parseJavaJson(result.stdout);
+}
+
+function runExternalObjectExport({ jdbcUrl, dbConfig, requestedNames, verbose }) {
+  if (requestedNames.length === 0) {
+    return { objects: [] };
+  }
+
+  ensureJavaHelperCompiled('Db2ExternalObjectResolver.java', 'Db2ExternalObjectResolver');
+  if (verbose) {
+    console.log(`[verbose] Resolving ${requestedNames.length} unresolved external IBM i object names`);
+  }
+
+  const result = runJavaHelper('Db2ExternalObjectResolver', [
+    jdbcUrl,
+    String(dbConfig.user),
+    String(dbConfig.password),
+    requestedNames.join(','),
+  ]);
+
+  if (result.status !== 0) {
+    const errorText = (result.stderr || '').trim() || 'unknown DB2 external object error';
+    throw new Error(errorText);
+  }
+
+  return parseJavaJson(result.stdout);
+}
+
+function exportDb2Metadata({ program, dependencies, dbConfig, outputDir, verbose, canonicalAnalysis, context }) {
+  const requestedTables = buildRequestedTableNames(dependencies);
+  const requestedExternalObjects = buildRequestedExternalObjectNames(canonicalAnalysis);
+  const defaultSchema = resolveDefaultSchema(dbConfig);
+  const summary = createSkippedSummary('no DB2 connection configuration was available');
 
   if (!isDbConfigured(dbConfig)) {
     return {
-      summary: {
-        ...summary,
-        reason: 'no DB2 connection configuration was available',
-      },
+      summary,
       notes: ['DB2 metadata export was skipped because no DB2 connection configuration was available.'],
+      canonicalUpdates: { entities: {}, relations: [] },
     };
   }
 
   const jdbcUrl = buildJdbcUrl(dbConfig, defaultSchema);
   if (!jdbcUrl) {
     return {
-      summary: {
-        ...summary,
-        reason: 'DB2 connection configuration is incomplete',
-      },
+      summary: createSkippedSummary('DB2 connection configuration is incomplete'),
       notes: ['DB2 metadata export was skipped because DB2 connection configuration is incomplete.'],
+      canonicalUpdates: { entities: {}, relations: [] },
     };
   }
 
-  if (requestedTables.length === 0) {
-    const linkage = buildDb2SourceLinkage({
-      requestedTables,
-      exportedTables: [],
-      canonicalAnalysis,
-      context,
-    });
+  if (requestedTables.length === 0 && requestedExternalObjects.length === 0) {
     const payload = {
       program: normalizeIdentifier(program),
       tables: [],
-      tableLinks: linkage.tableLinks,
+      tableLinks: [],
+      externalObjects: [],
+      notes: [],
     };
-    writeOutputs(outputDir, payload, renderDb2MetadataMarkdown(program, []));
+    writeOutputs(outputDir, payload, renderDb2MetadataMarkdown(program, [], [], []));
     return {
       payload,
       summary: {
+        ...createSkippedSummary('no source-linked DB2 tables or unresolved external calls were detected'),
         status: 'exported',
-        file: JSON_FILE,
-        markdownFile: MARKDOWN_FILE,
-        tableCount: 0,
-        requestedTableCount: 0,
-        resolvedTableCount: 0,
-        unresolvedTableCount: requestedTables.length,
-        ambiguousTableCount: 0,
-        tables: [],
       },
-      notes: linkage.unresolvedTables.length > 0
-        ? [`DB2 metadata lookup did not resolve tables: ${linkage.unresolvedTables.join(', ')}.`]
-        : [],
+      notes: [],
+      canonicalUpdates: { entities: {}, relations: [] },
     };
   }
 
   try {
-    ensureJavaHelperCompiled('Db2MetadataExporter.java', 'Db2MetadataExporter');
-    if (verbose) {
-      console.log(`[verbose] Exporting DB2 metadata for ${requestedTables.length} tables`);
-    }
-
-    const result = runJavaHelper('Db2MetadataExporter', [
+    const rawTableExport = runTableMetadataExport({
       jdbcUrl,
-      String(dbConfig.user),
-      String(dbConfig.password),
+      dbConfig,
       defaultSchema,
-      requestedTables.join(','),
-    ]);
+      requestedTables,
+      verbose,
+    });
+    const rawExternalExport = runExternalObjectExport({
+      jdbcUrl,
+      dbConfig,
+      requestedNames: requestedExternalObjects,
+      verbose,
+    });
 
-    if (result.status !== 0) {
-      const errorText = (result.stderr || '').trim() || 'unknown DB2 metadata error';
-      return {
-        summary: {
-          ...summary,
-          reason: `the DB2 helper failed: ${errorText}`,
-        },
-        notes: [`DB2 metadata export was skipped because the DB2 helper failed: ${errorText}`],
-      };
-    }
-
-    const parsed = parseJavaJson(result.stdout);
-    const tables = dedupeTables(parsed.tables || []);
+    const tables = dedupeTables(rawTableExport.tables || []);
     const linkage = buildDb2SourceLinkage({
       requestedTables,
       exportedTables: tables,
@@ -296,18 +469,29 @@ function exportDb2Metadata({ program, dependencies, dbConfig, outputDir, verbose
       context,
     });
     const linkedTables = tables.map((table) => {
-      const sourceLink = linkage.tableLinkByExactKey.get(`${normalizeIdentifier(table.schema)}|${normalizeIdentifier(table.table)}`) || null;
+      const sourceLink = linkage.tableLinkByExactKey.get(`${normalizeIdentifier(table.schema)}|${normalizeIdentifier(table.table)}`)
+        || linkage.tableLinkByExactKey.get(`${normalizeIdentifier(table.systemSchema)}|${normalizeIdentifier(table.systemName)}`)
+        || null;
+      const compactLink = sourceLink ? buildCompactDb2TableLink(sourceLink, table) : null;
       return {
         ...table,
-        ...(sourceLink ? { sourceLink } : {}),
+        ...(sourceLink ? { sourceLink: { ...sourceLink, ...(compactLink ? { matchedBy: compactLink.matchedBy } : {}) } } : {}),
       };
     });
-    const payload = {
-      program: normalizeIdentifier(program),
-      tables: linkedTables,
+    const normalizedExternalObjects = (rawExternalExport.objects || rawExternalExport.externalObjects || [])
+      .map(normalizeExternalObject)
+      .sort((a, b) => {
+        if (a.requestedName !== b.requestedName) return a.requestedName.localeCompare(b.requestedName);
+        if (a.library !== b.library) return a.library.localeCompare(b.library);
+        return (a.systemName || a.sqlName).localeCompare(b.systemName || b.sqlName);
+      });
+
+    const canonicalUpdates = buildDb2CatalogSemanticUpdates({
+      canonicalAnalysis,
       tableLinks: linkage.tableLinks,
-    };
-    writeOutputs(outputDir, payload, renderDb2MetadataMarkdown(program, linkedTables));
+      exportedTables: linkedTables,
+      externalObjects: normalizedExternalObjects,
+    });
 
     const unresolvedTables = linkage.unresolvedTables;
     const notes = [];
@@ -315,8 +499,22 @@ function exportDb2Metadata({ program, dependencies, dbConfig, outputDir, verbose
       notes.push(`DB2 metadata lookup did not resolve tables: ${unresolvedTables.join(', ')}.`);
     }
     if (linkage.ambiguousTables.length > 0) {
-      notes.push(`DB2 metadata lookup matched multiple schemas for tables: ${linkage.ambiguousTables.map((entry) => `${entry.requestedName} (${entry.matchedSchemas.join(', ')})`).join('; ')}.`);
+      notes.push(`DB2 metadata lookup matched multiple catalog objects for tables: ${linkage.ambiguousTables.map((entry) => `${entry.requestedName} (${entry.matchedSchemas.join(', ')})`).join('; ')}.`);
     }
+    for (const diagnostic of linkage.diagnostics || []) {
+      if (diagnostic.code === 'DB2_TABLE_LOOKUP_FALLBACK') {
+        notes.push(diagnostic.message);
+      }
+    }
+
+    const payload = {
+      program: normalizeIdentifier(program),
+      tables: linkedTables,
+      tableLinks: linkage.tableLinks,
+      externalObjects: normalizedExternalObjects,
+      notes: uniqueSortedStrings(notes),
+    };
+    writeOutputs(outputDir, payload, renderDb2MetadataMarkdown(program, linkedTables, normalizedExternalObjects, payload.notes));
 
     return {
       payload,
@@ -329,29 +527,43 @@ function exportDb2Metadata({ program, dependencies, dbConfig, outputDir, verbose
         resolvedTableCount: linkage.tableLinks.filter((entry) => entry.matchStatus === 'resolved').length,
         unresolvedTableCount: unresolvedTables.length,
         ambiguousTableCount: linkage.ambiguousTables.length,
+        triggerCount: linkedTables.reduce((sum, entry) => sum + (entry.triggers || []).length, 0),
+        derivedObjectCount: linkedTables.reduce((sum, entry) => sum + (entry.derivedObjects || []).length, 0),
+        externalObjectCount: normalizedExternalObjects.length,
+        catalogResolvedProgramCount: Object.keys(canonicalUpdates.entities || {}).includes('programs')
+          ? canonicalUpdates.entities.programs.length
+          : 0,
+        catalogResolvedProcedureCount: (
+          (canonicalUpdates.entities && canonicalUpdates.entities.prototypes ? canonicalUpdates.entities.prototypes.length : 0)
+          + (canonicalUpdates.entities && canonicalUpdates.entities.procedureReferences ? canonicalUpdates.entities.procedureReferences.length : 0)
+        ),
+        fallbackLookupCount: (linkage.diagnostics || []).filter((entry) => entry.code === 'DB2_TABLE_LOOKUP_FALLBACK').length,
         tables: linkedTables.map((table) => {
-          const sourceLink = linkage.tableLinkByExactKey.get(`${normalizeIdentifier(table.schema)}|${normalizeIdentifier(table.table)}`) || {
-            requestedName: normalizeIdentifier(table.table),
-            matchStatus: 'resolved',
-            sourceEvidence: [],
-            sqlReferences: [],
-            nativeFiles: [],
-          };
+          const sourceLink = linkage.tableLinkByExactKey.get(`${normalizeIdentifier(table.schema)}|${normalizeIdentifier(table.table)}`)
+            || linkage.tableLinkByExactKey.get(`${normalizeIdentifier(table.systemSchema)}|${normalizeIdentifier(table.systemName)}`)
+            || {
+              requestedName: normalizeIdentifier(table.table || table.systemName),
+              matchStatus: 'resolved',
+              matches: [],
+              sourceEvidence: [],
+              sqlReferences: [],
+              nativeFiles: [],
+            };
           return buildCompactDb2TableLink(sourceLink, table);
         }),
+        externalObjects: normalizedExternalObjects,
         ...(unresolvedTables.length > 0 ? { unresolvedTables } : {}),
         ...(linkage.ambiguousTables.length > 0 ? { ambiguousTables: linkage.ambiguousTables } : {}),
       },
-      notes,
-      diagnostics: linkage.diagnostics,
+      notes: payload.notes,
+      diagnostics: linkage.diagnostics || [],
+      canonicalUpdates,
     };
   } catch (error) {
     return {
-      summary: {
-        ...summary,
-        reason: `the DB2 helper could not run: ${error.message}`,
-      },
+      summary: createSkippedSummary(`the DB2 helper could not run: ${error.message}`),
       notes: [`DB2 metadata export was skipped because the DB2 helper could not run: ${error.message}`],
+      canonicalUpdates: { entities: {}, relations: [] },
     };
   }
 }

--- a/src/db2/testDataExportService.js
+++ b/src/db2/testDataExportService.js
@@ -22,7 +22,9 @@ const {
 } = require('./db2Config');
 const {
   buildCompactTestDataLink,
+  buildDb2TableLookupIndex,
   buildDb2SourceLinkage,
+  normalizeCatalogTable,
 } = require('./db2EvidenceLinker');
 
 const JSON_FILE = 'test-data.json';
@@ -102,34 +104,76 @@ function buildRequestedTables(dependencies) {
 function buildExtractionPlan({ requestedTables, metadataPayload, defaultSchema }) {
   const plan = new Map();
   const metadataTables = (metadataPayload && Array.isArray(metadataPayload.tables) ? metadataPayload.tables : [])
-    .map((table) => ({
-      schema: normalizeIdentifier(table && table.schema),
-      table: normalizeIdentifier(table && table.table),
+    .map((table) => normalizeCatalogTable({
+      ...table,
       columns: Array.isArray(table && table.columns) ? table.columns : [],
     }));
+  const lookupIndex = buildDb2TableLookupIndex(metadataTables);
 
   for (const table of metadataTables) {
-    if (!table.table) continue;
+    if (!table.table && !table.systemName) continue;
     const key = `${table.schema}|${table.table}`;
     plan.set(key, {
       schema: table.schema,
       table: table.table,
+      systemSchema: table.systemSchema,
+      systemName: table.systemName,
       columns: table.columns,
       status: 'pending',
     });
   }
 
   for (const requestedTable of requestedTables) {
+    const requestedAliases = [
+      requestedTable.schema && requestedTable.table ? `${requestedTable.schema}.${requestedTable.table}` : '',
+      requestedTable.schema && requestedTable.table ? `${requestedTable.schema}/${requestedTable.table}` : '',
+      requestedTable.table,
+    ].filter(Boolean).map((value) => normalizeIdentifier(value));
+    const matches = Array.from(new Map(
+      requestedAliases.flatMap((alias) => (lookupIndex.aliasIndex.get(alias) || []))
+        .map((entry) => [`${entry.schema}|${entry.table}|${entry.systemSchema}|${entry.systemName}`, entry]),
+    ).values());
+
+    if (matches.length === 1) {
+      const match = matches[0];
+      const key = `${match.schema}|${match.table}`;
+      if (!plan.has(key)) {
+        plan.set(key, {
+          schema: match.schema,
+          table: match.table,
+          systemSchema: match.systemSchema,
+          systemName: match.systemName,
+          columns: match.columns || [],
+          status: 'pending',
+        });
+      }
+      continue;
+    }
+
+    if (matches.length > 1) {
+      plan.set(`${requestedTable.schema || ''}|${requestedTable.table}`, {
+        schema: '',
+        table: requestedTable.table,
+        systemSchema: '',
+        systemName: requestedTable.table,
+        columns: [],
+        status: 'skipped',
+        note: `Skipped because ${requestedTable.table} matched multiple DB2 catalog objects.`,
+      });
+      continue;
+    }
+
     const schema = requestedTable.schema || defaultSchema;
     const key = `${schema}|${requestedTable.table}`;
     if (plan.has(key)) {
       continue;
     }
-
     if (!schema) {
       plan.set(`|${requestedTable.table}`, {
         schema: '',
         table: requestedTable.table,
+        systemSchema: '',
+        systemName: requestedTable.table,
         columns: [],
         status: 'skipped',
         note: 'Skipped because no schema was detected and no default schema/library is configured.',
@@ -140,6 +184,8 @@ function buildExtractionPlan({ requestedTables, metadataPayload, defaultSchema }
     plan.set(key, {
       schema,
       table: requestedTable.table,
+      systemSchema: schema,
+      systemName: requestedTable.table,
       columns: [],
       status: 'pending',
     });
@@ -519,6 +565,7 @@ function exportTestData({
 }
 
 module.exports = {
+  buildExtractionPlan,
   exportTestData,
   DEFAULT_TEST_DATA_LIMIT,
   renderTestDataMarkdown,

--- a/src/prompt/promptBuilder.js
+++ b/src/prompt/promptBuilder.js
@@ -159,6 +159,20 @@ function formatDiagnosticFindings(diagnosticPacks) {
   });
 }
 
+function formatProgramCalls(programCalls) {
+  return asBulletList(programCalls, (item) => {
+    const flags = [];
+    if (item.kind) flags.push(item.kind);
+    if (item.resolutionSource && item.resolutionSource !== 'SOURCE') {
+      flags.push(item.resolutionSource);
+    }
+    if (item.catalogObjectType) {
+      flags.push(item.catalogObjectType);
+    }
+    return `${item.name || item}${flags.length ? ` (${flags.join(', ')})` : ''}`;
+  });
+}
+
 function getPathValue(value, dottedPath) {
   return String(dottedPath || '')
     .split('.')
@@ -239,7 +253,7 @@ function buildTemplateData(context, sourceSnippet, contract) {
     program: context.program || '',
     summary: [summary, db2Hint].filter(Boolean).join(' '),
     tables: asBulletList(tables, (item) => (item.kind ? `${item.name} (${item.kind})` : item.name || item)),
-    programCalls: asBulletList(programCalls, (item) => (item.kind ? `${item.name} (${item.kind})` : item.name || item)),
+    programCalls: formatProgramCalls(programCalls),
     copyMembers: asBulletList(copyMembers, (item) => item.name || item),
     nativeFiles: asBulletList(nativeFiles, (item) => {
       const flags = [];
@@ -279,6 +293,12 @@ function buildTemplateDataFromProjection(aiProjection, contract) {
   const summaryParts = [
     workflow && workflow.summary ? workflow.summary : '',
     formatDb2Hint(null, workflow),
+    workflow && Array.isArray(workflow.programCalls) && workflow.programCalls.some((entry) => entry.resolutionSource === 'CATALOG')
+      ? `Some external program calls are catalog-resolved rather than source-resolved.`
+      : '',
+    workflow && Array.isArray(workflow.procedureCalls) && workflow.procedureCalls.some((entry) => entry.resolutionSource === 'CATALOG')
+      ? `Some external procedure references are catalog-resolved rather than source-resolved.`
+      : '',
     workflow && Array.isArray(workflow.riskMarkers) && workflow.riskMarkers.length > 0
       ? `Risk markers: ${workflow.riskMarkers.join(', ')}.`
       : '',
@@ -291,7 +311,7 @@ function buildTemplateDataFromProjection(aiProjection, contract) {
     program: aiProjection.program || '',
     summary: summaryParts.join(' '),
     tables: asBulletList((workflow && workflow.tables) || [], (item) => (item.kind ? `${item.name} (${item.kind})` : item.name || item)),
-    programCalls: asBulletList((workflow && workflow.programCalls) || [], (item) => (item.kind ? `${item.name} (${item.kind})` : item.name || item)),
+    programCalls: formatProgramCalls((workflow && workflow.programCalls) || []),
     copyMembers: asBulletList((workflow && workflow.copyMembers) || [], (item) => item.name || item),
     nativeFiles: asBulletList((workflow && workflow.nativeFiles) || [], (item) => {
       const flags = [];

--- a/src/report/markdownReport.js
+++ b/src/report/markdownReport.js
@@ -31,11 +31,17 @@ function sectionList(values) {
       }
 
       if (value.name && value.kind) {
-        return `- ${value.name} (${value.kind})`;
+        const extras = [];
+        if (value.resolutionSource && value.resolutionSource !== 'SOURCE') extras.push(value.resolutionSource);
+        if (value.catalogObjectType) extras.push(value.catalogObjectType);
+        return `- ${value.name} (${[value.kind, ...extras].filter(Boolean).join(', ')})`;
       }
 
       if (value.name) {
-        return `- ${value.name}`;
+        const extras = [];
+        if (value.resolutionSource && value.resolutionSource !== 'SOURCE') extras.push(value.resolutionSource);
+        if (value.catalogObjectType) extras.push(value.catalogObjectType);
+        return `- ${value.name}${extras.length ? ` (${extras.join(', ')})` : ''}`;
       }
 
       if (value.text && value.type) {
@@ -246,8 +252,14 @@ function generateMarkdownReport(context, tokenReport) {
   const db2Ambiguous = Array.isArray(db2Metadata.ambiguousTables)
     ? db2Metadata.ambiguousTables.map((entry) => entry.requestedName || entry.table)
     : [];
+  const db2TriggerCount = Number(db2Metadata.triggerCount) || 0;
+  const db2DerivedObjectCount = Number(db2Metadata.derivedObjectCount) || 0;
+  const db2ExternalObjectCount = Number(db2Metadata.externalObjectCount) || 0;
+  const db2CatalogResolvedProgramCount = Number(db2Metadata.catalogResolvedProgramCount) || 0;
+  const db2CatalogResolvedProcedureCount = Number(db2Metadata.catalogResolvedProcedureCount) || 0;
+  const db2FallbackLookupCount = Number(db2Metadata.fallbackLookupCount) || 0;
   const db2Section = db2Metadata.status === 'exported'
-    ? `## DB2 Metadata\nDB2 metadata was exported for ${db2Metadata.tableCount || 0} tables.\n\n- Resolved source-linked tables: ${db2Resolved}\n- Unresolved matches: ${db2Unresolved.length}\n- Ambiguous matches: ${db2Ambiguous.length}\n${db2Unresolved.length > 0 ? `- Unresolved table names: ${db2Unresolved.join(', ')}\n` : ''}${db2Ambiguous.length > 0 ? `- Ambiguous table names: ${db2Ambiguous.join(', ')}\n` : ''}\nSee:\n- ${db2Metadata.file || 'db2-metadata.json'}\n- ${db2Metadata.markdownFile || 'db2-metadata.md'}\n`
+    ? `## DB2 Metadata\nDB2 metadata was exported for ${db2Metadata.tableCount || 0} tables.\n\n- Resolved source-linked tables: ${db2Resolved}\n- Unresolved matches: ${db2Unresolved.length}\n- Ambiguous matches: ${db2Ambiguous.length}\n- Trigger count: ${db2TriggerCount}\n- Derived object count: ${db2DerivedObjectCount}\n- Catalog-resolved external objects: ${db2ExternalObjectCount}\n- Catalog-resolved program calls: ${db2CatalogResolvedProgramCount}\n- Catalog-resolved procedure references: ${db2CatalogResolvedProcedureCount}\n- Catalog fallback lookups: ${db2FallbackLookupCount}\n${db2Unresolved.length > 0 ? `- Unresolved table names: ${db2Unresolved.join(', ')}\n` : ''}${db2Ambiguous.length > 0 ? `- Ambiguous table names: ${db2Ambiguous.join(', ')}\n` : ''}\nSee:\n- ${db2Metadata.file || 'db2-metadata.json'}\n- ${db2Metadata.markdownFile || 'db2-metadata.md'}\n`
     : `## DB2 Metadata\nDB2 metadata export was skipped because ${db2Metadata.reason || 'no DB2 connection configuration was available'}.\n`;
   const testDataLinked = Array.isArray(testData.tables)
     ? testData.tables.filter((entry) => entry.sourceEvidenceCount > 0).length
@@ -255,7 +267,7 @@ function generateMarkdownReport(context, tokenReport) {
   const testDataSection = testData.status === 'exported'
     ? `## Test Data Extract\nSample data was extracted for ${testData.tableCount || 0} tables.\n\n- Row Limit per Table: ${testData.rowLimit || 0}\n- Source-linked extracted tables: ${testDataLinked}\n\nSee:\n- ${testData.file || 'test-data.json'}\n- ${testData.markdownFile || 'test-data.md'}\n`
     : `## Test Data Extract\nTest data extraction was skipped because ${testData.reason || 'no DB2 connection configuration was available'}.\n`;
-  const procedureSection = `## Procedure Semantics\n- Procedures: ${(procedureAnalysis.summary && procedureAnalysis.summary.procedureCount) || 0}\n- Prototypes: ${(procedureAnalysis.summary && procedureAnalysis.summary.prototypeCount) || 0}\n- Procedure Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.procedureCallCount) || 0}\n- Internal Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.internalCallCount) || 0}\n- External Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.externalCallCount) || 0}\n- Dynamic Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.dynamicCallCount) || 0}\n- Unresolved Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.unresolvedCallCount) || 0}\n`;
+  const procedureSection = `## Procedure Semantics\n- Procedures: ${(procedureAnalysis.summary && procedureAnalysis.summary.procedureCount) || 0}\n- Prototypes: ${(procedureAnalysis.summary && procedureAnalysis.summary.prototypeCount) || 0}\n- Procedure Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.procedureCallCount) || 0}\n- Internal Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.internalCallCount) || 0}\n- External Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.externalCallCount) || 0}\n- Dynamic Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.dynamicCallCount) || 0}\n- Unresolved Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.unresolvedCallCount) || 0}\n- Catalog-Resolved Calls: ${(procedureAnalysis.summary && procedureAnalysis.summary.catalogResolvedCallCount) || 0}\n`;
 
   return `# Zeus RPG Analysis Report\n\n## Overview\n- Program: ${context.program}\n- Scanned At: ${context.scannedAt}\n- Source Root: ${context.sourceRoot}\n- Source File Count: ${summary.sourceFileCount || 0}\n- Table Count: ${summary.tableCount || 0}\n- Program Call Count: ${summary.programCallCount || 0}\n- Copy Member Count: ${summary.copyMemberCount || 0}\n- SQL Statement Count: ${summary.sqlStatementCount || 0}\n${summary.text ? `- Summary: ${summary.text}\n` : ''}\n${optimizationSection(tokenReport)}\n## Source Files\n${sectionList(context.sourceFiles)}\n\n${sourceNormalizationSection(sourceNormalization)}\n${sourceTypeAnalysisSection(sourceTypeAnalysis)}\n${ifsPathSection(ifsPaths)}\n${searchResultsSection(searchResults)}\n${diagnosticPackSection(diagnosticPacks)}\n## Tables\n${sectionList(dependencies.tables)}\n\n## Program Calls\n${sectionList(dependencies.programCalls)}\n\n## Copy Members\n${sectionList(dependencies.copyMembers)}\n\n${procedureSection}\n${bindingAnalysisSection(bindingAnalysis)}\n${nativeFileUsageSection(nativeFileUsage)}\n${sqlSection(sql)}\n${db2Section}\n${testDataSection}\n## Dependency Graph\nDependency graph generated for ${context.program}.\n\n- Nodes: ${graph.nodeCount || 0}\n- Edges: ${graph.edgeCount || 0}\n- Tables: ${graph.tableCount || 0}\n- Programs Called: ${graph.programCallCount || 0}\n- Copy Members: ${graph.copyMemberCount || 0}\n- Modules: ${graph.moduleCount || 0}\n- Service Programs: ${graph.serviceProgramCount || 0}\n- Binding Directories: ${graph.bindingDirectoryCount || 0}\n- Bind Relationships: ${graph.bindEdgeCount || 0}\n\nSee files:\n- ${(graph.files && graph.files.json) || 'dependency-graph.json'}\n- ${(graph.files && graph.files.mermaid) || 'dependency-graph.mmd'}\n- ${(graph.files && graph.files.markdown) || 'dependency-graph.md'}\n\n## Cross Program Dependency Graph\nA recursive program dependency graph was generated for ${context.program}.\n\n- Programs discovered: ${crossProgramGraph.programCount || 0}\n- Ambiguous program calls: ${ambiguousPrograms.length}\n- Ambiguous list: ${ambiguousText}\n- Unresolved program calls: ${unresolvedPrograms.length}\n- Unresolved list: ${unresolvedText}\n\nSee:\n- ${(crossProgramGraph.files && crossProgramGraph.files.json) || 'program-call-tree.json'}\n- ${(crossProgramGraph.files && crossProgramGraph.files.mermaid) || 'program-call-tree.mmd'}\n- ${(crossProgramGraph.files && crossProgramGraph.files.markdown) || 'program-call-tree.md'}\n\n## Impact Analysis\nImpact analysis can identify affected programs if a component changes.\n\nSee:\n- impact-analysis.json\n- impact-analysis.md\n\n## Interactive Architecture Viewer\nAn interactive architecture visualization has been generated.\n\nOpen:\n- architecture.html\n\nin your browser to explore program dependencies visually.\n\n## Architecture\n- See architecture-report.md for a full architecture overview.\n\n## Next Steps\n- Validate detected dependencies with the application design and naming standards.\n- Use canonical-analysis.json as the semantic source and context.json or optimized-context.json as prompt-ready projections.\n- Enrich with DB metadata, search results, and sample test data when available to improve reasoning.\n- Create a portable bundle with \`zeus bundle --program ${context.program}\`.\n`;
 }

--- a/src/sharing/safeSharingArtifactBuilder.js
+++ b/src/sharing/safeSharingArtifactBuilder.js
@@ -256,14 +256,20 @@ function createRedactor({ sourceArtifactPaths, safeArtifactPaths, analyzeManifes
         '.rootProgram',
         '.program',
         '.ownerProgram',
+        '.catalogSystemName',
+        '.catalogSqlName',
       ])
       || isPathFragment(pathValue, [
         '.entities.programs.[].name',
+        '.entities.externalObjects.[].name',
         '.dependencies.programCalls.[].name',
         '.programCalls.[].name',
         '.unresolvedPrograms.[]',
         '.ambiguousPrograms.[]',
         '.primaryCalls.[]',
+        '.externalObjects.[].requestedName',
+        '.externalObjects.[].sqlName',
+        '.externalObjects.[].systemName',
       ])
     ) {
       registerCategoryValue('PROGRAM', value);
@@ -277,12 +283,18 @@ function createRedactor({ sourceArtifactPaths, safeArtifactPaths, analyzeManifes
         '.sqlStatements.[].tables.[',
         '.sql.statements.[].tables.[',
         '.db2Metadata.tables.[].requestedName',
+        '.db2Metadata.tables.[].displayName',
         '.db2Metadata.tables.[].table',
+        '.db2Metadata.tables.[].systemName',
         '.db2Tables.[].requestedName',
+        '.db2Tables.[].displayName',
         '.db2Tables.[].table',
+        '.db2Tables.[].systemName',
         '.testData.tables.[].table',
+        '.testData.tables.[].systemName',
         '.tableLinks.[].requestedName',
         '.matches.[].table',
+        '.matches.[].systemName',
         '.unresolvedTables.[]',
       ])
     ) {
@@ -377,7 +389,7 @@ function createRedactor({ sourceArtifactPaths, safeArtifactPaths, analyzeManifes
     }
 
     if (
-      pathEndsWith(pathValue, ['.schema', '.referencesSchema'])
+      pathEndsWith(pathValue, ['.schema', '.referencesSchema', '.systemSchema', '.library', '.catalogLibrary', '.catalogSchema', '.programLibrary'])
       || isPathFragment(pathValue, ['.matchedSchemas.[]'])
     ) {
       registerCategoryValue('SCHEMA', value);

--- a/tests/ai-knowledge-projection.test.js
+++ b/tests/ai-knowledge-projection.test.js
@@ -86,7 +86,8 @@ test('buildPrompt consumes ai-knowledge projection workflows', () => {
         documentation: {
           summary: 'Program ORDERPGM reads ORDERS.',
           tables: [{ name: 'ORDERS', kind: 'TABLE' }],
-          programCalls: [{ name: 'INVPGM', kind: 'PROGRAM' }],
+          programCalls: [{ name: 'INVPGM', kind: 'PROGRAM', resolutionSource: 'CATALOG', catalogObjectType: '*PGM' }],
+          procedureCalls: [{ target: 'POSTINV', resolutionSource: 'CATALOG', catalogObjectType: '*SRVPGM' }],
           copyMembers: [],
           sqlStatements: [{ type: 'SELECT', intent: 'READ', tables: ['ORDERS'], text: 'select * from orders' }],
           riskMarkers: ['Dynamic SQL detected'],
@@ -106,6 +107,7 @@ test('buildPrompt consumes ai-knowledge projection workflows', () => {
     };
 
     const content = buildPrompt('documentation', projection, outputPath);
+    assert.match(content, /catalog-resolved rather than source-resolved/i);
     assert.match(content, /Risk markers: Dynamic SQL detected\./);
     assert.match(content, /Uncertainty markers: DYNAMIC_SQL\./);
     assert.match(content, /Evidence Highlights/);
@@ -161,12 +163,23 @@ test('buildAiKnowledgeProjection carries DB2 metadata and test data links into w
       unresolvedTableCount: 0,
       ambiguousTableCount: 0,
       tables: [
-        buildCompactDb2TableLink(tableLink, {
+        {
+          ...buildCompactDb2TableLink(tableLink, {
+            schema: 'SCHEMA_001',
+            table: 'TABLE_001',
+            systemSchema: 'SCHEMA_001',
+            systemName: 'TABLE001',
+            objectType: 'TABLE',
+            textDescription: 'Primary customer table',
+            estimatedRowCount: 25,
+            columns: [{ name: 'COLUMN_001', type: 'DECIMAL' }],
+            foreignKeys: [],
+            triggers: [{ name: 'TRG_001' }],
+            derivedObjects: [{ name: 'VIEW_001' }],
+          }),
           schema: 'SCHEMA_001',
           table: 'TABLE_001',
-          columns: [{ name: 'COLUMN_001', type: 'DECIMAL' }],
-          foreignKeys: [],
-        }),
+        },
       ],
     };
     context.testData = {
@@ -191,6 +204,9 @@ test('buildAiKnowledgeProjection carries DB2 metadata and test data links into w
 
     assert.equal(projection.entities.db2Tables.length, 1);
     assert.equal(projection.entities.db2Tables[0].table, 'TABLE_001');
+    assert.equal(projection.entities.db2Tables[0].systemName, 'TABLE001');
+    assert.equal(projection.entities.db2Tables[0].triggerCount, 1);
+    assert.equal(projection.entities.db2Tables[0].derivedObjectCount, 1);
     assert.ok(projection.entities.db2Tables[0].evidenceRefs.length >= 1);
     assert.equal(projection.workflows.documentation.db2Tables.length, 1);
     assert.equal(projection.workflows.documentation.testData.tables.length, 1);

--- a/tests/db2-catalog-intelligence.test.js
+++ b/tests/db2-catalog-intelligence.test.js
@@ -1,0 +1,210 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { buildCanonicalAnalysisModel } = require('../src/context/canonicalAnalysisModel');
+const { buildContext } = require('../src/context/contextBuilder');
+const { buildDb2SourceLinkage } = require('../src/db2/db2EvidenceLinker');
+const { buildDb2CatalogSemanticUpdates } = require('../src/db2/catalogSemanticModel');
+const { buildExtractionPlan } = require('../src/db2/testDataExportService');
+
+function createCanonicalFixture(tempRoot) {
+  const sourceFile = path.join(tempRoot, 'ORDERPGM.rpgle');
+  fs.writeFileSync(sourceFile, '      * ENTRY\n', 'utf8');
+
+  const canonicalAnalysis = buildCanonicalAnalysisModel({
+    program: 'ORDERPGM',
+    sourceRoot: tempRoot,
+    sourceFiles: [{
+      path: sourceFile,
+      sizeBytes: 16,
+      lines: 1,
+      sourceType: 'RPGLE',
+    }],
+    dependencies: {
+      tables: [{
+        name: 'CUSTPF',
+        evidence: [{ file: sourceFile, line: 10 }],
+      }],
+      calls: [{
+        name: 'INVOICEP',
+        evidence: [{ file: sourceFile, line: 22 }],
+      }],
+      copyMembers: [],
+      sqlStatements: [],
+      procedures: [],
+      prototypes: [{
+        name: 'POSTINV',
+        ownerProgram: 'ORDERPGM',
+        sourceFile,
+        startLine: 30,
+        endLine: 30,
+        sourceForm: 'FREE',
+        imported: true,
+        externalName: 'POSTINV',
+        evidence: [{ file: sourceFile, line: 30 }],
+      }],
+      procedureCalls: [],
+      nativeFiles: [],
+      nativeFileAccesses: [],
+      modules: [],
+      bindingDirectories: [],
+      servicePrograms: [],
+    },
+    notes: [],
+  });
+
+  return {
+    canonicalAnalysis,
+    context: buildContext({ canonicalAnalysis }),
+  };
+}
+
+test('DB2 linkage resolves requested tables by SQL name or system name', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-db2-catalog-linkage-'));
+  try {
+    const { canonicalAnalysis, context } = createCanonicalFixture(tempRoot);
+    const exportedTables = [{
+      schema: 'APP',
+      table: 'CUSTOMERS',
+      systemSchema: 'APP',
+      systemName: 'CUSTPF',
+      objectType: 'TABLE',
+      lookupStrategy: 'IBM_I_CATALOG',
+      columns: [{ name: 'CUSTNO', type: 'DECIMAL' }],
+      foreignKeys: [],
+      triggers: [],
+      derivedObjects: [],
+    }];
+
+    const linkage = buildDb2SourceLinkage({
+      requestedTables: ['CUSTPF', 'CUSTOMERS'],
+      exportedTables,
+      canonicalAnalysis,
+      context,
+    });
+
+    const systemNameLink = linkage.tableLinks.find((entry) => entry.requestedName === 'CUSTPF');
+    const sqlNameLink = linkage.tableLinks.find((entry) => entry.requestedName === 'CUSTOMERS');
+
+    assert.equal(systemNameLink.matchStatus, 'resolved');
+    assert.equal(systemNameLink.matches[0].matchType, 'SYSTEM_NAME');
+    assert.equal(sqlNameLink.matchStatus, 'resolved');
+    assert.equal(sqlNameLink.matches[0].matchType, 'SQL_NAME');
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('DB2 test-data extraction plan matches metadata by dual name and skips ambiguous matches', () => {
+  const metadataPayload = {
+    tables: [
+      {
+        schema: 'APP',
+        table: 'CUSTOMERS',
+        systemSchema: 'APP',
+        systemName: 'CUSTPF',
+        columns: [{ name: 'CUSTNO', primaryKey: true }],
+      },
+      {
+        schema: 'APP2',
+        table: 'CUSTOMERS_ARCHIVE',
+        systemSchema: 'APP2',
+        systemName: 'CUSTPF',
+        columns: [{ name: 'CUSTNO', primaryKey: true }],
+      },
+    ],
+  };
+
+  const resolvedPlan = buildExtractionPlan({
+    requestedTables: [{ schema: '', table: 'CUSTOMERS' }],
+    metadataPayload,
+    defaultSchema: 'APP',
+  });
+  const ambiguousPlan = buildExtractionPlan({
+    requestedTables: [{ schema: '', table: 'CUSTPF' }],
+    metadataPayload,
+    defaultSchema: 'APP',
+  });
+
+  assert.equal(resolvedPlan[0].status, 'pending');
+  assert.equal(resolvedPlan[0].table, 'CUSTOMERS');
+  assert.equal(resolvedPlan[0].systemName, 'CUSTPF');
+
+  const skippedEntry = ambiguousPlan.find((entry) => entry.table === 'CUSTPF' && entry.status === 'skipped');
+  assert.ok(skippedEntry);
+  assert.match(skippedEntry.note, /matched multiple DB2 catalog objects/i);
+});
+
+test('DB2 catalog semantic updates attach table identity, trigger relations, FK rules, and external object resolution', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-db2-semantic-updates-'));
+  try {
+    const { canonicalAnalysis, context } = createCanonicalFixture(tempRoot);
+    const exportedTables = [{
+      schema: 'APP',
+      table: 'CUSTOMERS',
+      systemSchema: 'APP',
+      systemName: 'CUSTPF',
+      objectType: 'TABLE',
+      textDescription: 'Customer master',
+      estimatedRowCount: 2400,
+      lookupStrategy: 'IBM_I_CATALOG',
+      columns: [{ name: 'CUSTNO', type: 'DECIMAL', primaryKey: true }],
+      foreignKeys: [{
+        column: 'COMPANY',
+        referencesSchema: 'APP',
+        referencesTable: 'COMPANY',
+        referencesColumn: 'COMPANY',
+        deleteRule: 'CASCADE',
+        updateRule: 'RESTRICT',
+      }],
+      triggers: [{
+        schema: 'APP',
+        name: 'CUSTOMER_AUDIT',
+        eventManipulation: 'INSERT',
+        actionTiming: 'AFTER',
+        actionOrientation: 'ROW',
+      }],
+      derivedObjects: [{
+        schema: 'APP',
+        name: 'CUSTOMERS_VIEW',
+        objectType: 'VIEW',
+      }],
+    }];
+    const linkage = buildDb2SourceLinkage({
+      requestedTables: ['CUSTPF'],
+      exportedTables,
+      canonicalAnalysis,
+      context,
+    });
+
+    const updates = buildDb2CatalogSemanticUpdates({
+      canonicalAnalysis,
+      tableLinks: linkage.tableLinks,
+      exportedTables,
+      externalObjects: [{
+        requestedName: 'INVOICEP',
+        library: 'APP',
+        schema: 'APP',
+        sqlName: 'INVOICE_PROCESS',
+        systemName: 'INVOICEP',
+        objectType: '*PGM',
+        evidenceSource: 'OBJECT_STATISTICS',
+        matchedBy: 'SYSTEM_NAME',
+      }],
+    });
+
+    assert.ok(updates.entities.tables.some((entry) => entry.db2Identity && entry.db2Identity.systemName === 'CUSTPF'));
+    assert.ok(updates.entities.db2Triggers.some((entry) => entry.name === 'CUSTOMER_AUDIT'));
+    assert.ok(updates.entities.externalObjects.some((entry) => entry.systemName === 'INVOICEP'));
+    assert.ok(updates.entities.programs.some((entry) => entry.name === 'INVOICEP' && entry.resolutionSource === 'CATALOG'));
+    assert.ok(updates.relations.some((entry) => entry.type === 'HAS_TRIGGER'));
+    assert.ok(updates.relations.some((entry) => entry.type === 'DERIVES_OBJECT'));
+    assert.ok(updates.relations.some((entry) => entry.type === 'REFERENCES_TABLE' && entry.attributes.deleteRule === 'CASCADE'));
+    assert.ok(updates.relations.some((entry) => entry.type === 'RESOLVES_TO_EXTERNAL_OBJECT'));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- promote DB2 catalog enrichment into a stronger first-class analysis stage instead of a thin JDBC appendix
- preserve SQL-name and system-name identity across DB2 metadata, test-data lookup, canonical analysis, prompts, and reports
- model DB2 triggers, derived objects, foreign-key rules, and catalog-resolved external IBM i objects in the semantic output

## Validation
- node --test tests/db2-catalog-intelligence.test.js
- node --test tests/db2-evidence-linker.test.js
- node --test tests/ai-knowledge-projection.test.js
- npm test
- node cli/zeus.js analyze --list-modes
- node cli/zeus.js workflow --list-presets
- node cli/zeus.js

Closes #85
Closes #86
Closes #87
Closes #88