### PR TITLE
Add analyzer stage registry, offline viewer, and local UI shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ Impact command syntax:
 zeus impact --target <name> [--program <name>] [--out <path>] [--profile <name>] [--source <path>] [--reproducible] [--verbose]
 ```
 
+Local UI shell syntax:
+
+```bash
+zeus serve [--source-output-root <path>] [--profile <name>] [--host 127.0.0.1] [--port <n>] [--verbose]
+```
+
 Fetch source syntax:
 
 ```bash
@@ -506,6 +512,38 @@ zeus analyze --source ./rpg_sources --program ORDERPGM
 Output:
 
 - `output/ORDERPGM/architecture.html`
+
+## Local UI Shell
+
+Zeus now also includes a first local-only UI shell over the existing output contract.
+
+Purpose:
+
+- browse completed analysis runs without reparsing artifacts in the browser
+- expose a stable read-only internal API for future richer UI work
+- keep CLI workflows and UI workflows on the same manifest and artifact model
+
+Current behavior:
+
+- `zeus serve --source-output-root ./output` starts a loopback-only HTTP server
+- the HTML shell at `/` uses the JSON API instead of reading files directly
+- the shell lists runs, shows manifest-derived summary metadata, and previews JSON, Markdown, and HTML artifacts on demand
+
+Current API endpoints:
+
+- `GET /api/health`
+- `GET /api/runs`
+- `GET /api/runs/:program`
+- `GET /api/runs/:program/artifacts/content?path=...`
+- `GET /runs/:program/artifacts/raw?path=...`
+
+Example:
+
+```bash
+zeus serve --source-output-root ./output --port 4782
+```
+
+Open the printed local URL in a browser to inspect available runs.
 
 ## Impact Analysis
 
@@ -986,6 +1024,7 @@ See [docs/import-manifest-contract.md](/c:/Java/workspace-java/zeus-rpg-promptki
 See [docs/source-ingest-normalization.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/source-ingest-normalization.md) for the analyze-time normalization contract and current CL/DDS scanner depth.
 See [docs/investigation-workflows.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/investigation-workflows.md) for the new IFS-path, full-text search, diagnostic-pack, and prompt-pack workflow additions.
 See [docs/analyzer-stage-pipeline.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/analyzer-stage-pipeline.md) for the registry-backed analyze stage contract and plugin seam.
+See [docs/local-ui-shell.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/local-ui-shell.md) for the read-only local UI shell and API contract.
 See [docs/viewer-asset-strategy.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/viewer-asset-strategy.md) for the offline viewer packaging strategy and licensing note.
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ It helps teams quickly produce consistent analysis artifacts from legacy RPG sou
 - `src/context/contextBuilder.js` - Backward-compatible `context.json` projection builder
 - `src/dependency/dependencyGraphBuilder.js` - Deterministic dependency graph model builder
 - `src/dependency/crossProgramGraphBuilder.js` - Recursive multi-program dependency graph builder
+- `src/analyze/stageRegistry.js` - Registry-backed analyzer stage and lifecycle hook wiring
 - `src/dependency/programSourceResolver.js` - Local program name to source file resolver
 - `src/dependency/graphSerializer.js` - Dependency graph serializers (JSON/Mermaid/Markdown wrapper)
 - `src/viewer/architectureViewerGenerator.js` - Generates interactive `architecture.html` from `program-call-tree.json`
@@ -173,11 +174,13 @@ Investigation options extend the same analyze pipeline and output contract:
 Analyze now runs through a split runtime contract:
 
 - `runAnalyzeCore(...)` executes semantic analysis without writing reports, prompts, or viewer files
+- core analyze stages are registered through a deterministic stage registry so new internal stages can be added without rewriting CLI control flow
 - the CLI applies an explicit artifact-writer adapter afterwards so future UI/API layers can reuse the same core result contract
 - source scans are cached by content hash and tool version under `output/.zeus-cache/source-scans/`
 - DB2 metadata and test-data artifacts are reused through `analysis-cache.json` when inputs are unchanged
 - cross-program traversal now applies explicit safety limits for depth, program count, nodes, edges, scanned files, and per-program outgoing calls
 - when those limits are reached, Zeus keeps the run successful but records truncation and limit diagnostics in `context.json`, `report.md`, and the analyze manifest instead of silently over-walking large trees
+- stage definitions, stage metadata, and stage diagnostics are recorded in `analysis-diagnostics.json` and `analyze-run-manifest.json`
 
 Bundle command syntax:
 
@@ -472,12 +475,19 @@ Purpose:
 
 Rendering details:
 
-- visualization library: `vis-network` loaded via CDN
+- visualization library: bundled `vis-network` pinned from the project lockfile and inlined into the generated HTML
+- no external `<script src=...>` dependency at runtime
 - node type colors:
   - `PROGRAM` -> blue
   - `TABLE` -> green
   - `COPY` -> orange
 - hierarchical top-down layout (`UD`) to keep the root program at the top
+
+Portability details:
+
+- works offline after the output folder or bundle is copied elsewhere
+- stays version-stable because the bundled viewer bytes come from the pinned dependency version, not a CDN
+- safe-sharing artifacts reuse the same self-contained viewer strategy
 
 Interactions:
 
@@ -975,6 +985,8 @@ See [docs/reproducible-output-mode.md](/c:/Java/workspace-java/zeus-rpg-promptki
 See [docs/import-manifest-contract.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/import-manifest-contract.md) for the public fetch provenance manifest contract.
 See [docs/source-ingest-normalization.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/source-ingest-normalization.md) for the analyze-time normalization contract and current CL/DDS scanner depth.
 See [docs/investigation-workflows.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/investigation-workflows.md) for the new IFS-path, full-text search, diagnostic-pack, and prompt-pack workflow additions.
+See [docs/analyzer-stage-pipeline.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/analyzer-stage-pipeline.md) for the registry-backed analyze stage contract and plugin seam.
+See [docs/viewer-asset-strategy.md](/c:/Java/workspace-java/zeus-rpg-promptkit/docs/viewer-asset-strategy.md) for the offline viewer packaging strategy and licensing note.
 
 ## Notes
 

--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -19,6 +19,7 @@ const { runImpact } = require('../src/cli/commands/impactCommand');
 const { runBundle } = require('../src/cli/commands/bundleCommand');
 const { runFetch } = require('../src/cli/commands/fetchCommand');
 const { runWorkflow } = require('../src/cli/commands/workflowCommand');
+const { runServe } = require('../src/cli/commands/serveCommand');
 
 function printHelp() {
   console.log('Usage:');
@@ -27,6 +28,7 @@ function printHelp() {
   console.log('  zeus bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--safe-sharing] [--reproducible] [--profile <name>] [--verbose]');
   console.log('  zeus impact --target <name> [--program <name>] [--out <path>] [--profile <name>] [--source <path>] [--reproducible] [--verbose]');
   console.log('  zeus fetch --host <hostname> --user <username> --password <password> --source-lib <lib> --ifs-dir <ifsPath> --out <localPath> [--files <list>] [--members <list>] [--replace true|false] [--streamfile-ccsid <ccsid>] [--transport auto|sftp|jt400|ftp] [--profile <name>] [--verbose]');
+  console.log('  zeus serve [--source-output-root <path>] [--profile <name>] [--host 127.0.0.1] [--port <n>] [--verbose]');
 }
 
 function parseArgs(argv) {
@@ -76,6 +78,11 @@ async function main() {
 
   if (command === 'fetch') {
     await runFetch(args);
+    return;
+  }
+
+  if (command === 'serve') {
+    await runServe(args);
     return;
   }
 

--- a/docs/analyzer-stage-pipeline.md
+++ b/docs/analyzer-stage-pipeline.md
@@ -1,0 +1,93 @@
+# Analyzer Stage Pipeline
+
+The analyze runtime is now built around a registry-backed stage pipeline instead of one hard-coded stage list in the CLI path.
+
+## Goals
+
+- keep `runAnalyzeCore(...)` as the semantic-core entry point
+- allow new internal stages to be added without editing multiple orchestration paths
+- preserve deterministic stage ordering and artifact contracts
+- expose stage metadata and diagnostics for manifests and debugging
+
+## Stage contract
+
+Each analyze stage is a plain object with:
+
+- `id`: stable unique stage identifier
+- `run(state)`: synchronous stage execution function returning the next state object
+- `title` (optional): human-readable label for manifests and debugging
+- `description` (optional): short explanation of what the stage does
+- `category` (optional): coarse grouping such as `scan`, `analysis`, `db2`, or `investigation`
+- `before` / `after` (optional): ordering anchors against other stage ids
+- `beforeRun`, `afterRun`, `onError` (optional): stage-local lifecycle hooks
+
+Stage output stays on the existing runtime contract:
+
+- merge additional state into the returned object
+- expose stage-local debug metadata through `stageMetadata`
+- expose stage-local warnings or notes through `stageDiagnostics`
+
+## Registry contract
+
+`createAnalyzeStageRegistry()` supports:
+
+- `registerStage(definition)`
+- `registerLifecycleHooks(hooks)`
+- `use(plugin)`
+- `resolveStages()`
+- `resolveLifecycleHooks()`
+
+Registered stages are ordered through deterministic topological sorting:
+
+- registration order is the stable tiebreaker
+- `before` and `after` anchors are validated
+- unknown anchors fail fast
+- cycles fail fast
+
+## Plugin contract
+
+An analyze plugin is an internal object with:
+
+- `name`
+- `register(api)`
+
+The `register(api)` callback receives:
+
+- `registerStage(definition)`
+- `registerLifecycleHooks(hooks)`
+- `listStages()`
+- `listLifecycleHooks()`
+
+This is intentionally an internal extension seam, not a public plugin marketplace. The current goal is to let new analyzer stages be introduced behind a stable contract while keeping CLI behavior deterministic.
+
+## Lifecycle hooks
+
+Lifecycle hooks are observational by design. They allow instrumentation and reporting without replacing the stage run loop.
+
+Supported hooks:
+
+- `beforeStage({ stage, state })`
+- `afterStage({ stage, state, nextState, stageReport })`
+- `onStageError({ stage, state, error, stageReport })`
+
+The built-in runner also records stage definition metadata in:
+
+- `analysis-diagnostics.json`
+- `analyze-run-manifest.json`
+
+That metadata includes the resolved plugin owner, category, ordering anchors, and registration order for each executed stage.
+
+## Built-in stages
+
+Current core stages are still the same semantic pipeline:
+
+1. `collect-scan`
+2. `build-context`
+3. `investigate-sources`
+4. `optimize-context`
+5. `export-db2`
+6. `export-test-data`
+7. `run-diagnostic-packs`
+8. `write-artifacts`
+
+Only the registration mechanism changed. The output contract and generated artifact set remain backward-compatible.

--- a/docs/local-ui-shell.md
+++ b/docs/local-ui-shell.md
@@ -1,0 +1,35 @@
+# Local UI Shell
+
+The first local UI slice is intentionally small and read-only. It exists to browse generated analysis runs without introducing a separate parsing layer in the browser.
+
+## Command
+
+```bash
+zeus serve --source-output-root ./output --port 4782
+```
+
+Behavior:
+
+- binds to loopback only (`127.0.0.1` by default)
+- serves a local HTML shell and a read-only JSON API
+- reads existing analyze output directories; it does not run analysis itself
+- reuses the current manifest and artifact contracts instead of introducing a parallel storage model
+
+## API endpoints
+
+- `GET /api/health`
+- `GET /api/runs`
+- `GET /api/runs/:program`
+- `GET /api/runs/:program/artifacts/content?path=...`
+- `GET /runs/:program/artifacts/raw?path=...`
+
+The browser shell consumes only those endpoints. It does not parse output directories directly.
+
+## Current shell scope
+
+- list analysis runs under the configured output root
+- show manifest-derived run summary details
+- enumerate available artifacts, including `safe-sharing/` variants
+- preview JSON, Markdown, and HTML artifacts on demand
+
+This is the API-and-shell foundation for future richer views. It is not yet the full interactive exploration layer described in the later UI issues.

--- a/docs/viewer-asset-strategy.md
+++ b/docs/viewer-asset-strategy.md
@@ -1,0 +1,45 @@
+# Viewer Asset Strategy
+
+The generated `architecture.html` artifact is intended to be portable and usable in restricted local environments. It therefore cannot depend on a CDN-hosted runtime script.
+
+## Current strategy
+
+- `architecture.html` is generated as a self-contained local artifact
+- the viewer bundles `vis-network` inline at generation time
+- the pinned package version comes from the project dependency lockfile
+- no extra local server or adjacent asset directory is required for basic viewing
+
+## Why inline instead of CDN
+
+- offline corporate environments often block external package CDNs
+- bundled analysis ZIP files should remain usable after being copied elsewhere
+- a pinned dependency avoids future behavior drift from whatever version a CDN serves later
+- safe-sharing artifacts should preserve the same local usability contract
+
+## Bundled library details
+
+Current bundled source:
+
+- package: `vis-network`
+- asset path: `vis-network/standalone/umd/vis-network.min.js`
+- source mode: inline in generated HTML
+
+The analyzer also records viewer asset metadata in the artifact-writer stage metadata so manifests and diagnostics can show which viewer asset version was used for a run.
+
+## Licensing note
+
+`vis-network` is distributed under a dual `(Apache-2.0 OR MIT)` license according to the package metadata currently pinned in this repository.
+
+Implications for Zeus:
+
+- the project pins the library version in `package.json` / `package-lock.json`
+- generated HTML includes the bundled runtime bytes needed for local use
+- future dependency upgrades should review the package metadata again before changing the pinned version
+
+## Verification
+
+Offline viewer verification currently checks that:
+
+- generated `architecture.html` contains no external `<script src=...>` reference
+- the old CDN URL is absent
+- smoke and reproducibility tests continue to pass with the self-contained viewer artifact

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "adm-zip": "^0.5.16",
         "basic-ftp": "^5.0.5",
-        "ssh2-sftp-client": "^11.0.0"
+        "ssh2-sftp-client": "^11.0.0",
+        "vis-network": "10.0.2"
       },
       "bin": {
         "zeus": "cli/zeus.js"
@@ -19,6 +20,26 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/adm-zip": {
       "version": "0.5.16",
@@ -71,6 +92,19 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-2.0.0.tgz",
+      "integrity": "sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
@@ -111,6 +145,13 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/keycharm": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.4.0.tgz",
+      "integrity": "sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peer": true
     },
     "node_modules/nan": {
       "version": "2.25.0",
@@ -242,6 +283,71 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vis-data": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-8.0.3.tgz",
+      "integrity": "sha512-jhnb6rJNqkKR1Qmlay0VuDXY9ZlvAnYN1udsrP4U+krgZEq7C0yNSKdZqmnCe13mdnf9AdVcdDGFOzy2mpPoqw==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "vis-util": ">=6.0.0"
+      }
+    },
+    "node_modules/vis-network": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-10.0.2.tgz",
+      "integrity": "sha512-qPl8GLYBeHEFqiTqp4VBbYQIJ2EA8KLr7TstA2E8nJxfEHaKCU81hQLz7hhq11NUpHbMaRzBjW5uZpVKJ45/wA==",
+      "license": "(Apache-2.0 OR MIT)",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0 || ^2.0.0",
+        "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
+        "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^13.0.0",
+        "vis-data": ">=8.0.0",
+        "vis-util": ">=6.0.0"
+      }
+    },
+    "node_modules/vis-util": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-6.0.0.tgz",
+      "integrity": "sha512-qtpts3HRma0zPe4bO7t9A2uejkRNj8Z2Tb6do6lN85iPNWExFkUiVhdAq5uLGIUqBFduyYeqWJKv/jMkxX0R5g==",
+      "license": "(Apache-2.0 OR MIT)",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/visjs"
+      },
+      "peerDependencies": {
+        "@egjs/hammerjs": "^2.0.0",
+        "component-emitter": "^1.3.0 || ^2.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "echo \"No lint configured\"",
     "test": "npm run test:ci && npm run test:unit",
     "test:ci": "npm run test:contract && npm run test:smoke",
-    "test:unit": "npm run test:corpus && node --test tests/analyze-stages.test.js tests/source-scan-cache.test.js tests/analyze-runtime-contract.test.js tests/analyze-governance-config.test.js tests/binding-semantics.test.js tests/source-normalization.test.js tests/source-integrity.test.js tests/source-type-scanners.test.js tests/db2-catalog-intelligence.test.js tests/impact-ambiguity.test.js tests/investigation-workflows.test.js tests/runtime-config.test.js tests/source-catalog.test.js",
+    "test:unit": "npm run test:corpus && node --test tests/analyze-stages.test.js tests/analyze-stage-registry.test.js tests/architecture-viewer.test.js tests/source-scan-cache.test.js tests/analyze-runtime-contract.test.js tests/analyze-governance-config.test.js tests/binding-semantics.test.js tests/source-normalization.test.js tests/source-integrity.test.js tests/source-type-scanners.test.js tests/db2-catalog-intelligence.test.js tests/impact-ambiguity.test.js tests/investigation-workflows.test.js tests/runtime-config.test.js tests/source-catalog.test.js",
     "test:contract": "node --test tests/analyze-run-manifest.test.js tests/bundle-manifest.test.js tests/fetch-readability-contract.test.js tests/ai-knowledge-projection.test.js tests/task-oriented-analysis-index.test.js tests/workflow-presets.test.js",
     "test:smoke": "node --test tests/v1-smoke.test.js tests/safe-sharing.test.js tests/reproducible-output.test.js",
     "test:corpus": "node --test tests/scanner-corpus.test.js",
@@ -23,7 +23,8 @@
   "dependencies": {
     "adm-zip": "^0.5.16",
     "basic-ftp": "^5.0.5",
-    "ssh2-sftp-client": "^11.0.0"
+    "ssh2-sftp-client": "^11.0.0",
+    "vis-network": "10.0.2"
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "echo \"No lint configured\"",
     "test": "npm run test:ci && npm run test:unit",
     "test:ci": "npm run test:contract && npm run test:smoke",
-    "test:unit": "npm run test:corpus && node --test tests/analyze-stages.test.js tests/analyze-stage-registry.test.js tests/architecture-viewer.test.js tests/source-scan-cache.test.js tests/analyze-runtime-contract.test.js tests/analyze-governance-config.test.js tests/binding-semantics.test.js tests/source-normalization.test.js tests/source-integrity.test.js tests/source-type-scanners.test.js tests/db2-catalog-intelligence.test.js tests/impact-ambiguity.test.js tests/investigation-workflows.test.js tests/runtime-config.test.js tests/source-catalog.test.js",
+    "test:unit": "npm run test:corpus && node --test tests/analyze-stages.test.js tests/analyze-stage-registry.test.js tests/architecture-viewer.test.js tests/local-ui-server.test.js tests/source-scan-cache.test.js tests/analyze-runtime-contract.test.js tests/analyze-governance-config.test.js tests/binding-semantics.test.js tests/source-normalization.test.js tests/source-integrity.test.js tests/source-type-scanners.test.js tests/db2-catalog-intelligence.test.js tests/impact-ambiguity.test.js tests/investigation-workflows.test.js tests/runtime-config.test.js tests/source-catalog.test.js",
     "test:contract": "node --test tests/analyze-run-manifest.test.js tests/bundle-manifest.test.js tests/fetch-readability-contract.test.js tests/ai-knowledge-projection.test.js tests/task-oriented-analysis-index.test.js tests/workflow-presets.test.js",
     "test:smoke": "node --test tests/v1-smoke.test.js tests/safe-sharing.test.js tests/reproducible-output.test.js",
     "test:corpus": "node --test tests/scanner-corpus.test.js",

--- a/src/analyze/analyzeArtifactWriter.js
+++ b/src/analyze/analyzeArtifactWriter.js
@@ -18,7 +18,10 @@ const { generateMarkdownReport } = require('../report/markdownReport');
 const { writeJsonReport } = require('../report/jsonReport');
 const { generateArchitectureReport } = require('../report/architectureReport');
 const { buildAiKnowledgeProjection } = require('../ai/knowledgeProjection');
-const { generateArchitectureViewer } = require('../viewer/architectureViewerGenerator');
+const {
+  generateArchitectureViewer,
+  getArchitectureViewerAssetMetadata,
+} = require('../viewer/architectureViewerGenerator');
 const { buildAnalysisIndex } = require('../workflow/analysisIndex');
 const { getPromptContract } = require('../prompt/promptRegistry');
 const { renderIfsPathMarkdown } = require('../investigation/ifsPathScanner');
@@ -50,6 +53,7 @@ function buildAnalysisDiagnostics(state) {
       id: stage.id,
       status: stage.status,
       durationMs: stage.durationMs,
+      definition: stage.definition || null,
       metadata: stage.metadata || {},
       diagnostics: stage.diagnostics || [],
     })) : [],
