### PR TITLE
Add SQL querying, diffing, and member-based resolution

### DIFF
--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -22,19 +22,23 @@ const { runWorkflow } = require('../src/cli/commands/workflowCommand');
 const { runServe } = require('../src/cli/commands/serveCommand');
 const { runDoctor } = require('../src/cli/commands/doctorCommand');
 const { runQueryTable } = require('../src/cli/commands/queryTableCommand');
+const { runQuerySql } = require('../src/cli/commands/querySqlCommand');
 const { runCopyToWorkspace } = require('../src/cli/commands/copyToWorkspaceCommand');
+const { runDiff } = require('../src/cli/commands/diffCommand');
 
 function printHelp() {
   console.log('Usage:');
-  console.log('  zeus [--config <path>] analyze --source <path> --program <name> [--profile <name>] [--out <path>] [--extensions .rpgle,.rpg] [--mode <name>] [--list-modes] [--list-diagnostic-packs] [--optimize-context] [--scan-ifs-paths] [--search-terms a,b] [--search-ignore path1,path2] [--search-max-results <n>] [--diagnostic-packs a,b] [--diagnostic-params k=v] [--host <hostname>] [--user <username>] [--password <password>] [--safe-sharing] [--emit-diagnostics] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
+  console.log('  zeus [--config <path>] analyze --source <path> (--program <name> | --member <name>) [--profile <name>] [--out <path>] [--extensions .rpgle,.rpg] [--mode <name>] [--list-modes] [--list-diagnostic-packs] [--optimize-context] [--scan-ifs-paths] [--search-terms a,b] [--search-ignore path1,path2] [--search-max-results <n>] [--diagnostic-packs a,b] [--diagnostic-params k=v] [--host <hostname>] [--user <username>] [--password <password>] [--safe-sharing] [--emit-diagnostics] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
   console.log('  zeus [--config <path>] workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.rpg] [--list-presets] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
   console.log('  zeus [--config <path>] bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--safe-sharing] [--reproducible] [--profile <name>] [--verbose]');
-  console.log('  zeus [--config <path>] impact --target <name> [--program <name>] [--out <path>] [--profile <name>] [--source <path>] [--reproducible] [--verbose]');
+  console.log('  zeus [--config <path>] impact (--target <name> | --field <name>) [--program <name> | --member <name>] [--out <path>] [--profile <name>] [--source <path>] [--reproducible] [--verbose]');
   console.log('  zeus [--config <path>] fetch --host <hostname> --user <username> --password <password> --source-lib <lib> --ifs-dir <ifsPath> --out <localPath> [--files <list>] [--members <list>] [--replace true|false] [--streamfile-ccsid <ccsid>] [--transport auto|sftp|jt400|ftp] [--profile <name>] [--verbose]');
   console.log('  zeus [--config <path>] serve [--source-output-root <path>] [--profile <name>] [--host 127.0.0.1] [--port <n>] [--verbose]');
   console.log('  zeus [--config <path>] doctor --profile <name>');
   console.log('  zeus [--config <path>] query-table --profile <name> --table <name> [--schema <name>] [--filter <pattern>]');
+  console.log('  zeus [--config <path>] query-sql --profile <name> --sql "SELECT ..." [--max-rows <n>] [--output table|csv]');
   console.log('  zeus [--config <path>] copy-to-workspace --profile <name> [--members <M1,M2,...>] [--force]');
+  console.log('  zeus [--config <path>] diff --profile <name> --member <name>');
 }
 
 function parseArgs(argv) {
@@ -132,8 +136,18 @@ async function main() {
     return;
   }
 
+  if (command === 'query-sql') {
+    await runQuerySql(args);
+    return;
+  }
+
   if (command === 'copy-to-workspace') {
     await runCopyToWorkspace(args);
+    return;
+  }
+
+  if (command === 'diff') {
+    await runDiff(args);
     return;
   }
 

--- a/config/profiles.example.json
+++ b/config/profiles.example.json
@@ -29,6 +29,37 @@
       }
     ]
   },
+  "default-shared": {
+    "outputRoot": "${env:ZEUS_OUTPUT_ROOT}",
+    "extensions": [".rpgle", ".sqlrpgle", ".clle", ".clp", ".dds", ".pf", ".lf", ".bnd", ".cpy"],
+    "db": {
+      "host": "${env:ZEUS_DB_HOST}",
+      "url": "${env:ZEUS_DB_URL}",
+      "user": "${env:ZEUS_DB_USER}",
+      "password": "${env:ZEUS_DB_PASSWORD}",
+      "defaultLibrary": "${env:ZEUS_DB_DEFAULT_LIBRARY}",
+      "defaultSchema": "${env:ZEUS_DB_DEFAULT_SCHEMA}"
+    }
+  },
+  "default-fetch": {
+    "extends": "default-shared",
+    "fetch": {
+      "host": "${env:ZEUS_FETCH_HOST}",
+      "user": "${env:ZEUS_FETCH_USER}",
+      "password": "${env:ZEUS_FETCH_PASSWORD}",
+      "sourceLib": "${env:ZEUS_FETCH_SOURCE_LIB}",
+      "ifsDir": "${env:ZEUS_FETCH_IFS_DIR}",
+      "out": "${env:ZEUS_FETCH_OUT}",
+      "files": ["QRPGLESRC", "QSRVSRC", "QCPYSRC", "QCLLESRC", "QCLSRC", "QSQLSRC", "SQLTBLSRC", "SQLVIEWSRC", "SQLIDXSRC", "FORMSRC", "QDDSSRC"],
+      "streamFileCcsid": 1208,
+      "replace": true,
+      "transport": "auto"
+    }
+  },
+  "default-local": {
+    "extends": "default-shared",
+    "sourceRoot": "${env:ZEUS_SOURCE_ROOT}"
+  },
   "default": {
     "sourceRoot": "./rpg",
     "outputRoot": "./output",

--- a/src/cli/commands/analyzeCommand.js
+++ b/src/cli/commands/analyzeCommand.js
@@ -28,6 +28,7 @@ const { buildSafeSharingArtifacts } = require('../../sharing/safeSharingArtifact
 const { listWorkflowModes, resolveWorkflowModeSettings } = require('../../workflow/workflowModeRegistry');
 const { resolvePromptTemplates } = require('../../prompt/promptBuilder');
 const { listDiagnosticPacks } = require('../../investigation/diagnosticPackRegistry');
+const { resolveMemberProgram } = require('../helpers/memberResolver');
 const {
   normalizeReproducibilitySettings,
   resolveDurationMs,
@@ -93,12 +94,32 @@ function runAnalyze(args) {
     }
   };
 
-  if (!args.program || !String(args.program).trim()) {
+  const config = resolveAnalyzeConfig(args);
+  let resolvedProgram = args.program;
+
+  if ((!resolvedProgram || !String(resolvedProgram).trim()) && args.member) {
+    if (!config.sourceRoot || !String(config.sourceRoot).trim()) {
+      console.error('Missing required option: --source <path>');
+      process.exit(2);
+    }
+    try {
+      const memberResolution = resolveMemberProgram({
+        member: args.member,
+        sourceRoot: config.sourceRoot,
+        extensions: config.extensions,
+      });
+      resolvedProgram = memberResolution.program;
+    } catch (error) {
+      console.error(error.message);
+      process.exit(2);
+    }
+  }
+
+  if (!resolvedProgram || !String(resolvedProgram).trim()) {
     console.error('Missing required option: --program <name>');
     process.exit(2);
   }
 
-  const config = resolveAnalyzeConfig(args);
   if (!config.sourceRoot || !String(config.sourceRoot).trim()) {
     console.error('Missing required option: --source <path>');
     process.exit(2);
@@ -106,7 +127,7 @@ function runAnalyze(args) {
 
   const sourceRoot = path.resolve(process.cwd(), config.sourceRoot);
   const outputRoot = path.resolve(process.cwd(), config.outputRoot);
-  const program = String(args.program).trim();
+  const program = String(resolvedProgram).trim();
   const workflowPreset = args['workflow-preset-settings'] && typeof args['workflow-preset-settings'] === 'object'
     ? {
       ...args['workflow-preset-settings'],

--- a/src/cli/commands/diffCommand.js
+++ b/src/cli/commands/diffCommand.js
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const path = require('path');
+const { loadProfiles, readWorkCopyConfig, resolveAnalyzeConfig, resolveFetchConfig, resolveProfile } = require('../../config/runtimeConfig');
+const { renderAsciiTable } = require('../helpers/asciiTable');
+const { buildLineComparison, readLines, resolveDiffPaths } = require('../../diff/workspaceDiffService');
+
+async function runDiff(args) {
+  if (!args.profile || !String(args.profile).trim()) {
+    console.error('Missing required option: --profile <name>');
+    process.exit(2);
+  }
+  if (!args.member || !String(args.member).trim()) {
+    console.error('Missing required option: --member <name>');
+    process.exit(2);
+  }
+
+  const cwd = process.cwd();
+  const env = process.env;
+  const profiles = loadProfiles({ cwd, env, args });
+  const profile = resolveProfile(profiles, args.profile, { env });
+  const analyzeConfig = resolveAnalyzeConfig(args, { cwd, env });
+  const fetchConfig = resolveFetchConfig(args, { cwd, env });
+  const workCopyConfig = readWorkCopyConfig(profile, env);
+  const fetchRoot = path.resolve(cwd, fetchConfig.out);
+  const workspaceRoot = path.resolve(cwd, analyzeConfig.sourceRoot || workCopyConfig.root);
+  const resolved = resolveDiffPaths({
+    member: args.member,
+    fetchRoot,
+    workspaceRoot,
+    workCopyMode: workCopyConfig.extension,
+  });
+  const comparison = buildLineComparison(
+    readLines(resolved.originalPath),
+    readLines(resolved.modifiedPath),
+  );
+
+  console.log(`Member: ${resolved.member}`);
+  console.log(`Original: ${resolved.originalPath}`);
+  console.log(`Modified: ${resolved.modifiedPath}`);
+  console.log('');
+  console.log(renderAsciiTable(
+    ['Line', 'Diff', 'Original', 'Modified'],
+    comparison.rows.map((row) => [row.line, row.marker, row.original, row.modified]),
+    { maxCellWidth: 60 },
+  ));
+  console.log(`Changed lines: ${comparison.changedCount}`);
+}
+
+module.exports = {
+  runDiff,
+};

--- a/src/cli/commands/doctorCommand.js
+++ b/src/cli/commands/doctorCommand.js
@@ -18,6 +18,7 @@ const {
   getProfilesMetadata,
   loadProfiles,
   resolveAnalyzeConfig,
+  resolveFetchConfig,
   resolveProfile,
 } = require('../../config/runtimeConfig');
 const {
@@ -33,6 +34,7 @@ const { renderAsciiTable } = require('../helpers/asciiTable');
 function formatStatus(status) {
   if (status === 'PASS') return '[PASS]';
   if (status === 'FAIL') return '[FAIL]';
+  if (status === 'WARN') return '[WARN]';
   return '[SKIP]';
 }
 
@@ -48,10 +50,180 @@ function extractJavaVersion(output) {
     .find(Boolean) || 'unknown';
 }
 
+function isSet(value) {
+  return value !== undefined && value !== null && String(value).trim().length > 0;
+}
+
+function buildSetHint(name, value) {
+  return `set ${name}=${value}`;
+}
+
+function addEnvCheck(checks, { name, expected = true, envValue, fallbackValue = '', required = true, hint }) {
+  if (!expected) {
+    return;
+  }
+
+  if (isSet(envValue)) {
+    checks.push({
+      name,
+      status: 'PASS',
+      details: `${name} gesetzt`,
+    });
+    return;
+  }
+
+  if (isSet(fallbackValue)) {
+    checks.push({
+      name,
+      status: required ? 'WARN' : 'WARN',
+      details: `${name} nicht gesetzt → Profil liefert Fallback (${buildSetHint(name, hint)})`,
+    });
+    return;
+  }
+
+  checks.push({
+    name,
+    status: required ? 'FAIL' : 'WARN',
+    details: `${name} nicht gesetzt -> ${buildSetHint(name, hint)}`,
+  });
+}
+
+function buildEnvironmentChecks({ profile, analyzeConfig, fetchConfig, env }) {
+  const checks = [];
+  const profileHasDb = Boolean(profile && profile.db);
+  const profileHasFetch = Boolean(profile && profile.fetch);
+  const dbUsesUrl = isSet(env.ZEUS_DB_URL);
+  const dbProfile = profile && profile.db ? profile.db : {};
+  const fetchProfile = profile && profile.fetch ? profile.fetch : {};
+
+  if (profileHasDb) {
+    addEnvCheck(checks, {
+      name: 'ZEUS_DB_URL',
+      expected: true,
+      envValue: env.ZEUS_DB_URL,
+      fallbackValue: dbProfile.url,
+      required: false,
+      hint: 'jdbc:as400://mein-ibmi-host;naming=system;libraries=DATEIEN',
+    });
+    addEnvCheck(checks, {
+      name: 'ZEUS_DB_HOST',
+      expected: true,
+      envValue: env.ZEUS_DB_HOST,
+      fallbackValue: dbProfile.host,
+      required: !dbUsesUrl,
+      hint: 'mein-ibmi-host',
+    });
+    addEnvCheck(checks, {
+      name: 'ZEUS_DB_USER',
+      expected: true,
+      envValue: env.ZEUS_DB_USER,
+      fallbackValue: dbProfile.user,
+      required: true,
+      hint: 'MEINUSER',
+    });
+    addEnvCheck(checks, {
+      name: 'ZEUS_DB_PASSWORD',
+      expected: true,
+      envValue: env.ZEUS_DB_PASSWORD,
+      fallbackValue: dbProfile.password,
+      required: true,
+      hint: 'mein-passwort',
+    });
+    addEnvCheck(checks, {
+      name: 'ZEUS_DB_DEFAULT_LIBRARY',
+      expected: true,
+      envValue: env.ZEUS_DB_DEFAULT_LIBRARY,
+      fallbackValue: dbProfile.defaultLibrary,
+      required: false,
+      hint: 'DATEIEN',
+    });
+    addEnvCheck(checks, {
+      name: 'ZEUS_DB_DEFAULT_SCHEMA',
+      expected: true,
+      envValue: env.ZEUS_DB_DEFAULT_SCHEMA,
+      fallbackValue: dbProfile.defaultSchema,
+      required: false,
+      hint: 'DATEIEN',
+    });
+  }
+
+  if (profileHasFetch) {
+    addEnvCheck(checks, {
+      name: 'ZEUS_FETCH_HOST',
+      expected: true,
+      envValue: env.ZEUS_FETCH_HOST,
+      fallbackValue: fetchProfile.host,
+      required: true,
+      hint: 'mein-ibmi-host',
+    });
+    addEnvCheck(checks, {
+      name: 'ZEUS_FETCH_USER',
+      expected: true,
+      envValue: env.ZEUS_FETCH_USER,
+      fallbackValue: fetchProfile.user,
+      required: true,
+      hint: 'MEINUSER',
+    });
+    addEnvCheck(checks, {
+      name: 'ZEUS_FETCH_PASSWORD',
+      expected: true,
+      envValue: env.ZEUS_FETCH_PASSWORD,
+      fallbackValue: fetchProfile.password,
+      required: true,
+      hint: 'mein-passwort',
+    });
+    addEnvCheck(checks, {
+      name: 'ZEUS_FETCH_SOURCE_LIB',
+      expected: true,
+      envValue: env.ZEUS_FETCH_SOURCE_LIB,
+      fallbackValue: fetchProfile.sourceLib,
+      required: true,
+      hint: 'SOURCEN',
+    });
+    addEnvCheck(checks, {
+      name: 'ZEUS_FETCH_IFS_DIR',
+      expected: true,
+      envValue: env.ZEUS_FETCH_IFS_DIR,
+      fallbackValue: fetchProfile.ifsDir,
+      required: true,
+      hint: '/home/zeus/rpg_sources',
+    });
+    addEnvCheck(checks, {
+      name: 'ZEUS_FETCH_OUT',
+      expected: true,
+      envValue: env.ZEUS_FETCH_OUT,
+      fallbackValue: fetchProfile.out,
+      required: true,
+      hint: 'C:/Projekte/ticket/zeus-fetch',
+    });
+  }
+
+  addEnvCheck(checks, {
+    name: 'ZEUS_OUTPUT_ROOT',
+    expected: true,
+    envValue: env.ZEUS_OUTPUT_ROOT,
+    fallbackValue: profile && profile.outputRoot,
+    required: false,
+    hint: 'C:/Projekte/ticket/zeus-output',
+  });
+  addEnvCheck(checks, {
+    name: 'ZEUS_SOURCE_ROOT',
+    expected: true,
+    envValue: env.ZEUS_SOURCE_ROOT,
+    fallbackValue: profile && profile.sourceRoot,
+    required: false,
+    hint: 'C:/Projekte/ticket/zeus-source',
+  });
+
+  return checks;
+}
+
 function runDoctorChecks(args, { cwd = process.cwd(), env = process.env } = {}) {
   const checks = [];
   let hasCriticalFailure = false;
   let resolvedAnalyzeConfig = null;
+  let resolvedFetchConfig = null;
+  let resolvedProfile = null;
 
   if (!args.profile || !String(args.profile).trim()) {
     throw new Error('Missing required option: --profile <name>');
@@ -59,8 +231,9 @@ function runDoctorChecks(args, { cwd = process.cwd(), env = process.env } = {}) 
 
   try {
     const profiles = loadProfiles({ cwd, env, args });
-    resolveProfile(profiles, args.profile, { env });
+    resolvedProfile = resolveProfile(profiles, args.profile, { env });
     resolvedAnalyzeConfig = resolveAnalyzeConfig(args, { cwd, env });
+    resolvedFetchConfig = resolvedProfile && resolvedProfile.fetch ? resolveFetchConfig(args, { cwd, env }) : null;
     const metadata = getProfilesMetadata(profiles);
     checks.push({
       name: 'Config/Profile',
@@ -74,6 +247,17 @@ function runDoctorChecks(args, { cwd = process.cwd(), env = process.env } = {}) 
       status: 'FAIL',
       details: error.message,
     });
+  }
+
+  const envChecks = buildEnvironmentChecks({
+    profile: resolvedProfile,
+    analyzeConfig: resolvedAnalyzeConfig,
+    fetchConfig: resolvedFetchConfig,
+    env,
+  });
+  checks.push(...envChecks);
+  if (envChecks.some((entry) => entry.status === 'FAIL')) {
+    hasCriticalFailure = true;
   }
 
   const javaResult = spawnSync('java', ['-version'], {
@@ -179,6 +363,7 @@ async function runDoctor(args) {
 }
 
 module.exports = {
+  buildEnvironmentChecks,
   runDoctor,
   runDoctorChecks,
 };

--- a/src/cli/commands/impactCommand.js
+++ b/src/cli/commands/impactCommand.js
@@ -15,6 +15,7 @@ const path = require('path');
 const { generateImpactAnalysis, normalizeId } = require('../../impact/impactAnalyzer');
 const { resolveAnalyzeConfig } = require('../../config/runtimeConfig');
 const { findImpactGraph } = require('../helpers/impactGraphResolver');
+const { resolveMemberProgram } = require('../helpers/memberResolver');
 const { normalizeReproducibilitySettings } = require('../../reproducibility/reproducibility');
 
 function runImpact(args) {
@@ -25,17 +26,40 @@ function runImpact(args) {
     }
   };
 
+  if (!args.target && args.field) {
+    args.target = args.field;
+  }
+
   if (!args.target || !String(args.target).trim()) {
     console.error('Missing required option: --target <name>');
     process.exit(2);
   }
 
   const config = resolveAnalyzeConfig(args);
+  let resolvedProgram = args.program;
+  if ((!resolvedProgram || !String(resolvedProgram).trim()) && args.member) {
+    if (!config.sourceRoot || !String(config.sourceRoot).trim()) {
+      console.error('Missing required option: --source <path>');
+      process.exit(2);
+    }
+    try {
+      const memberResolution = resolveMemberProgram({
+        member: args.member,
+        sourceRoot: config.sourceRoot,
+        extensions: config.extensions,
+      });
+      resolvedProgram = memberResolution.program;
+    } catch (error) {
+      console.error(error.message);
+      process.exit(2);
+    }
+  }
+
   const outputRoot = path.resolve(process.cwd(), config.outputRoot);
   const resolved = findImpactGraph({
     outputRoot,
     target: args.target,
-    program: args.program,
+    program: resolvedProgram,
   });
 
   logVerbose(`Target: ${normalizeId(args.target)}`);

--- a/src/cli/commands/querySqlCommand.js
+++ b/src/cli/commands/querySqlCommand.js
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const { resolveAnalyzeConfig } = require('../../config/runtimeConfig');
+const { isDbConfigured } = require('../../db2/db2Config');
+const { runReadOnlyDb2Query, validateReadOnlySql } = require('../../db2/readOnlyQueryService');
+const { renderAsciiTable } = require('../helpers/asciiTable');
+const { renderCsv } = require('../helpers/csvRenderer');
+
+const DEFAULT_MAX_ROWS = 200;
+
+function parseMaxRows(value) {
+  if (value === undefined || value === null || value === true) {
+    return DEFAULT_MAX_ROWS;
+  }
+  const parsed = Number.parseInt(String(value).trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error('Invalid option: --max-rows must be a positive integer');
+  }
+  return parsed;
+}
+
+function normalizeOutput(value) {
+  const normalized = String(value || 'table').trim().toLowerCase();
+  if (normalized === 'table' || normalized === 'csv') {
+    return normalized;
+  }
+  throw new Error('Invalid option: --output must be one of: table, csv');
+}
+
+function toRowMatrix(columns, rows) {
+  return (rows || []).map((row) => (columns || []).map((column) => row && typeof row === 'object' ? row[column] : ''));
+}
+
+async function runQuerySql(args) {
+  if (!args.profile || !String(args.profile).trim()) {
+    console.error('Missing required option: --profile <name>');
+    process.exit(2);
+  }
+  if (!args.sql || !String(args.sql).trim()) {
+    console.error('Missing required option: --sql "SELECT ..."');
+    process.exit(2);
+  }
+
+  const sql = String(args.sql).trim();
+  const maxRows = parseMaxRows(args['max-rows']);
+  const output = normalizeOutput(args.output);
+  const config = resolveAnalyzeConfig(args);
+
+  if (!isDbConfigured(config.db)) {
+    console.error('DB2 connection configuration is incomplete for the selected profile.');
+    process.exit(2);
+  }
+
+  validateReadOnlySql(sql);
+  const result = runReadOnlyDb2Query({
+    dbConfig: config.db,
+    query: sql,
+    maxRows,
+  });
+  const columns = Array.isArray(result.columns) ? result.columns : [];
+  const matrix = toRowMatrix(columns, result.rows);
+
+  if (output === 'csv') {
+    process.stdout.write(renderCsv(columns, matrix));
+    return;
+  }
+
+  console.log(`SQL: ${sql}`);
+  console.log('');
+
+  if (matrix.length === 0) {
+    console.log('0 row(s) returned');
+    return;
+  }
+
+  console.log(renderAsciiTable(columns, matrix, { maxCellWidth: 40 }));
+  console.log(`${matrix.length} row(s) returned`);
+}
+
+module.exports = {
+  DEFAULT_MAX_ROWS,
+  normalizeOutput,
+  parseMaxRows,
+  runQuerySql,
+  toRowMatrix,
+};

--- a/src/cli/commands/queryTableCommand.js
+++ b/src/cli/commands/queryTableCommand.js
@@ -14,13 +14,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 const {
   resolveAnalyzeConfig,
 } = require('../../config/runtimeConfig');
-const { resolveDefaultSchema, isDbConfigured } = require('../../db2/db2Config');
+const { isDbConfigured } = require('../../db2/db2Config');
 const {
   escapeSqlLiteral,
-  runReadOnlyDb2Query,
+  executeReadOnlyDb2QueryWithFallback,
   validateSqlIdentifier,
 } = require('../../db2/readOnlyQueryService');
 const { renderAsciiTable } = require('../helpers/asciiTable');
+const { discoverSchema } = require('../../db2/schemaDiscovery');
 
 function validateFilterPattern(value) {
   const normalized = String(value || '').trim().toUpperCase();
@@ -47,7 +48,7 @@ function buildQueryTableQueries({ schema, table, filter }) {
   }
 
   return {
-    tableInfo: `SELECT TABLE_SCHEMA, TABLE_NAME, ROW_COUNT
+    tableInfo: `SELECT TABLE_SCHEMA, TABLE_NAME
 FROM QSYS2.SYSTABLES
 WHERE ${whereClauses.join(' AND ')}
 ORDER BY TABLE_SCHEMA, TABLE_NAME`,
@@ -77,21 +78,65 @@ async function runQueryTable(args) {
   const table = validateSqlIdentifier(args.table, '--table');
   const schema = args.schema
     ? validateSqlIdentifier(args.schema, '--schema')
-    : resolveDefaultSchema(config.db);
+    : null;
   const filter = args.filter ? validateFilterPattern(args.filter) : '';
-  const queries = buildQueryTableQueries({ schema, table, filter });
-  const tableInfo = runReadOnlyDb2Query({
+  const discovered = !schema ? discoverSchema(config.db, table) : null;
+  const effectiveSchema = schema || (discovered && discovered.TABLE_SCHEMA ? String(discovered.TABLE_SCHEMA).trim().toUpperCase() : '');
+  const queries = buildQueryTableQueries({ schema: effectiveSchema, table, filter });
+  const tableInfo = executeReadOnlyDb2QueryWithFallback({
     dbConfig: config.db,
     query: queries.tableInfo,
     maxRows: 50,
+    context: {
+      table,
+      schema: effectiveSchema,
+    },
+    retryHandlers: {
+      SQL0204: ({ context }) => {
+        const fallbackSchema = discoverSchema(config.db, context.table);
+        if (!fallbackSchema || !fallbackSchema.TABLE_SCHEMA) {
+          return null;
+        }
+        return {
+          query: buildQueryTableQueries({
+            schema: String(fallbackSchema.TABLE_SCHEMA).trim().toUpperCase(),
+            table: context.table,
+            filter,
+          }).tableInfo,
+        };
+      },
+    },
   });
-  const columns = runReadOnlyDb2Query({
+  const columns = executeReadOnlyDb2QueryWithFallback({
     dbConfig: config.db,
     query: queries.columns,
     maxRows: 500,
+    context: {
+      table,
+      schema: effectiveSchema,
+      filter,
+    },
+    retryHandlers: {
+      SQL0204: ({ context }) => {
+        const fallbackSchema = discoverSchema(config.db, context.table);
+        if (!fallbackSchema || !fallbackSchema.TABLE_SCHEMA) {
+          return null;
+        }
+        return {
+          query: buildQueryTableQueries({
+            schema: String(fallbackSchema.TABLE_SCHEMA).trim().toUpperCase(),
+            table: context.table,
+            filter: context.filter,
+          }).columns,
+        };
+      },
+    },
   });
 
-  console.log(`Table lookup: ${schema ? `${schema}.${table}` : table}`);
+  console.log(`Table lookup: ${effectiveSchema ? `${effectiveSchema}.${table}` : table}`);
+  if (!schema && effectiveSchema) {
+    console.log(`Schema discovery: ${table} -> ${effectiveSchema}`);
+  }
   console.log('');
 
   if ((tableInfo.rows || []).length === 0) {
@@ -99,8 +144,8 @@ async function runQueryTable(args) {
   } else {
     console.log('Table Info');
     console.log(renderAsciiTable(
-      ['TABLE_SCHEMA', 'TABLE_NAME', 'ROW_COUNT'],
-      tableInfo.rows.map((row) => [row.TABLE_SCHEMA, row.TABLE_NAME, row.ROW_COUNT]),
+      ['TABLE_SCHEMA', 'TABLE_NAME'],
+      tableInfo.rows.map((row) => [row.TABLE_SCHEMA, row.TABLE_NAME]),
     ));
   }
 
@@ -121,6 +166,7 @@ async function runQueryTable(args) {
       row.NUMERIC_SCALE,
       row.IS_NULLABLE,
     ]),
+    { maxCellWidth: 40 },
   ));
 }
 

--- a/src/cli/helpers/asciiTable.js
+++ b/src/cli/helpers/asciiTable.js
@@ -15,30 +15,45 @@ function repeat(char, count) {
   return String(char || ' ').repeat(Math.max(0, Number(count) || 0));
 }
 
-function renderCell(value) {
+function truncateCell(value, maxLen = 40) {
+  const rendered = value === null || value === undefined ? '' : String(value);
+  if (!Number.isFinite(Number(maxLen)) || Number(maxLen) <= 0) {
+    return rendered;
+  }
+  const limit = Math.max(1, Number(maxLen));
+  if (rendered.length <= limit) {
+    return rendered;
+  }
+  if (limit === 1) {
+    return '…';
+  }
+  return `${rendered.slice(0, limit - 1)}…`;
+}
+
+function renderCell(value, options = {}) {
   if (value === null || value === undefined) {
     return '';
   }
   if (typeof value === 'object') {
-    return JSON.stringify(value);
+    return truncateCell(JSON.stringify(value), options.maxCellWidth);
   }
-  return String(value);
+  return truncateCell(String(value), options.maxCellWidth);
 }
 
 function buildSeparator(widths) {
   return `+-${widths.map((width) => repeat('-', width)).join('-+-')}-+`;
 }
 
-function buildRow(values, widths) {
-  return `| ${values.map((value, index) => renderCell(value).padEnd(widths[index], ' ')).join(' | ')} |`;
+function buildRow(values, widths, options) {
+  return `| ${values.map((value, index) => renderCell(value, options).padEnd(widths[index], ' ')).join(' | ')} |`;
 }
 
-function renderAsciiTable(columns, rows) {
+function renderAsciiTable(columns, rows, options = {}) {
   const headers = Array.isArray(columns) ? columns.map((column) => String(column || '')) : [];
   const normalizedRows = Array.isArray(rows) ? rows : [];
   const widths = headers.map((header, columnIndex) => Math.max(
     header.length,
-    ...normalizedRows.map((row) => renderCell(Array.isArray(row) ? row[columnIndex] : '').length),
+    ...normalizedRows.map((row) => renderCell(Array.isArray(row) ? row[columnIndex] : '', options).length),
   ));
 
   if (widths.length === 0) {
@@ -48,12 +63,12 @@ function renderAsciiTable(columns, rows) {
   const separator = buildSeparator(widths);
   const lines = [
     separator,
-    buildRow(headers, widths),
+    buildRow(headers, widths, options),
     separator,
   ];
 
   for (const row of normalizedRows) {
-    lines.push(buildRow(Array.isArray(row) ? row : [], widths));
+    lines.push(buildRow(Array.isArray(row) ? row : [], widths, options));
   }
 
   lines.push(separator);
@@ -62,4 +77,5 @@ function renderAsciiTable(columns, rows) {
 
 module.exports = {
   renderAsciiTable,
+  truncateCell,
 };

--- a/src/cli/helpers/csvRenderer.js
+++ b/src/cli/helpers/csvRenderer.js
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+function escapeCsvValue(value) {
+  return `"${String(value ?? '').replace(/"/g, '""')}"`;
+}
+
+function renderCsv(columns, rows) {
+  const header = (columns || []).map((column) => String(column || '')).join(';');
+  const lines = (rows || []).map((row) => (columns || [])
+    .map((column, index) => {
+      if (Array.isArray(row)) {
+        return escapeCsvValue(row[index]);
+      }
+      return escapeCsvValue(row && typeof row === 'object' ? row[column] : '');
+    })
+    .join(';'));
+  return `${[header, ...lines].join('\n')}\n`;
+}
+
+module.exports = {
+  renderCsv,
+};

--- a/src/cli/helpers/memberResolver.js
+++ b/src/cli/helpers/memberResolver.js
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+const { collectSourceFiles } = require('../../collector/sourceCollector');
+const { buildSourceCatalog, normalizeName } = require('../../source/sourceCatalog');
+const { resolveProgram } = require('../../dependency/programSourceResolver');
+
+function resolveMemberProgram({ member, sourceRoot, extensions }) {
+  const normalizedMember = normalizeName(member);
+  if (!normalizedMember) {
+    throw new Error('Missing required option: --member <name>');
+  }
+
+  const resolvedSourceRoot = path.resolve(sourceRoot);
+  if (!fs.existsSync(resolvedSourceRoot)) {
+    throw new Error(`Source directory not found: ${resolvedSourceRoot}. Provide a valid --source path.`);
+  }
+
+  const sourceFiles = collectSourceFiles(resolvedSourceRoot, extensions);
+  const catalog = buildSourceCatalog({
+    sourceRoot: resolvedSourceRoot,
+    sourceFiles,
+  });
+  const resolved = resolveProgram(normalizedMember, catalog);
+
+  if (!resolved) {
+    throw new Error(`Member "${normalizedMember}" not found under ${resolvedSourceRoot}.`);
+  }
+  if (resolved.ambiguous) {
+    throw new Error(resolved.warning || `Member "${normalizedMember}" is ambiguous.`);
+  }
+
+  return {
+    program: normalizedMember,
+    sourceRoot: resolvedSourceRoot,
+    sourcePath: resolved.path,
+    catalog,
+  };
+}
+
+module.exports = {
+  resolveMemberProgram,
+};

--- a/src/db2/columnFallback.js
+++ b/src/db2/columnFallback.js
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const {
+  escapeSqlLiteral,
+  runReadOnlyDb2Query,
+  validateSqlIdentifier,
+} = require('./readOnlyQueryService');
+
+const COLUMN_ALIASES = Object.freeze({
+  WERBEJAHR: ['WERBEJAHR', 'PJAHR', 'XJAHR', 'WERBJAHR'],
+  WERBENUMMER: ['WERBENUMMER', 'PWERBNR', 'XWERBNR', 'WERBNR'],
+  DAN: ['INTERNE_ARTIKEL_DAN', 'PDAN', 'XDAN', 'ARTIKEL_DAN', 'DAN'],
+  VKST: ['VERKAUFSSTELLE_ID', 'PVKST', 'VERKAUFSSTELLE', 'VKST_NR'],
+  PREIS: ['WERBE_VERKAUFSPREIS', 'PWPREIS', 'PREIS_ERFASST', 'VKP'],
+  TIMESTAMP: ['ZEITPUNKT_AENDERUNG', 'XTIMESTMP', 'LETZTEAENDERUNG'],
+});
+
+function getActualColumns(dbConfig, schema, table, runtime = {}) {
+  const resolvedSchema = validateSqlIdentifier(schema, '--schema');
+  const resolvedTable = validateSqlIdentifier(table, '--table');
+  const result = runReadOnlyDb2Query({
+    dbConfig,
+    query: `SELECT COLUMN_NAME
+FROM QSYS2.SYSCOLUMNS
+WHERE TABLE_SCHEMA = ${escapeSqlLiteral(resolvedSchema)}
+  AND TABLE_NAME = ${escapeSqlLiteral(resolvedTable)}
+ORDER BY ORDINAL_POSITION`,
+    maxRows: 500,
+    runtime,
+  });
+  return (result.rows || [])
+    .map((row) => String((row && row.COLUMN_NAME) || '').trim().toUpperCase())
+    .filter(Boolean);
+}
+
+function resolveColumn(dbConfig, schema, table, logicalName, runtime = {}) {
+  const candidates = COLUMN_ALIASES[String(logicalName || '').trim().toUpperCase()] || [String(logicalName || '').trim().toUpperCase()];
+  const actualColumns = getActualColumns(dbConfig, schema, table, runtime);
+  return candidates.find((candidate) => actualColumns.some((column) => column === String(candidate).trim().toUpperCase())) || null;
+}
+
+module.exports = {
+  COLUMN_ALIASES,
+  getActualColumns,
+  resolveColumn,
+};

--- a/src/db2/readOnlyQueryService.js
+++ b/src/db2/readOnlyQueryService.js
@@ -42,6 +42,18 @@ function parseReadOnlyQueryResult(stdout) {
   return JSON.parse(content);
 }
 
+function extractSqlState(error) {
+  const text = String(error && error.message ? error.message : error || '');
+  const match = text.match(/\b(SQL\d{4}|SQLSTATE\s*[=:]?\s*([0-9A-Z]{5}))\b/i);
+  if (!match) {
+    return '';
+  }
+  if (match[2]) {
+    return String(match[2]).toUpperCase();
+  }
+  return String(match[1]).toUpperCase();
+}
+
 function validateSqlIdentifier(value, label) {
   const normalized = String(value || '').trim().toUpperCase();
   if (!normalized) {
@@ -80,8 +92,52 @@ function runReadOnlyDb2Query({ dbConfig, query, maxRows = 50, runtime = {} }) {
   return parseReadOnlyQueryResult(result.stdout);
 }
 
+function executeReadOnlyDb2QueryWithFallback({
+  dbConfig,
+  query,
+  maxRows = 200,
+  runtime = {},
+  context = {},
+  retryHandlers = {},
+}) {
+  try {
+    return runReadOnlyDb2Query({
+      dbConfig,
+      query,
+      maxRows,
+      runtime,
+    });
+  } catch (error) {
+    const sqlState = extractSqlState(error);
+    const handler = retryHandlers[sqlState];
+    if (typeof handler !== 'function') {
+      throw error;
+    }
+    const fallback = handler({
+      dbConfig,
+      query,
+      maxRows,
+      runtime,
+      context,
+      error,
+      sqlState,
+    });
+    if (!fallback || typeof fallback.query !== 'string') {
+      throw error;
+    }
+    return runReadOnlyDb2Query({
+      dbConfig,
+      query: fallback.query,
+      maxRows: fallback.maxRows || maxRows,
+      runtime,
+    });
+  }
+}
+
 module.exports = {
+  executeReadOnlyDb2QueryWithFallback,
   escapeSqlLiteral,
+  extractSqlState,
   parseReadOnlyQueryResult,
   runReadOnlyDb2Query,
   SQL_IDENTIFIER_PATTERN,

--- a/src/db2/schemaDiscovery.js
+++ b/src/db2/schemaDiscovery.js
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const { escapeSqlLiteral, runReadOnlyDb2Query, validateSqlIdentifier } = require('./readOnlyQueryService');
+
+const PREFERRED_SCHEMAS = Object.freeze(['DATEIEN', 'PRODLIB', 'DATEN', 'PROD']);
+
+function sortSchemaCandidates(rows) {
+  return [...(rows || [])].sort((left, right) => {
+    const leftSchema = String((left && left.TABLE_SCHEMA) || '').trim().toUpperCase();
+    const rightSchema = String((right && right.TABLE_SCHEMA) || '').trim().toUpperCase();
+    const leftPreferredIndex = PREFERRED_SCHEMAS.indexOf(leftSchema);
+    const rightPreferredIndex = PREFERRED_SCHEMAS.indexOf(rightSchema);
+    const leftRank = leftPreferredIndex === -1 ? Number.MAX_SAFE_INTEGER : leftPreferredIndex;
+    const rightRank = rightPreferredIndex === -1 ? Number.MAX_SAFE_INTEGER : rightPreferredIndex;
+    if (leftRank !== rightRank) {
+      return leftRank - rightRank;
+    }
+    return leftSchema.localeCompare(rightSchema);
+  });
+}
+
+function discoverSchema(dbConfig, tableName, runtime = {}) {
+  const table = validateSqlIdentifier(tableName, '--table');
+  const result = runReadOnlyDb2Query({
+    dbConfig,
+    query: `SELECT TABLE_SCHEMA
+FROM QSYS2.SYSTABLES
+WHERE TABLE_NAME = ${escapeSqlLiteral(table)}
+ORDER BY TABLE_SCHEMA`,
+    maxRows: 20,
+    runtime,
+  });
+  const sorted = sortSchemaCandidates(result.rows);
+  return sorted[0] || null;
+}
+
+module.exports = {
+  discoverSchema,
+  PREFERRED_SCHEMAS,
+  sortSchemaCandidates,
+};

--- a/src/diff/workspaceDiffService.js
+++ b/src/diff/workspaceDiffService.js
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+const { discoverFetchedSources } = require('../workspace/workCopyService');
+const { buildWorkCopyTargetName } = require('../workspace/workCopyService');
+
+function normalizeMember(value) {
+  return String(value || '').trim().toUpperCase();
+}
+
+function resolveDiffPaths({
+  member,
+  fetchRoot,
+  workspaceRoot,
+  workCopyMode,
+}) {
+  const normalizedMember = normalizeMember(member);
+  const discovered = discoverFetchedSources(fetchRoot);
+  const original = discovered.find((entry) => entry.member === normalizedMember);
+  if (!original) {
+    throw new Error(`No fetched source found for member "${normalizedMember}" under ${path.resolve(fetchRoot)}.`);
+  }
+
+  const candidateNames = Array.from(new Set([
+    buildWorkCopyTargetName(original, workCopyMode),
+    `${original.member}${original.extension}`,
+  ]));
+  const modifiedPath = candidateNames
+    .map((fileName) => path.join(workspaceRoot, fileName))
+    .find((candidate) => fs.existsSync(candidate));
+
+  if (!modifiedPath) {
+    throw new Error(`No workspace copy found for member "${normalizedMember}" under ${path.resolve(workspaceRoot)}.`);
+  }
+
+  return {
+    member: normalizedMember,
+    originalPath: original.sourcePath,
+    modifiedPath,
+  };
+}
+
+function readLines(filePath) {
+  return fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+}
+
+function buildLineComparison(originalLines, modifiedLines) {
+  const maxLines = Math.max(originalLines.length, modifiedLines.length);
+  const rows = [];
+  let changedCount = 0;
+
+  for (let index = 0; index < maxLines; index += 1) {
+    const original = originalLines[index];
+    const modified = modifiedLines[index];
+    let marker = ' ';
+    if (original === undefined) {
+      marker = '+';
+      changedCount += 1;
+    } else if (modified === undefined) {
+      marker = '-';
+      changedCount += 1;
+    } else if (original !== modified) {
+      marker = '~';
+      changedCount += 1;
+    }
+    rows.push({
+      line: index + 1,
+      marker,
+      original: original === undefined ? '' : original,
+      modified: modified === undefined ? '' : modified,
+    });
+  }
+
+  return {
+    rows,
+    changedCount,
+  };
+}
+
+module.exports = {
+  buildLineComparison,
+  readLines,
+  resolveDiffPaths,
+};

--- a/src/fetch/fetchService.js
+++ b/src/fetch/fetchService.js
@@ -23,15 +23,9 @@ const { downloadDirectory } = require('./sftpDownloader');
 const { downloadDirectoryViaJt400 } = require('./jt400Downloader');
 const { downloadDirectoryViaFtp } = require('./ftpDownloader');
 const { buildImportManifest, writeImportManifest } = require('./importManifest');
+const { SOURCE_FILES_PRIORITY } = require('./memberDiscovery');
 
-const DEFAULT_SOURCE_FILES = [
-  'QRPGLESRC',
-  'QCPYSRC',
-  'QCLSRC',
-  'QCLLESRC',
-  'QSQLRPGLESRC',
-  'QDDSSRC',
-];
+const DEFAULT_SOURCE_FILES = [...SOURCE_FILES_PRIORITY];
 const DEFAULT_TRANSPORT = 'auto';
 const TRANSPORTS = ['auto', 'sftp', 'jt400', 'ftp'];
 

--- a/src/fetch/memberDiscovery.js
+++ b/src/fetch/memberDiscovery.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const SOURCE_FILES_PRIORITY = Object.freeze([
+  'QRPGLESRC',
+  'QSRVSRC',
+  'QCPYSRC',
+  'QCLLESRC',
+  'QCLSRC',
+  'QSQLSRC',
+  'SQLTBLSRC',
+  'SQLVIEWSRC',
+  'SQLIDXSRC',
+  'FORMSRC',
+  'QDDSSRC',
+]);
+
+async function discoverMember(fetchConfig, memberName, runtime = {}) {
+  const member = String(memberName || '').trim().toUpperCase();
+  if (!member) {
+    return null;
+  }
+
+  const fetchSingle = runtime.fetchSingle;
+  if (typeof fetchSingle !== 'function') {
+    return null;
+  }
+
+  for (const sourceFile of SOURCE_FILES_PRIORITY) {
+    try {
+      const result = await fetchSingle(fetchConfig, sourceFile, member);
+      if (result && result.success) {
+        return {
+          file: sourceFile,
+          result,
+        };
+      }
+    } catch (_) {
+      // Try the next likely source file.
+    }
+  }
+
+  return null;
+}
+
+module.exports = {
+  discoverMember,
+  SOURCE_FILES_PRIORITY,
+};

--- a/tests/column-fallback.test.js
+++ b/tests/column-fallback.test.js
@@ -1,0 +1,47 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { COLUMN_ALIASES, getActualColumns, resolveColumn } = require('../src/db2/columnFallback');
+
+function buildRuntimeWithRows(rows) {
+  return {
+    runJavaHelper() {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          columns: ['COLUMN_NAME'],
+          rows,
+          rowCount: rows.length,
+        }),
+        stderr: '',
+      };
+    },
+  };
+}
+
+test('getActualColumns returns uppercase column names in ordinal order', () => {
+  const columns = getActualColumns({
+    host: 'ibmi.example.com',
+    user: 'ZEUS',
+    password: 'secret',
+  }, 'DATEIEN', 'WERBPLA_00', buildRuntimeWithRows([
+    { COLUMN_NAME: 'pjahr' },
+    { COLUMN_NAME: 'pwpreis' },
+  ]));
+
+  assert.deepEqual(columns, ['PJAHR', 'PWPREIS']);
+});
+
+test('resolveColumn uses central alias candidates before giving up', () => {
+  const resolved = resolveColumn({
+    host: 'ibmi.example.com',
+    user: 'ZEUS',
+    password: 'secret',
+  }, 'DATEIEN', 'WERBPLA_00', 'WERBEJAHR', buildRuntimeWithRows([
+    { COLUMN_NAME: 'PJAHR' },
+    { COLUMN_NAME: 'PWPREIS' },
+  ]));
+
+  assert.deepEqual(COLUMN_ALIASES.WERBEJAHR, ['WERBEJAHR', 'PJAHR', 'XJAHR', 'WERBJAHR']);
+  assert.equal(resolved, 'PJAHR');
+});

--- a/tests/doctor-command.test.js
+++ b/tests/doctor-command.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildEnvironmentChecks } = require('../src/cli/commands/doctorCommand');
+
+test('buildEnvironmentChecks flags missing env vars with concrete set hints', () => {
+  const checks = buildEnvironmentChecks({
+    profile: {
+      db: {},
+      fetch: {},
+    },
+    analyzeConfig: null,
+    fetchConfig: null,
+    env: {},
+  });
+
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_DB_HOST' && entry.status === 'FAIL' && /set ZEUS_DB_HOST=mein-ibmi-host/.test(entry.details)));
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_FETCH_OUT' && entry.status === 'FAIL' && /set ZEUS_FETCH_OUT=C:\/Projekte\/ticket\/zeus-fetch/.test(entry.details)));
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_OUTPUT_ROOT' && entry.status === 'WARN'));
+});
+
+test('buildEnvironmentChecks downgrades to warnings when the profile already provides literal fallbacks', () => {
+  const checks = buildEnvironmentChecks({
+    profile: {
+      db: {
+        host: 'profile-host',
+        user: 'profile-user',
+        password: 'profile-pass',
+      },
+      fetch: {
+        out: './rpg_sources',
+      },
+      outputRoot: './output',
+    },
+    analyzeConfig: null,
+    fetchConfig: null,
+    env: {},
+  });
+
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_DB_HOST' && entry.status === 'WARN'));
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_FETCH_OUT' && entry.status === 'WARN'));
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_OUTPUT_ROOT' && entry.status === 'WARN'));
+});

--- a/tests/member-resolver.test.js
+++ b/tests/member-resolver.test.js
@@ -1,0 +1,49 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { resolveMemberProgram } = require('../src/cli/helpers/memberResolver');
+
+test('resolveMemberProgram resolves a unique member from the local source catalog', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-member-resolver-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  fs.mkdirSync(path.join(sourceRoot, 'QRPGLESRC'), { recursive: true });
+  fs.writeFileSync(path.join(sourceRoot, 'QRPGLESRC', 'ORDERPGM.rpgle'), '**FREE\n', 'utf8');
+
+  try {
+    const resolved = resolveMemberProgram({
+      member: 'orderpgm',
+      sourceRoot,
+      extensions: ['.rpgle'],
+    });
+
+    assert.equal(resolved.program, 'ORDERPGM');
+    assert.equal(resolved.sourcePath.endsWith(path.join('QRPGLESRC', 'ORDERPGM.rpgle')), true);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('resolveMemberProgram rejects ambiguous duplicate members', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-member-resolver-amb-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  fs.mkdirSync(path.join(sourceRoot, 'QRPGLESRC'), { recursive: true });
+  fs.mkdirSync(path.join(sourceRoot, 'QCLLESRC'), { recursive: true });
+  fs.writeFileSync(path.join(sourceRoot, 'QRPGLESRC', 'PROGRAM_010.rpgle'), '**FREE\n', 'utf8');
+  fs.writeFileSync(path.join(sourceRoot, 'QCLLESRC', 'PROGRAM_010.clle'), 'PGM\nENDPGM\n', 'utf8');
+
+  try {
+    assert.throws(
+      () => resolveMemberProgram({
+        member: 'PROGRAM_010',
+        sourceRoot,
+        extensions: ['.rpgle', '.clle'],
+      }),
+      /Ambiguous local sources found/,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/query-sql-command.test.js
+++ b/tests/query-sql-command.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  DEFAULT_MAX_ROWS,
+  normalizeOutput,
+  parseMaxRows,
+  toRowMatrix,
+} = require('../src/cli/commands/querySqlCommand');
+
+test('parseMaxRows defaults to the larger read-only query budget', () => {
+  assert.equal(parseMaxRows(undefined), DEFAULT_MAX_ROWS);
+  assert.equal(parseMaxRows('250'), 250);
+  assert.throws(
+    () => parseMaxRows('0'),
+    /--max-rows/,
+  );
+});
+
+test('normalizeOutput accepts table and csv only', () => {
+  assert.equal(normalizeOutput(undefined), 'table');
+  assert.equal(normalizeOutput('csv'), 'csv');
+  assert.throws(
+    () => normalizeOutput('json'),
+    /--output must be one of: table, csv/,
+  );
+});
+
+test('toRowMatrix preserves column order for object rows', () => {
+  const matrix = toRowMatrix(['ID', 'NAME'], [
+    { NAME: 'Alpha', ID: 1 },
+    { NAME: 'Beta', ID: 2 },
+  ]);
+
+  assert.deepEqual(matrix, [
+    [1, 'Alpha'],
+    [2, 'Beta'],
+  ]);
+});

--- a/tests/query-table-command.test.js
+++ b/tests/query-table-command.test.js
@@ -16,6 +16,7 @@ test('buildQueryTableQueries constrains table, schema, and optional column filte
   assert.match(queries.tableInfo, /FROM QSYS2\.SYSTABLES/);
   assert.match(queries.tableInfo, /TABLE_SCHEMA = 'MYLIB'/);
   assert.match(queries.tableInfo, /TABLE_NAME = 'ORDERS'/);
+  assert.doesNotMatch(queries.tableInfo, /ROW_COUNT/);
   assert.match(queries.columns, /FROM QSYS2\.SYSCOLUMNS/);
   assert.match(queries.columns, /COLUMN_NAME LIKE '%DATE%'/);
   assert.match(queries.columns, /ORDINAL_POSITION/);

--- a/tests/read-only-query-service.test.js
+++ b/tests/read-only-query-service.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  executeReadOnlyDb2QueryWithFallback,
+  extractSqlState,
+} = require('../src/db2/readOnlyQueryService');
+
+test('extractSqlState recognizes IBM i SQL codes and SQLSTATE values', () => {
+  assert.equal(extractSqlState(new Error('SQL0204 Tabelle nicht gefunden')), 'SQL0204');
+  assert.equal(extractSqlState(new Error('Fehler SQLSTATE=55019 Commitment control')), '55019');
+  assert.equal(extractSqlState(new Error('kein sql state hier')), '');
+});
+
+test('executeReadOnlyDb2QueryWithFallback retries with the handler-provided query', () => {
+  const calls = [];
+  const result = executeReadOnlyDb2QueryWithFallback({
+    dbConfig: {
+      host: 'ibmi.example.com',
+      user: 'ZEUS',
+      password: 'secret',
+    },
+    query: 'SELECT * FROM MISSING',
+    maxRows: 200,
+    context: {
+      table: 'MISSING',
+    },
+    retryHandlers: {
+      SQL0204: ({ context }) => ({
+        query: `SELECT * FROM ${context.table}_FALLBACK`,
+      }),
+    },
+    runtime: {
+      runJavaHelper(_className, args) {
+        calls.push(args[3]);
+        if (calls.length === 1) {
+          return {
+            status: 2,
+            stdout: '',
+            stderr: 'SQL0204 Tabelle nicht gefunden',
+          };
+        }
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            columns: ['ID'],
+            rows: [{ ID: 1 }],
+            rowCount: 1,
+          }),
+          stderr: '',
+        };
+      },
+    },
+  });
+
+  assert.deepEqual(calls, ['SELECT * FROM MISSING', 'SELECT * FROM MISSING_FALLBACK']);
+  assert.equal(result.rowCount, 1);
+});

--- a/tests/schema-discovery.test.js
+++ b/tests/schema-discovery.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { discoverSchema, sortSchemaCandidates } = require('../src/db2/schemaDiscovery');
+
+function buildRuntimeWithRows(rows) {
+  return {
+    runJavaHelper() {
+      return {
+        status: 0,
+        stdout: JSON.stringify({
+          columns: ['TABLE_SCHEMA'],
+          rows,
+          rowCount: rows.length,
+        }),
+        stderr: '',
+      };
+    },
+  };
+}
+
+test('sortSchemaCandidates prefers production-like schemas first', () => {
+  const sorted = sortSchemaCandidates([
+    { TABLE_SCHEMA: 'ARCHIVE' },
+    { TABLE_SCHEMA: 'DATEIEN' },
+    { TABLE_SCHEMA: 'PROD' },
+  ]);
+
+  assert.deepEqual(sorted.map((entry) => entry.TABLE_SCHEMA), ['DATEIEN', 'PROD', 'ARCHIVE']);
+});
+
+test('discoverSchema returns the preferred schema candidate', () => {
+  const resolved = discoverSchema({
+    host: 'ibmi.example.com',
+    user: 'ZEUS',
+    password: 'secret',
+  }, 'meine_tabelle', buildRuntimeWithRows([
+    { TABLE_SCHEMA: 'ARCHIVE' },
+    { TABLE_SCHEMA: 'DATEIEN' },
+  ]));
+
+  assert.equal(resolved.TABLE_SCHEMA, 'DATEIEN');
+});

--- a/tests/workspace-diff-service.test.js
+++ b/tests/workspace-diff-service.test.js
@@ -1,0 +1,65 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  buildLineComparison,
+  resolveDiffPaths,
+} = require('../src/diff/workspaceDiffService');
+
+function createDiffFixture() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-workspace-diff-'));
+  const fetchRoot = path.join(tempRoot, 'rpg_sources');
+  const workspaceRoot = path.join(tempRoot, 'source');
+
+  fs.mkdirSync(path.join(fetchRoot, 'QRPGLESRC'), { recursive: true });
+  fs.mkdirSync(workspaceRoot, { recursive: true });
+  fs.writeFileSync(path.join(fetchRoot, 'QRPGLESRC', 'MAINPROG.rpgle'), '**FREE\nA\nB\n', 'utf8');
+  fs.writeFileSync(path.join(fetchRoot, 'zeus-import-manifest.json'), `${JSON.stringify({
+    files: [{
+      member: 'MAINPROG',
+      localPath: 'QRPGLESRC/MAINPROG.rpgle',
+      origin: {
+        member: 'MAINPROG',
+        localPath: 'QRPGLESRC/MAINPROG.rpgle',
+      },
+    }],
+  }, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(path.join(workspaceRoot, 'MAINPROG.rpgle.txt'), '**FREE\nA\nC\n', 'utf8');
+
+  return {
+    tempRoot,
+    fetchRoot,
+    workspaceRoot,
+  };
+}
+
+test('resolveDiffPaths maps a member to fetched original and local work copy', () => {
+  const fixture = createDiffFixture();
+
+  try {
+    const resolved = resolveDiffPaths({
+      member: 'MAINPROG',
+      fetchRoot: fixture.fetchRoot,
+      workspaceRoot: fixture.workspaceRoot,
+      workCopyMode: 'txt',
+    });
+
+    assert.equal(resolved.originalPath.endsWith(path.join('QRPGLESRC', 'MAINPROG.rpgle')), true);
+    assert.equal(resolved.modifiedPath.endsWith('MAINPROG.rpgle.txt'), true);
+  } finally {
+    fs.rmSync(fixture.tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('buildLineComparison marks changed and unchanged rows', () => {
+  const comparison = buildLineComparison(
+    ['A', 'B'],
+    ['A', 'C', 'D'],
+  );
+
+  assert.equal(comparison.changedCount, 2);
+  assert.deepEqual(comparison.rows.map((row) => row.marker), [' ', '~', '+']);
+});


### PR DESCRIPTION
## Summary
- add query-sql, local diff support, and member-based CLI resolution for analyze and impact
- add schema discovery, column alias helpers, and generic SQL-state fallback support for read-only DB2 queries
- expand doctor env checks, fetch source-file priority defaults, and the example profile setup

## Testing
- node --test tests\\runtime-config.test.js tests\\query-table-command.test.js tests\\query-sql-command.test.js tests\\doctor-command.test.js tests\\schema-discovery.test.js tests\\column-fallback.test.js tests\\work-copy-service.test.js tests\\read-only-query-service.test.js tests\\member-resolver.test.js tests\\workspace-diff-service.test.js