@@ -136,6 +140,7 @@ function writeAnalyzeArtifacts(state) {
     'report.md',
     ...(emitDiagnostics ? ['analysis-diagnostics.json'] : []),
   ];
+  const viewerAssetMetadata = getArchitectureViewerAssetMetadata();
   const analysisIndex = buildAnalysisIndex({
     canonicalAnalysis,
     context,
@@ -242,6 +247,7 @@ function writeAnalyzeArtifacts(state) {
       workflowPreset: workflowPreset ? workflowPreset.name : null,
       promptTemplateCount: selectedPromptTemplates.length,
       diagnosticsFileWritten: Boolean(emitDiagnostics),
+      viewerAsset: viewerAssetMetadata,
     },
   };
 }

--- a/src/analyze/analyzePipeline.js
+++ b/src/analyze/analyzePipeline.js
@@ -48,6 +48,7 @@ const {
   writeAnalysisArtifactCache,
 } = require('./analysisArtifactCache');
 const { resolveTimestamp } = require('../reproducibility/reproducibility');
+const { createAnalyzeStageRegistry } = require('./stageRegistry');
 
 function resolvePromptContext(context, optimizedContext) {
   return optimizedContext || context;
@@ -824,20 +825,93 @@ function runDiagnosticPacksStage(state) {
   };
 }
 
-function getAnalyzeCoreStages() {
-  return [
-    { id: 'collect-scan', run: collectAndScanStage },
-    { id: 'build-context', run: buildContextStage },
-    { id: 'investigate-sources', run: investigateSourcesStage },
-    { id: 'optimize-context', run: optimizeContextStage },
-    { id: 'export-db2', run: exportDb2Stage },
-    { id: 'export-test-data', run: exportTestDataStage },
-    { id: 'run-diagnostic-packs', run: runDiagnosticPacksStage },
-  ];
+function registerCoreAnalyzeStages(registry) {
+  registry.registerStage({
+    id: 'collect-scan',
+    title: 'Collect and scan source files',
+    description: 'Discovers source files, validates encodings, and runs the base scanner suite.',
+    category: 'scan',
+    run: collectAndScanStage,
+  });
+  registry.registerStage({
+    id: 'build-context',
+    title: 'Build semantic context',
+    description: 'Builds canonical/context projections and the dependency graphs.',
+    category: 'analysis',
+    after: 'collect-scan',
+    run: buildContextStage,
+  });
+  registry.registerStage({
+    id: 'investigate-sources',
+    title: 'Run source investigations',
+    description: 'Applies optional IFS-path, full-text search, and similar source investigations.',
+    category: 'investigation',
+    after: 'build-context',
+    run: investigateSourcesStage,
+  });
+  registry.registerStage({
+    id: 'optimize-context',
+    title: 'Optimize prompt context',
+    description: 'Builds the salience-ranked optimized context projection when enabled.',
+    category: 'optimization',
+    after: 'investigate-sources',
+    run: optimizeContextStage,
+  });
+  registry.registerStage({
+    id: 'export-db2',
+    title: 'Export DB2 metadata',
+    description: 'Exports DB2 metadata and folds linked evidence back into semantic analysis.',
+    category: 'db2',
+    after: 'optimize-context',
+    run: exportDb2Stage,
+  });
+  registry.registerStage({
+    id: 'export-test-data',
+    title: 'Export governed test data',
+    description: 'Exports bounded DB2 sample rows with configured masking and governance policy.',
+    category: 'db2',
+    after: 'export-db2',
+    run: exportTestDataStage,
+  });
+  registry.registerStage({
+    id: 'run-diagnostic-packs',
+    title: 'Run diagnostic packs',
+    description: 'Executes optional read-only investigation packs after the main semantic pipeline.',
+    category: 'investigation',
+    after: 'export-test-data',
+    run: runDiagnosticPacksStage,
+  });
+
+  return registry;
+}
+
+function buildAnalyzeStageRegistry(options = {}) {
+  const registry = createAnalyzeStageRegistry();
+  registerCoreAnalyzeStages(registry);
+
+  const plugins = Array.isArray(options.plugins) ? options.plugins : [];
+  for (const plugin of plugins) {
+    registry.use(plugin);
+  }
+
+  return registry;
+}
+
+function getAnalyzeCoreStages(options = {}) {
+  return buildAnalyzeStageRegistry(options).resolveStages();
 }
 
 function runAnalyzeCore(initialState) {
-  return runStages(getAnalyzeCoreStages(), initialState);
+  const stageRegistry = initialState && initialState.stageRegistry && typeof initialState.stageRegistry.resolveStages === 'function'
+    ? initialState.stageRegistry
+    : buildAnalyzeStageRegistry({
+      plugins: initialState && Array.isArray(initialState.analyzePlugins) ? initialState.analyzePlugins : [],
+    });
+  return runStages(stageRegistry.resolveStages(), initialState, {
+    lifecycleHooks: typeof stageRegistry.resolveLifecycleHooks === 'function'
+      ? stageRegistry.resolveLifecycleHooks()
+      : [],
+  });
 }
 
 function runAnalyzeArtifactAdapter(initialState) {
@@ -851,7 +925,9 @@ function runAnalyzePipeline(initialState) {
 }
 
 module.exports = {
+  buildAnalyzeStageRegistry,
   getAnalyzeCoreStages,
+  registerCoreAnalyzeStages,
   runAnalyzeArtifactAdapter,
   runAnalyzeCore,
   runAnalyzePipeline,

--- a/src/analyze/analyzeRunManifest.js
+++ b/src/analyze/analyzeRunManifest.js
@@ -257,6 +257,7 @@ function buildAnalyzeRunManifest({
       startedAt: stage.startedAt,
       completedAt: stage.completedAt,
       durationMs: stage.durationMs,
+      definition: stage.definition || null,
       metadata: stage.metadata || {},
       diagnostics: stage.diagnostics || [],
     })),
@@ -281,6 +282,7 @@ function buildAnalyzeRunManifest({
     stages: manifest.stages.map((stage) => ({
       id: stage.id,
       status: stage.status,
+      definition: stage.definition,
       metadata: stage.metadata,
       diagnostics: stage.diagnostics,
     })),

--- a/src/analyze/runStages.js
+++ b/src/analyze/runStages.js
@@ -40,6 +40,84 @@ function normalizeStageDiagnostics(diagnostics) {
     .filter((entry) => entry.message);
 }
 
+function normalizeStageDefinition(stage) {
+  if (!stage || typeof stage !== 'object') {
+    return null;
+  }
+
+  const pluginName = stage.pluginName ? String(stage.pluginName).trim() : '';
+  const title = stage.title ? String(stage.title).trim() : '';
+  const description = stage.description ? String(stage.description).trim() : '';
+  const category = stage.category ? String(stage.category).trim() : '';
+  const registrationOrder = Number.isInteger(stage.registrationOrder) ? stage.registrationOrder : null;
+  const before = Array.isArray(stage.before) ? stage.before.map((entry) => String(entry).trim()).filter(Boolean) : [];
+  const after = Array.isArray(stage.after) ? stage.after.map((entry) => String(entry).trim()).filter(Boolean) : [];
+
+  if (!pluginName && !title && !description && !category && registrationOrder === null && before.length === 0 && after.length === 0) {
+    return null;
+  }
+
+  return {
+    pluginName: pluginName || 'core',
+    title: title || null,
+    description: description || null,
+    category: category || null,
+    registrationOrder,
+    before,
+    after,
+  };
+}
+
+function normalizeLifecycleHooks(lifecycleHooks) {
+  if (!Array.isArray(lifecycleHooks)) {
+    return [];
+  }
+
+  return lifecycleHooks
+    .filter((entry) => entry && typeof entry === 'object')
+    .map((entry) => ({
+      beforeStage: typeof entry.beforeStage === 'function' ? entry.beforeStage : null,
+      afterStage: typeof entry.afterStage === 'function' ? entry.afterStage : null,
+      onStageError: typeof entry.onStageError === 'function' ? entry.onStageError : null,
+      pluginName: entry.pluginName ? String(entry.pluginName).trim() : 'core',
+    }))
+    .filter((entry) => entry.beforeStage || entry.afterStage || entry.onStageError);
+}
+
+function buildStageLifecycleHandlers(stage, lifecycleHooks) {
+  const beforeHandlers = lifecycleHooks
+    .map((entry) => entry.beforeStage)
+    .filter(Boolean);
+  const afterHandlers = lifecycleHooks
+    .map((entry) => entry.afterStage)
+    .filter(Boolean);
+  const errorHandlers = lifecycleHooks
+    .map((entry) => entry.onStageError)
+    .filter(Boolean);
+
+  if (typeof stage.beforeRun === 'function') {
+    beforeHandlers.push((payload) => stage.beforeRun(payload));
+  }
+  if (typeof stage.afterRun === 'function') {
+    afterHandlers.push((payload) => stage.afterRun(payload));
+  }
+  if (typeof stage.onError === 'function') {
+    errorHandlers.push((payload) => stage.onError(payload));
+  }
+
+  return {
+    beforeHandlers,
+    afterHandlers,
+    errorHandlers,
+  };
+}
+
+function invokeLifecycleHandlers(handlers, payload) {
+  for (const handler of handlers) {
+    handler(payload);
+  }
+}
+
 function finalizeStageState(state, stageReport, stageReports) {
   return {
     ...state,
@@ -49,7 +127,8 @@ function finalizeStageState(state, stageReport, stageReports) {
   };
 }
 
-function runStages(stages, initialState) {
+function runStages(stages, initialState, options = {}) {
+  const lifecycleHooks = normalizeLifecycleHooks(options.lifecycleHooks);
   return stages.reduce((state, stage) => {
     if (!stage || typeof stage.run !== 'function') {
       throw new Error('Invalid analyze stage: missing run function');
@@ -58,8 +137,13 @@ function runStages(stages, initialState) {
     const reproducibility = normalizeReproducibilitySettings(state.reproducibility);
     const startedAt = resolveTimestamp(reproducibility);
     const startedNs = process.hrtime.bigint();
+    const { beforeHandlers, afterHandlers, errorHandlers } = buildStageLifecycleHandlers(stage, lifecycleHooks);
 
     try {
+      invokeLifecycleHandlers(beforeHandlers, {
+        stage,
+        state,
+      });
       const result = stage.run(state);
       const durationMs = resolveDurationMs(reproducibility, Number((process.hrtime.bigint() - startedNs) / 1000000n));
       const stageReport = {
@@ -70,12 +154,20 @@ function runStages(stages, initialState) {
         durationMs,
         metadata: normalizeStageMetadata(result && result.stageMetadata),
         diagnostics: normalizeStageDiagnostics(result && result.stageDiagnostics),
+        definition: normalizeStageDefinition(stage),
       };
       const nextState = {
         ...(result || {}),
       };
       delete nextState.stageMetadata;
       delete nextState.stageDiagnostics;
+
+      invokeLifecycleHandlers(afterHandlers, {
+        stage,
+        state,
+        nextState,
+        stageReport,
+      });
 
       const stageReports = [...(state.stageReports || []), stageReport];
       return finalizeStageState(nextState, stageReport, stageReports);
@@ -93,7 +185,14 @@ function runStages(stages, initialState) {
           code: 'STAGE_FAILED',
           message: error.message,
         }],
+        definition: normalizeStageDefinition(stage),
       };
+      invokeLifecycleHandlers(errorHandlers, {
+        stage,
+        state,
+        error,
+        stageReport,
+      });
       error.stageId = stageReport.id;
       error.stageReports = [...(state.stageReports || []), stageReport];
       throw error;

--- a/src/analyze/stageRegistry.js
+++ b/src/analyze/stageRegistry.js
@@ -1,0 +1,248 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+function normalizeOptionalString(value) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const normalized = String(value).trim();
+  return normalized || null;
+}
+
+function normalizeAnchorList(value) {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  const items = Array.isArray(value) ? value : [value];
+  return Array.from(new Set(items
+    .map((entry) => normalizeOptionalString(entry))
+    .filter(Boolean)));
+}
+
+function normalizeStageDefinition(definition, options = {}) {
+  if (!definition || typeof definition !== 'object') {
+    throw new Error('Invalid analyze stage definition: expected an object');
+  }
+
+  const id = normalizeOptionalString(definition.id);
+  if (!id) {
+    throw new Error('Invalid analyze stage definition: missing id');
+  }
+  if (typeof definition.run !== 'function') {
+    throw new Error(`Invalid analyze stage definition for ${id}: missing run function`);
+  }
+
+  return {
+    id,
+    title: normalizeOptionalString(definition.title),
+    description: normalizeOptionalString(definition.description),
+    category: normalizeOptionalString(definition.category),
+    pluginName: normalizeOptionalString(options.pluginName || definition.pluginName) || 'core',
+    before: normalizeAnchorList(definition.before),
+    after: normalizeAnchorList(definition.after),
+    run: definition.run,
+    beforeRun: typeof definition.beforeRun === 'function' ? definition.beforeRun : null,
+    afterRun: typeof definition.afterRun === 'function' ? definition.afterRun : null,
+    onError: typeof definition.onError === 'function' ? definition.onError : null,
+    registrationOrder: Number(options.registrationOrder),
+  };
+}
+
+function normalizeLifecycleHooks(hooks, options = {}) {
+  if (!hooks || typeof hooks !== 'object' || Array.isArray(hooks)) {
+    throw new Error('Invalid analyze lifecycle hooks: expected an object');
+  }
+
+  const beforeStage = typeof hooks.beforeStage === 'function' ? hooks.beforeStage : null;
+  const afterStage = typeof hooks.afterStage === 'function' ? hooks.afterStage : null;
+  const onStageError = typeof hooks.onStageError === 'function' ? hooks.onStageError : null;
+
+  if (!beforeStage && !afterStage && !onStageError) {
+    throw new Error('Invalid analyze lifecycle hooks: expected at least one hook function');
+  }
+
+  return {
+    pluginName: normalizeOptionalString(options.pluginName || hooks.pluginName) || 'core',
+    beforeStage,
+    afterStage,
+    onStageError,
+  };
+}
+
+function sortByRegistrationOrder(entries) {
+  return [...entries].sort((left, right) => left.registrationOrder - right.registrationOrder);
+}
+
+function buildResolvedOrder(stageDefinitions) {
+  const stages = sortByRegistrationOrder(stageDefinitions);
+  const byId = new Map();
+  for (const stage of stages) {
+    if (byId.has(stage.id)) {
+      throw new Error(`Duplicate analyze stage id: ${stage.id}`);
+    }
+    byId.set(stage.id, stage);
+  }
+
+  const incoming = new Map(stages.map((stage) => [stage.id, new Set()]));
+  const outgoing = new Map(stages.map((stage) => [stage.id, new Set()]));
+
+  const addEdge = (fromId, toId, relation) => {
+    if (!byId.has(fromId)) {
+      throw new Error(`Analyze stage ${toId} references unknown ${relation} anchor: ${fromId}`);
+    }
+    if (!byId.has(toId)) {
+      throw new Error(`Analyze stage ${fromId} references unknown ${relation} anchor: ${toId}`);
+    }
+    if (fromId === toId) {
+      throw new Error(`Analyze stage ${fromId} cannot reference itself via ${relation}`);
+    }
+
+    incoming.get(toId).add(fromId);
+    outgoing.get(fromId).add(toId);
+  };
+
+  for (const stage of stages) {
+    for (const targetId of stage.before) {
+      addEdge(stage.id, targetId, 'before');
+    }
+    for (const targetId of stage.after) {
+      addEdge(targetId, stage.id, 'after');
+    }
+  }
+
+  const ready = stages
+    .filter((stage) => incoming.get(stage.id).size === 0)
+    .sort((left, right) => left.registrationOrder - right.registrationOrder);
+  const resolved = [];
+
+  while (ready.length > 0) {
+    const current = ready.shift();
+    resolved.push(current);
+
+    const nextIds = Array.from(outgoing.get(current.id))
+      .sort((leftId, rightId) => byId.get(leftId).registrationOrder - byId.get(rightId).registrationOrder);
+
+    for (const nextId of nextIds) {
+      const dependencies = incoming.get(nextId);
+      dependencies.delete(current.id);
+      if (dependencies.size === 0) {
+        ready.push(byId.get(nextId));
+        ready.sort((left, right) => left.registrationOrder - right.registrationOrder);
+      }
+    }
+  }
+
+  if (resolved.length !== stages.length) {
+    const unresolved = stages
+      .filter((stage) => !resolved.some((entry) => entry.id === stage.id))
+      .map((stage) => stage.id);
+    throw new Error(`Analyze stage ordering contains a cycle: ${unresolved.join(', ')}`);
+  }
+
+  return resolved;
+}
+
+function createAnalyzeStageRegistry() {
+  const stageDefinitions = [];
+  const lifecycleHooks = [];
+
+  const api = {
+    registerStage(definition, options = {}) {
+      const registrationOrder = stageDefinitions.length;
+      const stage = normalizeStageDefinition(definition, {
+        ...options,
+        registrationOrder,
+      });
+      stageDefinitions.push(stage);
+      return api;
+    },
+
+    registerLifecycleHooks(hooks, options = {}) {
+      lifecycleHooks.push(normalizeLifecycleHooks(hooks, options));
+      return api;
+    },
+
+    use(plugin) {
+      const pluginName = normalizeOptionalString(plugin && plugin.name) || 'anonymous-plugin';
+      const register = typeof plugin === 'function'
+        ? plugin
+        : (plugin && typeof plugin.register === 'function' ? plugin.register.bind(plugin) : null);
+
+      if (!register) {
+        throw new Error(`Invalid analyze plugin ${pluginName}: missing register function`);
+      }
+
+      register({
+        registerStage(definition) {
+          return api.registerStage(definition, { pluginName });
+        },
+        registerLifecycleHooks(hooks) {
+          return api.registerLifecycleHooks(hooks, { pluginName });
+        },
+        listStages() {
+          return api.listStages();
+        },
+        listLifecycleHooks() {
+          return api.listLifecycleHooks();
+        },
+      });
+      return api;
+    },
+
+    listStages() {
+      return sortByRegistrationOrder(stageDefinitions).map((stage) => ({
+        id: stage.id,
+        title: stage.title,
+        description: stage.description,
+        category: stage.category,
+        pluginName: stage.pluginName,
+        before: [...stage.before],
+        after: [...stage.after],
+        registrationOrder: stage.registrationOrder,
+      }));
+    },
+
+    listLifecycleHooks() {
+      return lifecycleHooks.map((entry, index) => ({
+        pluginName: entry.pluginName,
+        registrationOrder: index,
+        hooks: {
+          beforeStage: Boolean(entry.beforeStage),
+          afterStage: Boolean(entry.afterStage),
+          onStageError: Boolean(entry.onStageError),
+        },
+      }));
+    },
+
+    resolveStages() {
+      return buildResolvedOrder(stageDefinitions).map((stage) => ({
+        ...stage,
+        before: [...stage.before],
+        after: [...stage.after],
+      }));
+    },
+
+    resolveLifecycleHooks() {
+      return lifecycleHooks.map((entry) => ({
+        ...entry,
+      }));
+    },
+  };
+
+  return api;
+}
+
+module.exports = {
+  createAnalyzeStageRegistry,
+};

--- a/src/cli/commands/serveCommand.js
+++ b/src/cli/commands/serveCommand.js
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const path = require('path');
+
+const { resolveBundleConfig } = require('../../config/runtimeConfig');
+const { startLocalUiServer, DEFAULT_UI_HOST, DEFAULT_UI_PORT } = require('../../ui/localUiServer');
+
+function parsePort(value, fallback) {
+  if (value === undefined || value === null || value === true) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(String(value).trim(), 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    console.error('Invalid option: --port must be a non-negative integer');
+    process.exit(2);
+  }
+  return parsed;
+}
+
+async function runServe(args) {
+  const verbose = Boolean(args.verbose);
+  const config = resolveBundleConfig(args);
+  const outputRoot = path.resolve(process.cwd(), config.sourceOutputRoot);
+  const host = args.host || DEFAULT_UI_HOST;
+  const port = parsePort(args.port, DEFAULT_UI_PORT);
+
+  const result = await startLocalUiServer({
+    outputRoot,
+    host,
+    port,
+  });
+
+  if (verbose) {
+    console.log(`[verbose] Output root: ${result.outputRoot}`);
+    console.log('[verbose] API routes: /api/health, /api/runs, /api/runs/:program, /api/runs/:program/artifacts/content');
+  }
+
+  console.log(`Zeus local UI available at: ${result.url}`);
+  console.log(`Serving analysis output root: ${result.outputRoot}`);
+  console.log('Press Ctrl+C to stop.');
+
+  const shutdown = () => {
+    result.server.close(() => {
+      process.exit(0);
+    });
+  };
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+
+  return result;
+}
+
+module.exports = {
+  runServe,
+};

--- a/src/ui/localUiDataApi.js
+++ b/src/ui/localUiDataApi.js
@@ -1,0 +1,219 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+
+const { readAnalyzeRunManifest, ANALYZE_RUN_MANIFEST_FILE } = require('../analyze/analyzeRunManifest');
+const { SAFE_SHARING_DIR } = require('../sharing/safeSharingArtifactBuilder');
+
+const BUNDLE_MANIFEST_FILE = 'bundle-manifest.json';
+const WORKFLOW_MANIFEST_FILE = 'workflow-run-manifest.json';
+
+function inferArtifactKind(fileName) {
+  const ext = path.extname(String(fileName || '').toLowerCase());
+  if (ext === '.json') return 'json';
+  if (ext === '.md') return 'markdown';
+  if (ext === '.html') return 'html';
+  if (ext === '.mmd') return 'mermaid';
+  return ext ? ext.slice(1) : 'unknown';
+}
+
+function readJsonIfExists(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function normalizeRelativePath(relativePath) {
+  return String(relativePath || '').split(path.sep).join('/');
+}
+
+function readArtifactEntries(programOutputDir) {
+  const entries = [];
+
+  for (const dirent of fs.readdirSync(programOutputDir, { withFileTypes: true })) {
+    if (dirent.isFile()) {
+      entries.push({
+        path: dirent.name,
+        absolutePath: path.join(programOutputDir, dirent.name),
+      });
+    }
+  }
+
+  const safeSharingDir = path.join(programOutputDir, SAFE_SHARING_DIR);
+  if (fs.existsSync(safeSharingDir)) {
+    for (const dirent of fs.readdirSync(safeSharingDir, { withFileTypes: true })) {
+      if (!dirent.isFile()) continue;
+      entries.push({
+        path: `${SAFE_SHARING_DIR}/${dirent.name}`,
+        absolutePath: path.join(safeSharingDir, dirent.name),
+      });
+    }
+  }
+
+  return entries
+    .map((entry) => {
+      const stats = fs.statSync(entry.absolutePath);
+      return {
+        path: normalizeRelativePath(entry.path),
+        kind: inferArtifactKind(entry.path),
+        sizeBytes: stats.size,
+      };
+    })
+    .sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function buildRunSummary(program, programOutputDir, analyzeManifest, bundleManifest, workflowManifest) {
+  const run = analyzeManifest && analyzeManifest.run ? analyzeManifest.run : {};
+  const options = analyzeManifest && analyzeManifest.inputs && analyzeManifest.inputs.options
+    ? analyzeManifest.inputs.options
+    : {};
+  const artifacts = readArtifactEntries(programOutputDir);
+
+  return {
+    program,
+    status: run.status || null,
+    completedAt: run.completedAt || null,
+    sourceRoot: analyzeManifest && analyzeManifest.inputs ? analyzeManifest.inputs.sourceRoot || null : null,
+    workflowMode: options.guidedMode ? options.guidedMode.name || null : null,
+    workflowPreset: options.workflowPreset ? options.workflowPreset.name || null : null,
+    reproducible: Boolean(options.reproducibleEnabled),
+    artifactCount: artifacts.length,
+    safeSharingEnabled: artifacts.some((artifact) => artifact.path.startsWith(`${SAFE_SHARING_DIR}/`)),
+    bundleAvailable: Boolean(bundleManifest),
+    workflowRunAvailable: Boolean(workflowManifest),
+  };
+}
+
+function listAnalysisRuns(outputRoot) {
+  const resolvedRoot = path.resolve(outputRoot);
+  if (!fs.existsSync(resolvedRoot)) {
+    return [];
+  }
+
+  return fs.readdirSync(resolvedRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const programOutputDir = path.join(resolvedRoot, entry.name);
+      const analyzeManifest = readAnalyzeRunManifest(programOutputDir);
+      const bundleManifest = readJsonIfExists(path.join(programOutputDir, BUNDLE_MANIFEST_FILE));
+      const workflowManifest = readJsonIfExists(path.join(programOutputDir, WORKFLOW_MANIFEST_FILE));
+      if (!analyzeManifest && !bundleManifest && !workflowManifest) {
+        return null;
+      }
+
+      return buildRunSummary(
+        entry.name,
+        programOutputDir,
+        analyzeManifest,
+        bundleManifest,
+        workflowManifest,
+      );
+    })
+    .filter(Boolean)
+    .sort((left, right) => {
+      const leftTime = left.completedAt ? Date.parse(left.completedAt) : 0;
+      const rightTime = right.completedAt ? Date.parse(right.completedAt) : 0;
+      if (rightTime !== leftTime) {
+        return rightTime - leftTime;
+      }
+      return left.program.localeCompare(right.program);
+    });
+}
+
+function resolveProgramOutputDir(outputRoot, program) {
+  const normalizedProgram = String(program || '').trim();
+  if (!normalizedProgram) {
+    throw new Error('Program name is required');
+  }
+
+  const programOutputDir = path.join(path.resolve(outputRoot), normalizedProgram);
+  if (!fs.existsSync(programOutputDir)) {
+    throw new Error(`Analysis run not found: ${normalizedProgram}`);
+  }
+  return programOutputDir;
+}
+
+function readAnalysisRun(outputRoot, program) {
+  const programOutputDir = resolveProgramOutputDir(outputRoot, program);
+  const analyzeManifest = readAnalyzeRunManifest(programOutputDir);
+  if (!analyzeManifest) {
+    throw new Error(`Analyze manifest not found for run: ${program}`);
+  }
+
+  const bundleManifest = readJsonIfExists(path.join(programOutputDir, BUNDLE_MANIFEST_FILE));
+  const workflowManifest = readJsonIfExists(path.join(programOutputDir, WORKFLOW_MANIFEST_FILE));
+  const artifacts = readArtifactEntries(programOutputDir);
+
+  return {
+    summary: buildRunSummary(program, programOutputDir, analyzeManifest, bundleManifest, workflowManifest),
+    analyzeManifest,
+    bundleManifest,
+    workflowManifest,
+    artifacts,
+  };
+}
+
+function resolveArtifactPath(programOutputDir, artifactPath) {
+  const relativePath = normalizeRelativePath(artifactPath).replace(/^\/+/, '');
+  if (!relativePath) {
+    throw new Error('Artifact path is required');
+  }
+
+  const absolutePath = path.resolve(programOutputDir, relativePath);
+  const rootWithSep = `${path.resolve(programOutputDir)}${path.sep}`;
+  if (absolutePath !== path.resolve(programOutputDir) && !absolutePath.startsWith(rootWithSep)) {
+    throw new Error(`Artifact path escapes run directory: ${relativePath}`);
+  }
+  if (!fs.existsSync(absolutePath) || !fs.statSync(absolutePath).isFile()) {
+    throw new Error(`Artifact not found: ${relativePath}`);
+  }
+
+  return {
+    relativePath,
+    absolutePath,
+    kind: inferArtifactKind(relativePath),
+  };
+}
+
+function inferContentType(kind) {
+  if (kind === 'json') return 'application/json; charset=utf-8';
+  if (kind === 'html') return 'text/html; charset=utf-8';
+  return 'text/plain; charset=utf-8';
+}
+
+function readArtifactContent(outputRoot, program, artifactPath) {
+  const programOutputDir = resolveProgramOutputDir(outputRoot, program);
+  const resolved = resolveArtifactPath(programOutputDir, artifactPath);
+  const content = fs.readFileSync(resolved.absolutePath, 'utf8');
+
+  return {
+    program: String(program || '').trim(),
+    path: resolved.relativePath,
+    kind: resolved.kind,
+    contentType: inferContentType(resolved.kind),
+    content,
+  };
+}
+
+module.exports = {
+  ANALYZE_RUN_MANIFEST_FILE,
+  BUNDLE_MANIFEST_FILE,
+  WORKFLOW_MANIFEST_FILE,
+  inferArtifactKind,
+  listAnalysisRuns,
+  readAnalysisRun,
+  readArtifactContent,
+};

--- a/src/ui/localUiServer.js
+++ b/src/ui/localUiServer.js
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const http = require('http');
+const path = require('path');
+
+const {
+  listAnalysisRuns,
+  readAnalysisRun,
+  readArtifactContent,
+} = require('./localUiDataApi');
+const { renderLocalUiShell } = require('./localUiShell');
+
+const DEFAULT_UI_HOST = '127.0.0.1';
+const DEFAULT_UI_PORT = 4782;
+
+function normalizeHost(host) {
+  const normalized = String(host || DEFAULT_UI_HOST).trim();
+  if (!normalized || normalized === 'localhost') {
+    return DEFAULT_UI_HOST;
+  }
+  if (normalized === '127.0.0.1' || normalized === '::1') {
+    return normalized;
+  }
+  throw new Error('Local UI server only supports localhost/loopback binding');
+}
+
+function parsePositiveInteger(value, fallback) {
+  if (value === undefined || value === null || value === true) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(String(value).trim(), 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error('Local UI port must be a non-negative integer');
+  }
+  return parsed;
+}
+
+function sendJson(response, statusCode, payload) {
+  response.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  response.end(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function sendText(response, statusCode, content, contentType = 'text/plain; charset=utf-8') {
+  response.writeHead(statusCode, {
+    'Content-Type': contentType,
+    'Cache-Control': 'no-store',
+  });
+  response.end(content);
+}
+
+function splitPathname(pathname) {
+  return String(pathname || '')
+    .split('/')
+    .filter(Boolean)
+    .map((entry) => decodeURIComponent(entry));
+}
+
+function createLocalUiRequestHandler({ outputRoot }) {
+  const resolvedOutputRoot = path.resolve(outputRoot);
+
+  return function handleRequest(request, response) {
+    const url = new URL(request.url, 'http://127.0.0.1');
+    const pathname = url.pathname;
+    const segments = splitPathname(pathname);
+
+    if (request.method !== 'GET') {
+      sendJson(response, 405, { error: 'Method not allowed' });
+      return;
+    }
+
+    try {
+      if (pathname === '/' || pathname === '/index.html') {
+        sendText(response, 200, renderLocalUiShell(), 'text/html; charset=utf-8');
+        return;
+      }
+
+      if (pathname === '/api/health') {
+        sendJson(response, 200, {
+          ok: true,
+          outputRoot: resolvedOutputRoot,
+        });
+        return;
+      }
+
+      if (pathname === '/api/runs') {
+        sendJson(response, 200, listAnalysisRuns(resolvedOutputRoot));
+        return;
+      }
+
+      if (segments[0] === 'api' && segments[1] === 'runs' && segments.length === 3) {
+        sendJson(response, 200, readAnalysisRun(resolvedOutputRoot, segments[2]));
+        return;
+      }
+
+      if (segments[0] === 'api' && segments[1] === 'runs' && segments[3] === 'artifacts' && segments[4] === 'content') {
+        const artifactPath = url.searchParams.get('path');
+        const artifact = readArtifactContent(resolvedOutputRoot, segments[2], artifactPath);
+        sendJson(response, 200, artifact);
+        return;
+      }
+
+      if (segments[0] === 'runs' && segments[2] === 'artifacts' && segments[3] === 'raw') {
+        const artifactPath = url.searchParams.get('path');
+        const artifact = readArtifactContent(resolvedOutputRoot, segments[1], artifactPath);
+        sendText(response, 200, artifact.content, artifact.contentType);
+        return;
+      }
+
+      sendJson(response, 404, { error: `Route not found: ${pathname}` });
+    } catch (error) {
+      sendJson(response, /not found/i.test(error.message) ? 404 : 400, {
+        error: error.message,
+      });
+    }
+  };
+}
+
+async function startLocalUiServer({ outputRoot, host = DEFAULT_UI_HOST, port = DEFAULT_UI_PORT } = {}) {
+  const resolvedHost = normalizeHost(host);
+  const resolvedPort = parsePositiveInteger(port, DEFAULT_UI_PORT);
+  const resolvedOutputRoot = path.resolve(outputRoot || 'output');
+  const server = http.createServer(createLocalUiRequestHandler({
+    outputRoot: resolvedOutputRoot,
+  }));
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(resolvedPort, resolvedHost, resolve);
+  });
+
+  const address = server.address();
+  const actualPort = address && typeof address === 'object' ? address.port : resolvedPort;
+  return {
+    server,
+    host: resolvedHost,
+    port: actualPort,
+    outputRoot: resolvedOutputRoot,
+    url: `http://${resolvedHost === '::1' ? '[::1]' : resolvedHost}:${actualPort}`,
+  };
+}
+
+module.exports = {
+  DEFAULT_UI_HOST,
+  DEFAULT_UI_PORT,
+  createLocalUiRequestHandler,
+  startLocalUiServer,
+};

--- a/src/ui/localUiShell.js
+++ b/src/ui/localUiShell.js
@@ -1,0 +1,492 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+function renderLocalUiShell() {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Zeus Local UI</title>
+  <style>
+    :root {
+      --bg: #f3efe5;
+      --panel: #fffaf0;
+      --panel-strong: #f9f1de;
+      --text: #1f2933;
+      --muted: #5c6b73;
+      --line: #d4c3a3;
+      --accent: #8a4b08;
+      --accent-soft: #edd7b5;
+      --success: #166534;
+      --danger: #991b1b;
+      --shadow: 0 18px 40px rgba(73, 52, 18, 0.12);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background:
+        radial-gradient(circle at top left, rgba(138, 75, 8, 0.14), transparent 34%),
+        linear-gradient(180deg, #fcf8ef 0%, var(--bg) 100%);
+      color: var(--text);
+      font-family: Georgia, "Times New Roman", serif;
+    }
+    .app {
+      display: grid;
+      grid-template-columns: 320px 1fr;
+      min-height: 100vh;
+    }
+    aside {
+      border-right: 1px solid var(--line);
+      background: rgba(255, 250, 240, 0.88);
+      backdrop-filter: blur(6px);
+      padding: 24px 20px;
+    }
+    main {
+      padding: 24px;
+      display: grid;
+      grid-template-rows: auto auto 1fr;
+      gap: 18px;
+    }
+    h1, h2, h3 { margin: 0; font-weight: 700; }
+    h1 { font-size: 28px; letter-spacing: 0.02em; }
+    h2 { font-size: 19px; }
+    h3 { font-size: 15px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+    p { margin: 0; color: var(--muted); }
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      box-shadow: var(--shadow);
+    }
+    .hero {
+      padding: 22px 24px;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 20px;
+    }
+    .hero-meta {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 7px 12px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: var(--panel-strong);
+      font-size: 12px;
+      color: var(--accent);
+    }
+    .stack {
+      display: grid;
+      gap: 14px;
+    }
+    .run-list {
+      margin-top: 18px;
+      display: grid;
+      gap: 10px;
+    }
+    .run-item {
+      border: 1px solid var(--line);
+      background: white;
+      border-radius: 14px;
+      padding: 14px 16px;
+      cursor: pointer;
+      transition: transform 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+    }
+    .run-item:hover {
+      transform: translateY(-1px);
+      border-color: var(--accent);
+      box-shadow: 0 10px 24px rgba(138, 75, 8, 0.08);
+    }
+    .run-item.active {
+      background: linear-gradient(135deg, #fff5df, #fffaf0);
+      border-color: var(--accent);
+    }
+    .run-item strong { display: block; font-size: 16px; }
+    .run-item small { color: var(--muted); display: block; margin-top: 4px; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 14px;
+    }
+    .metric {
+      padding: 16px 18px;
+    }
+    .metric strong {
+      display: block;
+      font-size: 26px;
+      color: var(--accent);
+      margin-top: 8px;
+    }
+    .workspace {
+      display: grid;
+      grid-template-columns: 280px 1fr;
+      gap: 18px;
+      min-height: 0;
+    }
+    .artifact-list {
+      padding: 18px;
+      display: grid;
+      gap: 10px;
+      align-content: start;
+      max-height: calc(100vh - 248px);
+      overflow: auto;
+    }
+    .artifact-button {
+      width: 100%;
+      text-align: left;
+      border: 1px solid var(--line);
+      background: white;
+      border-radius: 12px;
+      padding: 12px 13px;
+      cursor: pointer;
+    }
+    .artifact-button.active {
+      border-color: var(--accent);
+      background: #fff1d6;
+    }
+    .artifact-button strong {
+      display: block;
+      font-size: 14px;
+      overflow-wrap: anywhere;
+    }
+    .artifact-button span {
+      display: block;
+      font-size: 12px;
+      color: var(--muted);
+      margin-top: 4px;
+    }
+    .preview {
+      padding: 18px;
+      display: grid;
+      grid-template-rows: auto 1fr;
+      min-height: 0;
+    }
+    .preview-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 14px;
+    }
+    .preview-body {
+      min-height: 420px;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: #fffdf7;
+      overflow: hidden;
+    }
+    .preview-text {
+      margin: 0;
+      padding: 16px;
+      height: 100%;
+      overflow: auto;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: "Cascadia Code", Consolas, monospace;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+    .preview-frame {
+      width: 100%;
+      height: 100%;
+      border: 0;
+      background: white;
+    }
+    .empty {
+      padding: 28px;
+      color: var(--muted);
+      border: 1px dashed var(--line);
+      border-radius: 16px;
+      background: rgba(255, 250, 240, 0.8);
+    }
+    a.link {
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 13px;
+    }
+    a.link:hover {
+      text-decoration: underline;
+    }
+    @media (max-width: 980px) {
+      .app { grid-template-columns: 1fr; }
+      aside { border-right: 0; border-bottom: 1px solid var(--line); }
+      .grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .workspace { grid-template-columns: 1fr; }
+      .artifact-list { max-height: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="app">
+    <aside>
+      <div class="stack">
+        <div>
+          <h1>Zeus Local UI</h1>
+          <p>Read-only shell over the analyze output contract.</p>
+        </div>
+        <div class="pill">Local-only API</div>
+      </div>
+      <div id="run-list" class="run-list"></div>
+    </aside>
+    <main>
+      <section class="panel hero">
+        <div class="stack">
+          <h2 id="hero-title">Analysis Runs</h2>
+          <p id="hero-subtitle">Select a run to inspect manifests and artifact previews.</p>
+        </div>
+        <div class="hero-meta" id="hero-meta"></div>
+      </section>
+      <section class="grid" id="metric-grid"></section>
+      <section class="workspace">
+        <div class="panel artifact-list" id="artifact-list"></div>
+        <div class="panel preview">
+          <div class="preview-header">
+            <div class="stack">
+              <h2 id="preview-title">Artifact Preview</h2>
+              <p id="preview-subtitle">Choose an artifact from the run.</p>
+            </div>
+            <a id="preview-link" class="link" href="#" target="_blank" rel="noreferrer" hidden>Open Raw</a>
+          </div>
+          <div class="preview-body" id="preview-body">
+            <div class="empty">No artifact selected.</div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+  <script>
+    const state = {
+      runs: [],
+      runDetail: null,
+      selectedProgram: null,
+      selectedArtifactPath: null,
+    };
+
+    const preferredArtifacts = [
+      'report.md',
+      'architecture.html',
+      'analysis-index.json',
+      'context.json',
+      'ai_prompt_documentation.md',
+      'safe-sharing/report.md'
+    ];
+
+    function byId(id) {
+      return document.getElementById(id);
+    }
+
+    function escapeHtml(value) {
+      return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    }
+
+    function formatDate(value) {
+      if (!value) return 'n/a';
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+    }
+
+    function chooseDefaultArtifact(detail) {
+      const artifacts = detail && Array.isArray(detail.artifacts) ? detail.artifacts : [];
+      for (const candidate of preferredArtifacts) {
+        const match = artifacts.find((artifact) => artifact.path === candidate);
+        if (match) return match.path;
+      }
+      return artifacts.length > 0 ? artifacts[0].path : null;
+    }
+
+    async function fetchJson(url) {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(await response.text());
+      }
+      return response.json();
+    }
+
+    function renderRunList() {
+      const container = byId('run-list');
+      if (state.runs.length === 0) {
+        container.innerHTML = '<div class="empty">No analysis runs were found in the configured output root.</div>';
+        return;
+      }
+
+      container.innerHTML = state.runs.map((run) => {
+        const activeClass = run.program === state.selectedProgram ? ' active' : '';
+        const mode = run.workflowPreset || run.workflowMode || 'standard';
+        return '<button class="run-item' + activeClass + '" data-program="' + escapeHtml(run.program) + '">' +
+          '<strong>' + escapeHtml(run.program) + '</strong>' +
+          '<small>Status: ' + escapeHtml(run.status || 'unknown') + '</small>' +
+          '<small>Workflow: ' + escapeHtml(mode) + '</small>' +
+          '<small>Completed: ' + escapeHtml(formatDate(run.completedAt)) + '</small>' +
+          '</button>';
+      }).join('');
+
+      for (const button of container.querySelectorAll('.run-item')) {
+        button.addEventListener('click', () => {
+          selectRun(button.getAttribute('data-program'));
+        });
+      }
+    }
+
+    function renderHero(detail) {
+      if (!detail) {
+        byId('hero-title').textContent = 'Analysis Runs';
+        byId('hero-subtitle').textContent = 'Select a run to inspect manifests and artifact previews.';
+        byId('hero-meta').innerHTML = '';
+        return;
+      }
+
+      const summary = detail.summary;
+      byId('hero-title').textContent = summary.program;
+      byId('hero-subtitle').textContent = 'Manifest-driven local view over the run artifacts.';
+
+      const pills = [
+        'Status: ' + (summary.status || 'unknown'),
+        'Mode: ' + (summary.workflowPreset || summary.workflowMode || 'standard'),
+        'Artifacts: ' + summary.artifactCount,
+        summary.safeSharingEnabled ? 'Safe sharing available' : 'Safe sharing not generated'
+      ];
+
+      byId('hero-meta').innerHTML = pills.map((item) => '<div class="pill">' + escapeHtml(item) + '</div>').join('');
+    }
+
+    function renderMetrics(detail) {
+      const container = byId('metric-grid');
+      if (!detail) {
+        container.innerHTML = '';
+        return;
+      }
+
+      const analyze = detail.analyzeManifest;
+      const metrics = [
+        ['Completed', formatDate(detail.summary.completedAt)],
+        ['Stages', String(analyze.summary.stageCount || 0)],
+        ['Diagnostics', String(analyze.summary.diagnosticCount || 0)],
+        ['Source Files', String(analyze.inputs.sourceSnapshot.fileCount || 0)]
+      ];
+
+      container.innerHTML = metrics.map(([label, value]) => (
+        '<div class="panel metric"><h3>' + escapeHtml(label) + '</h3><strong>' + escapeHtml(value) + '</strong></div>'
+      )).join('');
+    }
+
+    function renderArtifacts(detail) {
+      const container = byId('artifact-list');
+      if (!detail || !Array.isArray(detail.artifacts) || detail.artifacts.length === 0) {
+        container.innerHTML = '<div class="empty">This run has no previewable artifacts.</div>';
+        return;
+      }
+
+      container.innerHTML = detail.artifacts.map((artifact) => {
+        const activeClass = artifact.path === state.selectedArtifactPath ? ' active' : '';
+        return '<button class="artifact-button' + activeClass + '" data-path="' + escapeHtml(artifact.path) + '">' +
+          '<strong>' + escapeHtml(artifact.path) + '</strong>' +
+          '<span>' + escapeHtml(artifact.kind) + ' • ' + escapeHtml(String(artifact.sizeBytes)) + ' bytes</span>' +
+        '</button>';
+      }).join('');
+
+      for (const button of container.querySelectorAll('.artifact-button')) {
+        button.addEventListener('click', () => {
+          selectArtifact(button.getAttribute('data-path'));
+        });
+      }
+    }
+
+    async function renderArtifactPreview() {
+      const previewBody = byId('preview-body');
+      const previewTitle = byId('preview-title');
+      const previewSubtitle = byId('preview-subtitle');
+      const previewLink = byId('preview-link');
+
+      if (!state.runDetail || !state.selectedArtifactPath) {
+        previewTitle.textContent = 'Artifact Preview';
+        previewSubtitle.textContent = 'Choose an artifact from the run.';
+        previewBody.innerHTML = '<div class="empty">No artifact selected.</div>';
+        previewLink.hidden = true;
+        return;
+      }
+
+      const artifact = state.runDetail.artifacts.find((entry) => entry.path === state.selectedArtifactPath);
+      if (!artifact) {
+        previewBody.innerHTML = '<div class="empty">The selected artifact is no longer available.</div>';
+        previewLink.hidden = true;
+        return;
+      }
+
+      previewTitle.textContent = artifact.path;
+      previewSubtitle.textContent = artifact.kind + ' preview';
+      const rawUrl = '/runs/' + encodeURIComponent(state.selectedProgram) + '/artifacts/raw?path=' + encodeURIComponent(artifact.path);
+      previewLink.href = rawUrl;
+      previewLink.hidden = false;
+
+      if (artifact.kind === 'html') {
+        previewBody.innerHTML = '<iframe class="preview-frame" src="' + rawUrl + '"></iframe>';
+        return;
+      }
+
+      previewBody.innerHTML = '<pre class="preview-text">Loading...</pre>';
+      const payload = await fetchJson('/api/runs/' + encodeURIComponent(state.selectedProgram) + '/artifacts/content?path=' + encodeURIComponent(artifact.path));
+      const content = artifact.kind === 'json'
+        ? JSON.stringify(JSON.parse(payload.content), null, 2)
+        : payload.content;
+      previewBody.innerHTML = '<pre class="preview-text">' + escapeHtml(content) + '</pre>';
+    }
+
+    async function selectArtifact(artifactPath) {
+      state.selectedArtifactPath = artifactPath;
+      renderArtifacts(state.runDetail);
+      await renderArtifactPreview();
+    }
+
+    async function selectRun(program) {
+      state.selectedProgram = program;
+      renderRunList();
+      state.runDetail = await fetchJson('/api/runs/' + encodeURIComponent(program));
+      renderHero(state.runDetail);
+      renderMetrics(state.runDetail);
+      renderArtifacts(state.runDetail);
+      state.selectedArtifactPath = chooseDefaultArtifact(state.runDetail);
+      renderArtifacts(state.runDetail);
+      await renderArtifactPreview();
+    }
+
+    async function boot() {
+      state.runs = await fetchJson('/api/runs');
+      renderRunList();
+      if (state.runs.length > 0) {
+        await selectRun(state.runs[0].program);
+      }
+    }
+
+    boot().catch((error) => {
+      byId('preview-body').innerHTML = '<div class="empty">' + escapeHtml(error.message || String(error)) + '</div>';
+    });
+  </script>
+</body>
+</html>`;
+}
+
+module.exports = {
+  renderLocalUiShell,
+};

--- a/src/viewer/architectureViewerGenerator.js
+++ b/src/viewer/architectureViewerGenerator.js
@@ -11,9 +11,13 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
+const crypto = require('crypto');
 const fs = require('fs');
+const path = require('path');
 
-const VIS_NETWORK_CDN = 'https://unpkg.com/vis-network/standalone/umd/vis-network.min.js';
+const VIS_NETWORK_ASSET = 'standalone/umd/vis-network.min.js';
+
+let cachedViewerAsset = null;
 
 function readGraph(graphPath) {
   if (!graphPath || !fs.existsSync(graphPath)) {
@@ -25,6 +29,41 @@ function readGraph(graphPath) {
 
 function escapeInlineJson(value) {
   return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function escapeInlineScript(source) {
+  return String(source || '').replace(/<\/script/gi, '<\\/script');
+}
+
+function loadViewerAsset() {
+  if (cachedViewerAsset) {
+    return cachedViewerAsset;
+  }
+
+  const packageJsonPath = require.resolve('vis-network/package.json');
+  const packageDir = path.dirname(packageJsonPath);
+  const assetPath = path.join(packageDir, ...VIS_NETWORK_ASSET.split('/'));
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const source = fs.readFileSync(assetPath, 'utf8');
+
+  cachedViewerAsset = {
+    source,
+    metadata: {
+      packageName: packageJson.name,
+      version: packageJson.version,
+      license: packageJson.license || null,
+      asset: `vis-network/${VIS_NETWORK_ASSET}`,
+      sourceMode: 'bundled-inline',
+      sha256: crypto.createHash('sha256').update(source).digest('hex'),
+    },
+  };
+  return cachedViewerAsset;
+}
+
+function getArchitectureViewerAssetMetadata() {
+  return {
+    ...loadViewerAsset().metadata,
+  };
 }
 
 function renderSummary(graph) {
@@ -47,14 +86,17 @@ function renderHtml(graph) {
   const unresolvedSection = unresolvedPrograms.length > 0
     ? `<div class="unresolved"><strong>Unresolved Programs:</strong> ${unresolvedPrograms.join(', ')}</div>`
     : '';
+  const viewerAsset = loadViewerAsset();
+  const assetComment = `${viewerAsset.metadata.packageName}@${viewerAsset.metadata.version} | ${viewerAsset.metadata.asset} | ${viewerAsset.metadata.license || 'license-unknown'}`;
 
   return `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta name="zeus-viewer-library" content="${viewerAsset.metadata.packageName}@${viewerAsset.metadata.version}">
   <title>Architecture Viewer</title>
-  <script src="${VIS_NETWORK_CDN}"></script>
+  <!-- Bundled viewer asset: ${assetComment} -->
   <style>
     body {
       margin: 0;
@@ -81,13 +123,18 @@ function renderHtml(graph) {
       color: #64748b;
       margin-bottom: 8px;
     }
+    .asset {
+      font-size: 12px;
+      color: #64748b;
+      margin-bottom: 8px;
+    }
     .unresolved {
       font-size: 13px;
       color: #9f1239;
       margin: 6px 0;
     }
     #network {
-      height: calc(100vh - 126px);
+      height: calc(100vh - 144px);
       min-height: 540px;
       margin: 14px;
       border: 1px solid #d6dde8;
@@ -101,9 +148,11 @@ function renderHtml(graph) {
     <h1>Architecture Viewer</h1>
     <div class="summary">${renderSummary(graph)}</div>
     <div class="help">Mouse wheel: zoom | Drag canvas: pan | Drag nodes: reposition | Click node: highlight connected edges | Double-click node: center</div>
+    <div class="asset">Bundled asset: ${viewerAsset.metadata.packageName} ${viewerAsset.metadata.version}</div>
     ${unresolvedSection}
   </header>
   <div id="network"></div>
+  <script>${escapeInlineScript(viewerAsset.source)}</script>
   <script>
     const graphData = ${escapeInlineJson(graph)};
 
@@ -299,5 +348,6 @@ function generateArchitectureViewer({ graphPath, outputPath }) {
 
 module.exports = {
   generateArchitectureViewer,
+  getArchitectureViewerAssetMetadata,
   renderHtml,
 };

--- a/tests/analyze-stage-registry.test.js
+++ b/tests/analyze-stage-registry.test.js
@@ -1,0 +1,155 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  buildAnalyzeStageRegistry,
+  runAnalyzeCore,
+} = require('../src/analyze/analyzePipeline');
+const { createAnalyzeStageRegistry } = require('../src/analyze/stageRegistry');
+
+function createAnalyzeFixture() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-analyze-plugin-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  fs.mkdirSync(sourceRoot, { recursive: true });
+  fs.writeFileSync(path.join(sourceRoot, 'ORDERPGM.rpgle'), '**FREE\nCALL SUBPGM;\n', 'utf8');
+  fs.writeFileSync(path.join(sourceRoot, 'SUBPGM.rpgle'), '**FREE\nDCL-F ORDERS DISK;\n', 'utf8');
+  return {
+    tempRoot,
+    sourceRoot,
+  };
+}
+
+test('analyze stage registry resolves plugin stages deterministically around core stages', () => {
+  const registry = buildAnalyzeStageRegistry({
+    plugins: [{
+      name: 'custom-audit',
+      register({ registerStage }) {
+        registerStage({
+          id: 'plugin-audit',
+          title: 'Plugin audit stage',
+          category: 'plugin',
+          after: 'build-context',
+          before: 'optimize-context',
+          run(state) {
+            return state;
+          },
+        });
+      },
+    }],
+  });
+
+  const stageIds = registry.resolveStages().map((stage) => stage.id);
+  assert.equal(stageIds.indexOf('plugin-audit') > stageIds.indexOf('build-context'), true);
+  assert.equal(stageIds.indexOf('plugin-audit') < stageIds.indexOf('optimize-context'), true);
+
+  const stage = registry.listStages().find((entry) => entry.id === 'plugin-audit');
+  assert.equal(stage.pluginName, 'custom-audit');
+  assert.deepEqual(stage.before, ['optimize-context']);
+  assert.deepEqual(stage.after, ['build-context']);
+});
+
+test('analyze stage registry rejects unknown anchors and cyclic ordering', () => {
+  const unknownAnchorRegistry = createAnalyzeStageRegistry();
+  unknownAnchorRegistry.registerStage({
+    id: 'one',
+    run(state) {
+      return state;
+    },
+    after: 'missing-stage',
+  });
+  assert.throws(() => unknownAnchorRegistry.resolveStages(), /unknown after anchor: missing-stage/);
+
+  const cyclicRegistry = createAnalyzeStageRegistry();
+  cyclicRegistry.registerStage({
+    id: 'one',
+    after: 'two',
+    run(state) {
+      return state;
+    },
+  });
+  cyclicRegistry.registerStage({
+    id: 'two',
+    after: 'one',
+    run(state) {
+      return state;
+    },
+  });
+  assert.throws(() => cyclicRegistry.resolveStages(), /contains a cycle/);
+});
+
+test('runAnalyzeCore accepts plugin stages and lifecycle hooks without changing core wiring', () => {
+  const { tempRoot, sourceRoot } = createAnalyzeFixture();
+  const lifecycleEvents = [];
+
+  try {
+    const result = runAnalyzeCore({
+      program: 'ORDERPGM',
+      sourceRoot,
+      outputRoot: path.join(tempRoot, 'output'),
+      config: {
+        extensions: ['.rpgle'],
+        contextOptimizer: {},
+        testData: { limit: 10, maskColumns: [] },
+        db: null,
+      },
+      testDataLimit: 10,
+      skipTestData: true,
+      verbose: false,
+      optimizeContextEnabled: false,
+      logVerbose() {},
+      analyzePlugins: [{
+        name: 'custom-note-plugin',
+        register({ registerStage, registerLifecycleHooks }) {
+          registerLifecycleHooks({
+            beforeStage({ stage }) {
+              lifecycleEvents.push(`before:${stage.id}`);
+            },
+            afterStage({ stage, stageReport }) {
+              lifecycleEvents.push(`after:${stage.id}:${stageReport.status}`);
+            },
+          });
+
+          registerStage({
+            id: 'plugin-note',
+            title: 'Inject plugin note',
+            description: 'Adds a small plugin-owned marker into the analyze state.',
+            category: 'plugin',
+            after: 'build-context',
+            before: 'investigate-sources',
+            run(state) {
+              return {
+                ...state,
+                pluginNote: 'injected',
+                stageMetadata: {
+                  injected: true,
+                },
+                stageDiagnostics: [{
+                  severity: 'info',
+                  code: 'PLUGIN_NOTE',
+                  message: 'Plugin stage injected marker state.',
+                }],
+              };
+            },
+          });
+        },
+      }],
+    });
+
+    assert.equal(result.pluginNote, 'injected');
+    const pluginStage = result.stageReports.find((stage) => stage.id === 'plugin-note');
+    assert.ok(pluginStage);
+    assert.equal(pluginStage.status, 'completed');
+    assert.equal(pluginStage.definition.pluginName, 'custom-note-plugin');
+    assert.equal(pluginStage.definition.category, 'plugin');
+    assert.equal(pluginStage.definition.registrationOrder >= 0, true);
+    assert.deepEqual(pluginStage.metadata, { injected: true });
+    assert.ok(result.diagnostics.some((entry) => entry.code === 'PLUGIN_NOTE'));
+    assert.ok(lifecycleEvents.includes('before:plugin-note'));
+    assert.ok(lifecycleEvents.includes('after:plugin-note:completed'));
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/architecture-viewer.test.js
+++ b/tests/architecture-viewer.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  generateArchitectureViewer,
+  getArchitectureViewerAssetMetadata,
+  renderHtml,
+} = require('../src/viewer/architectureViewerGenerator');
+
+function createGraphFixture() {
+  return {
+    rootProgram: 'ORDERPGM',
+    summary: {
+      programCount: 2,
+      tableCount: 1,
+      copyMemberCount: 0,
+      edgeCount: 1,
+      unresolvedPrograms: [],
+    },
+    nodes: [
+      { id: 'ORDERPGM', type: 'PROGRAM' },
+      { id: 'ORDERS', type: 'TABLE' },
+    ],
+    edges: [
+      { from: 'ORDERPGM', to: 'ORDERS', type: 'USES_TABLE' },
+    ],
+    unresolvedPrograms: [],
+  };
+}
+
+test('architecture viewer renders as self-contained offline HTML with bundled asset metadata', () => {
+  const graph = createGraphFixture();
+  const metadata = getArchitectureViewerAssetMetadata();
+  const html = renderHtml(graph);
+
+  assert.equal(metadata.packageName, 'vis-network');
+  assert.match(metadata.version, /^\d+\.\d+\.\d+$/);
+  assert.equal(metadata.asset, 'vis-network/standalone/umd/vis-network.min.js');
+  assert.equal(metadata.sourceMode, 'bundled-inline');
+  assert.match(metadata.sha256, /^[a-f0-9]{64}$/);
+
+  assert.equal(/<script[^>]+src=/i.test(html), false);
+  assert.equal(html.includes('unpkg.com/vis-network'), false);
+  assert.match(html, /meta name="zeus-viewer-library"/);
+  assert.match(html, new RegExp(`Bundled asset: ${metadata.packageName} ${metadata.version}`));
+  assert.match(html, /new vis\.Network/);
+});
+
+test('generateArchitectureViewer writes a portable offline artifact to disk', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-architecture-viewer-'));
+  const graphPath = path.join(tempRoot, 'program-call-tree.json');
+  const outputPath = path.join(tempRoot, 'architecture.html');
+
+  try {
+    fs.writeFileSync(graphPath, `${JSON.stringify(createGraphFixture(), null, 2)}\n`, 'utf8');
+    const writtenPath = generateArchitectureViewer({
+      graphPath,
+      outputPath,
+    });
+
+    assert.equal(writtenPath, outputPath);
+    assert.equal(fs.existsSync(outputPath), true);
+    const html = fs.readFileSync(outputPath, 'utf8');
+    assert.equal(/<script[^>]+src=/i.test(html), false);
+    assert.equal(html.includes('unpkg.com/vis-network'), false);
+    assert.match(html, /Bundled viewer asset: vis-network@/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/local-ui-server.test.js
+++ b/tests/local-ui-server.test.js
@@ -1,0 +1,156 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const { startLocalUiServer } = require('../src/ui/localUiServer');
+
+const projectRoot = path.resolve(__dirname, '..');
+const cliPath = path.join(projectRoot, 'cli', 'zeus.js');
+
+function createUiFixture() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-local-ui-'));
+  const outputRoot = path.join(tempRoot, 'output');
+  const programDir = path.join(outputRoot, 'ORDERPGM');
+  const safeDir = path.join(programDir, 'safe-sharing');
+  fs.mkdirSync(safeDir, { recursive: true });
+
+  fs.writeFileSync(path.join(programDir, 'report.md'), '# Report\n\nSummary.\n', 'utf8');
+  fs.writeFileSync(path.join(programDir, 'context.json'), `${JSON.stringify({ program: 'ORDERPGM' }, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(path.join(programDir, 'architecture.html'), '<!doctype html><title>Architecture Viewer</title>', 'utf8');
+  fs.writeFileSync(path.join(safeDir, 'report.md'), '# Safe Report\n', 'utf8');
+  fs.writeFileSync(path.join(programDir, 'analyze-run-manifest.json'), `${JSON.stringify({
+    schemaVersion: 1,
+    tool: { name: 'zeus-rpg-promptkit', command: 'analyze' },
+    run: {
+      status: 'succeeded',
+      completedAt: '2026-04-13T12:00:00.000Z',
+    },
+    inputs: {
+      sourceRoot: 'C:/temp/src',
+      options: {
+        guidedMode: { name: 'modernization' },
+        workflowPreset: { name: 'modernization-review' },
+        reproducibleEnabled: false,
+      },
+      sourceSnapshot: {
+        fileCount: 2,
+      },
+    },
+    summary: {
+      stageCount: 8,
+      diagnosticCount: 1,
+    },
+    artifacts: [
+      { path: 'context.json', kind: 'json', sizeBytes: 24, sha256: 'a' },
+      { path: 'report.md', kind: 'markdown', sizeBytes: 18, sha256: 'b' },
+      { path: 'architecture.html', kind: 'html', sizeBytes: 48, sha256: 'c' },
+    ],
+  }, null, 2)}\n`, 'utf8');
+
+  return {
+    tempRoot,
+    outputRoot,
+  };
+}
+
+test('local UI server exposes runs, details, and artifact content through a read-only API', async () => {
+  const { tempRoot, outputRoot } = createUiFixture();
+  let started = null;
+
+  try {
+    started = await startLocalUiServer({
+      outputRoot,
+      port: 0,
+    });
+
+    const health = await fetch(`${started.url}/api/health`).then((response) => response.json());
+    assert.equal(health.ok, true);
+
+    const runs = await fetch(`${started.url}/api/runs`).then((response) => response.json());
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].program, 'ORDERPGM');
+    assert.equal(runs[0].workflowPreset, 'modernization-review');
+
+    const detail = await fetch(`${started.url}/api/runs/ORDERPGM`).then((response) => response.json());
+    assert.equal(detail.summary.program, 'ORDERPGM');
+    assert.ok(detail.artifacts.some((artifact) => artifact.path === 'architecture.html'));
+    assert.ok(detail.artifacts.some((artifact) => artifact.path === 'safe-sharing/report.md'));
+
+    const artifact = await fetch(`${started.url}/api/runs/ORDERPGM/artifacts/content?path=report.md`).then((response) => response.json());
+    assert.equal(artifact.kind, 'markdown');
+    assert.match(artifact.content, /Summary\./);
+
+    const rawArtifactResponse = await fetch(`${started.url}/runs/ORDERPGM/artifacts/raw?path=architecture.html`);
+    assert.equal(rawArtifactResponse.status, 200);
+    assert.match(rawArtifactResponse.headers.get('content-type'), /text\/html/);
+    assert.match(await rawArtifactResponse.text(), /Architecture Viewer/);
+
+    const shellHtml = await fetch(`${started.url}/`).then((response) => response.text());
+    assert.match(shellHtml, /Zeus Local UI/);
+    assert.match(shellHtml, /\/api\/runs/);
+
+    const traversal = await fetch(`${started.url}/api/runs/ORDERPGM/artifacts/content?path=..%2Fsecret.txt`);
+    assert.equal(traversal.status, 400);
+  } finally {
+    if (started) {
+      await new Promise((resolve) => started.server.close(resolve));
+    }
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('serve CLI boots the local UI shell on loopback and answers health checks', async () => {
+  const { tempRoot, outputRoot } = createUiFixture();
+
+  try {
+    const child = spawn(process.execPath, [cliPath, 'serve', '--source-output-root', outputRoot, '--port', '0'], {
+      cwd: projectRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    const started = await new Promise((resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
+
+      const timeout = setTimeout(() => {
+        child.kill('SIGTERM');
+        reject(new Error(`serve command did not start in time\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+      }, 10000);
+
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString('utf8');
+        const match = stdout.match(/Zeus local UI available at: (http:\/\/[^\s]+)/);
+        if (match) {
+          clearTimeout(timeout);
+          resolve(match[1]);
+        }
+      });
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString('utf8');
+      });
+      child.once('error', (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      child.once('exit', (code) => {
+        if (code !== null && code !== 0) {
+          clearTimeout(timeout);
+          reject(new Error(`serve command exited early with code ${code}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+        }
+      });
+    });
+
+    const health = await fetch(`${started}/api/health`).then((response) => response.json());
+    assert.equal(health.ok, true);
+
+    await new Promise((resolve) => {
+      child.once('exit', () => resolve());
+      child.kill('SIGTERM');
+    });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/reproducible-output.test.js
+++ b/tests/reproducible-output.test.js
@@ -46,6 +46,7 @@ test('reproducible mode produces identical analyze, impact, and bundle artifacts
     'optimized-context.json',
     'ai-knowledge.json',
     'analysis-index.json',
+    'architecture.html',
     'report.md',
     'architecture-report.md',
     'ai_prompt_documentation.md',

--- a/tests/safe-sharing.test.js
+++ b/tests/safe-sharing.test.js
@@ -47,6 +47,7 @@ test('analyze --safe-sharing writes redacted variants with stable placeholders',
     assert.equal(fs.existsSync(path.join(safeDir, 'context.json')), true);
     assert.equal(fs.existsSync(path.join(safeDir, 'ai-knowledge.json')), true);
     assert.equal(fs.existsSync(path.join(safeDir, 'report.md')), true);
+    assert.equal(fs.existsSync(path.join(safeDir, 'architecture.html')), true);
     assert.equal(fs.existsSync(path.join(safeDir, 'ai_prompt_documentation.md')), true);
     assert.equal(fs.existsSync(path.join(safeDir, 'ai_prompt_modernization.md')), true);
     assert.equal(fs.existsSync(path.join(safeDir, 'analyze-run-manifest.json')), true);
@@ -56,6 +57,7 @@ test('analyze --safe-sharing writes redacted variants with stable placeholders',
     const safeManifest = readJson(path.join(safeDir, 'redaction-manifest.json'));
     const safeReport = fs.readFileSync(path.join(safeDir, 'report.md'), 'utf8');
     const safePrompt = fs.readFileSync(path.join(safeDir, 'ai_prompt_modernization.md'), 'utf8');
+    const safeViewer = fs.readFileSync(path.join(safeDir, 'architecture.html'), 'utf8');
 
     assert.equal(safeContext.program, 'PROGRAM_001');
     assert.ok(safeContext.dependencies.tables.every((entry) => /^TABLE_\d{3}$/.test(entry.name)));
@@ -69,6 +71,8 @@ test('analyze --safe-sharing writes redacted variants with stable placeholders',
     assert.ok(safeManifest.summary.placeholderCounts.TABLE >= 1);
     assert.ok(safeManifest.summary.placeholderCounts.VALUE >= 1);
     assert.ok(safeManifest.redactedArtifacts.includes('safe-sharing/report.md'));
+    assert.equal(/<script[^>]+src=/i.test(safeViewer), false);
+    assert.doesNotMatch(safeViewer, /unpkg\.com\/vis-network/);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/tests/v1-smoke.test.js
+++ b/tests/v1-smoke.test.js
@@ -149,6 +149,10 @@ test('V1 smoke flow generates analysis artifacts and bundle outputs', () => {
     const graph = readJson(path.join(programOutputDir, 'program-call-tree.json'));
     assert.equal(graph.summary.programCount, 2);
     assert.equal(graph.summary.tableCount, 3);
+    const architectureViewer = fs.readFileSync(path.join(programOutputDir, 'architecture.html'), 'utf8');
+    assert.equal(/<script[^>]+src=/i.test(architectureViewer), false);
+    assert.doesNotMatch(architectureViewer, /unpkg\.com\/vis-network/);
+    assert.match(architectureViewer, /Bundled asset: vis-network /);
 
     const analyzeManifest = readJson(path.join(programOutputDir, 'analyze-run-manifest.json'));
     assert.equal(analyzeManifest.schemaVersion, 1);
@@ -167,6 +171,7 @@ test('V1 smoke flow generates analysis artifacts and bundle outputs', () => {
     assert.ok(analyzeManifest.stages.some((stage) => stage.id === 'investigate-sources'));
     assert.ok(analyzeManifest.stages.some((stage) => stage.id === 'run-diagnostic-packs'));
     assert.ok(analyzeManifest.stages.some((stage) => stage.id === 'write-artifacts'));
+    assert.ok(analyzeManifest.stages.every((stage) => Object.prototype.hasOwnProperty.call(stage, 'definition')));
     assert.ok(analyzeManifest.artifacts.some((artifact) => artifact.path === 'context.json'));
     assert.ok(analyzeManifest.artifacts.some((artifact) => artifact.path === 'analysis-index.json'));
     assert.equal(analyzeManifest.comparison, null);


### PR DESCRIPTION
## Summary
- add a registry-backed analyzer stage pipeline with deterministic ordering, lifecycle hooks, and stage definition metadata in diagnostics/manifests
- make rchitecture.html offline-capable and version-stable by bundling pinned is-network inline instead of using a CDN
- add a local-only read-only serve command with a manifest-driven analysis API and lightweight browser shell over existing output artifacts
- document the internal stage contract, viewer asset strategy, and local UI shell/API contract

## Validation
- node --test tests/analyze-stage-registry.test.js tests/architecture-viewer.test.js tests/analyze-stages.test.js
- node --test tests/local-ui-server.test.js tests/v1-smoke.test.js tests/analyze-run-manifest.test.js tests/analyze-runtime-contract.test.js
- npm run test:benchmark
- npm test

## Notes
- 
pm audit --omit=dev still reports the existing asic-ftp advisory; this PR does not change the FTP transport dependency path
- the new local UI slice is intentionally read-only and loopback-only; richer interactive panels remain future work

Closes #43
Closes #52
Closes #64