### PR TITLE
Add workflow automation and reusable core services

### DIFF
--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -30,6 +30,7 @@ function printHelp() {
   console.log('Usage:');
   console.log('  zeus [--config <path>] analyze --source <path> (--program <name> | --member <name>) [--profile <name>] [--out <path>] [--extensions .rpgle,.rpg] [--mode <name>] [--list-modes] [--list-diagnostic-packs] [--optimize-context] [--scan-ifs-paths] [--search-terms a,b] [--search-ignore path1,path2] [--search-max-results <n>] [--diagnostic-packs a,b] [--diagnostic-params k=v] [--host <hostname>] [--user <username>] [--password <password>] [--safe-sharing] [--emit-diagnostics] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
   console.log('  zeus [--config <path>] workflow --preset <name> --source <path> --program <name> [--profile <name>] [--out <path>] [--bundle-output <path>] [--extensions .rpgle,.rpg] [--list-presets] [--safe-sharing] [--reproducible] [--test-data-limit <n>] [--skip-test-data] [--verbose]');
+  console.log('  zeus [--config <path>] workflow run --profile <name> [--preset <name>] [--out <path>] [--continue-on-error]');
   console.log('  zeus [--config <path>] bundle --program <name> [--output <path>] [--source-output-root <path>] [--include-json] [--include-md] [--include-html] [--safe-sharing] [--reproducible] [--profile <name>] [--verbose]');
   console.log('  zeus [--config <path>] impact (--target <name> | --field <name>) [--program <name> | --member <name>] [--out <path>] [--profile <name>] [--source <path>] [--reproducible] [--verbose]');
   console.log('  zeus [--config <path>] fetch --host <hostname> --user <username> --password <password> --source-lib <lib> --ifs-dir <ifsPath> --out <localPath> [--files <list>] [--members <list>] [--replace true|false] [--streamfile-ccsid <ccsid>] [--transport auto|sftp|jt400|ftp] [--profile <name>] [--verbose]');
@@ -112,7 +113,7 @@ async function main() {
   }
 
   if (command === 'workflow') {
-    runWorkflow(args);
+    await runWorkflow(args);
     return;
   }
 

--- a/config/profiles.example.json
+++ b/config/profiles.example.json
@@ -58,7 +58,17 @@
   },
   "default-local": {
     "extends": "default-shared",
-    "sourceRoot": "${env:ZEUS_SOURCE_ROOT}"
+    "sourceRoot": "${env:ZEUS_SOURCE_ROOT}",
+    "workflow": {
+      "outputRoot": "analysis",
+      "defaultPreset": "legacy-rpg-analysis",
+      "analyzeModes": ["documentation", "defect-analysis"],
+      "presets": {
+        "legacy-rpg-analysis": {
+          "steps": ["fetch", "copy", "analyze", "report"]
+        }
+      }
+    }
   },
   "default": {
     "sourceRoot": "./rpg",
@@ -132,6 +142,27 @@
     "workCopy": {
       "root": "source/",
       "extension": "txt"
+    },
+    "workflow": {
+      "outputRoot": "analysis",
+      "defaultPreset": "legacy-rpg-analysis",
+      "tables": [
+        {
+          "schema": "MYLIB",
+          "table": "CUSTOMERS"
+        }
+      ],
+      "impact": [
+        {
+          "field": "CUSTOMER_ID",
+          "member": "ORDERPGM"
+        }
+      ],
+      "presets": {
+        "legacy-rpg-analysis": {
+          "steps": ["fetch", "copy", "analyze", "impact", "query-table", "report"]
+        }
+      }
     }
   }
 }

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const { runWorkflowEngine } = require('../workflow/workflowRunner');
+const { executeFetch } = require('../core/fetchService');
+const { executeAnalyze } = require('../core/analyzeService');
+const { executeQueryTable } = require('../core/queryService');
+
+async function runWorkflow(profile, preset, options = {}) {
+  const { runtime = {}, ...args } = options;
+  return runWorkflowEngine({
+    profile,
+    preset,
+    ...args,
+  }, runtime);
+}
+
+async function fetch(profile, options = {}) {
+  const { runtime = {}, ...args } = options;
+  return executeFetch({
+    profile,
+    ...args,
+  }, runtime);
+}
+
+function analyze(profile, options = {}) {
+  const { runtime = {}, ...args } = options;
+  return executeAnalyze({
+    profile,
+    ...args,
+  }, runtime);
+}
+
+function queryTable(profile, table, options = {}) {
+  const { runtime = {}, ...args } = options;
+  return executeQueryTable({
+    profile,
+    table,
+    ...args,
+  }, runtime);
+}
+
+module.exports = {
+  analyze,
+  fetch,
+  queryTable,
+  runWorkflow,
+};

--- a/src/cli/commands/analyzeCommand.js
+++ b/src/cli/commands/analyzeCommand.js
@@ -11,47 +11,11 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
-const fs = require('fs');
 const path = require('path');
-const { DEFAULT_TEST_DATA_LIMIT } = require('../../db2/testDataExportService');
-const { resolveAnalyzeConfig } = require('../../config/runtimeConfig');
-const {
-  runAnalyzeArtifactAdapter,
-  runAnalyzeCore,
-} = require('../../analyze/analyzePipeline');
-const {
-  buildAnalyzeRunManifest,
-  readAnalyzeRunManifest,
-  writeAnalyzeRunManifest,
-} = require('../../analyze/analyzeRunManifest');
-const { buildSafeSharingArtifacts } = require('../../sharing/safeSharingArtifactBuilder');
 const { listWorkflowModes, resolveWorkflowModeSettings } = require('../../workflow/workflowModeRegistry');
 const { resolvePromptTemplates } = require('../../prompt/promptBuilder');
 const { listDiagnosticPacks } = require('../../investigation/diagnosticPackRegistry');
-const { resolveMemberProgram } = require('../helpers/memberResolver');
-const {
-  normalizeReproducibilitySettings,
-  resolveDurationMs,
-  resolveTimestamp,
-} = require('../../reproducibility/reproducibility');
-
-function parsePositiveInteger(value, fallback) {
-  if (value === undefined || value === null || value === true) return fallback;
-  const parsed = Number.parseInt(String(value).trim(), 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return null;
-  return parsed;
-}
-
-function parseCsv(value) {
-  if (value === undefined || value === null || value === true) {
-    return [];
-  }
-  return Array.from(new Set(String(value)
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter(Boolean)))
-    .sort((a, b) => a.localeCompare(b));
-}
+const { executeAnalyze } = require('../../core/analyzeService');
 
 function printWorkflowModes() {
   console.log('Supported analyze workflow modes:');
@@ -77,8 +41,6 @@ function printDiagnosticPacks() {
 }
 
 function runAnalyze(args) {
-  const verbose = Boolean(args.verbose);
-
   if (args['list-modes']) {
     printWorkflowModes();
     return;
@@ -87,284 +49,57 @@ function runAnalyze(args) {
     printDiagnosticPacks();
     return;
   }
-
-  const logVerbose = (message) => {
-    if (verbose) {
-      console.log(`[verbose] ${message}`);
-    }
-  };
-
-  const config = resolveAnalyzeConfig(args);
-  let resolvedProgram = args.program;
-
-  if ((!resolvedProgram || !String(resolvedProgram).trim()) && args.member) {
-    if (!config.sourceRoot || !String(config.sourceRoot).trim()) {
-      console.error('Missing required option: --source <path>');
-      process.exit(2);
-    }
-    try {
-      const memberResolution = resolveMemberProgram({
-        member: args.member,
-        sourceRoot: config.sourceRoot,
-        extensions: config.extensions,
-      });
-      resolvedProgram = memberResolution.program;
-    } catch (error) {
-      console.error(error.message);
-      process.exit(2);
-    }
-  }
-
-  if (!resolvedProgram || !String(resolvedProgram).trim()) {
-    console.error('Missing required option: --program <name>');
-    process.exit(2);
-  }
-
-  if (!config.sourceRoot || !String(config.sourceRoot).trim()) {
-    console.error('Missing required option: --source <path>');
-    process.exit(2);
-  }
-
-  const sourceRoot = path.resolve(process.cwd(), config.sourceRoot);
-  const outputRoot = path.resolve(process.cwd(), config.outputRoot);
-  const program = String(resolvedProgram).trim();
-  const workflowPreset = args['workflow-preset-settings'] && typeof args['workflow-preset-settings'] === 'object'
-    ? {
-      ...args['workflow-preset-settings'],
-      promptTemplates: [...(args['workflow-preset-settings'].promptTemplates || [])],
-      workflowKeys: [...(args['workflow-preset-settings'].workflowKeys || [])],
-      bundleArtifacts: [...(args['workflow-preset-settings'].bundleArtifacts || [])],
-    }
-    : null;
-  let workflowModeSettings = null;
-  if (args.mode) {
-    try {
-      workflowModeSettings = resolveWorkflowModeSettings(args.mode);
-    } catch (error) {
-      console.error(`${error.message}. Use --list-modes to inspect supported workflow modes.`);
-      process.exit(2);
-    }
-  }
-  const optimizeContextEnabled = Boolean(args['optimize-context'])
-    || Boolean(workflowModeSettings && workflowModeSettings.autoOptimizeContext);
-  const guidedMode = workflowModeSettings
-    ? {
-      ...workflowModeSettings,
-      effectiveOptimizeContext: optimizeContextEnabled,
-    }
-    : null;
-  const promptTemplates = workflowModeSettings
-    ? resolvePromptTemplates(workflowModeSettings.promptTemplates)
-    : resolvePromptTemplates();
-  const testDataLimit = parsePositiveInteger(args['test-data-limit'], Number(config.testData.limit) || DEFAULT_TEST_DATA_LIMIT);
-  const searchMaxResults = parsePositiveInteger(args['search-max-results'], 200);
-  const skipTestData = Boolean(args['skip-test-data']);
-  const safeSharingEnabled = Boolean(args['safe-sharing']);
-  const emitDiagnostics = Boolean(args['emit-diagnostics']);
-  const scanIfsPathsEnabled = Boolean(args['scan-ifs-paths']);
-  const searchTerms = parseCsv(args['search-terms']);
-  const searchIgnorePatterns = parseCsv(args['search-ignore']);
-  const diagnosticPacks = parseCsv(args['diagnostic-packs']);
-  const diagnosticParameterString = typeof args['diagnostic-params'] === 'string' ? args['diagnostic-params'] : '';
-  const reproducibility = normalizeReproducibilitySettings(Boolean(args.reproducible));
-
-  if (testDataLimit === null) {
-    console.error('Invalid option: --test-data-limit must be a positive integer');
-    process.exit(2);
-  }
-  if (searchMaxResults === null) {
-    console.error('Invalid option: --search-max-results must be a positive integer');
-    process.exit(2);
-  }
-
-  logVerbose(`Program: ${program}`);
-  logVerbose(`Source root: ${sourceRoot}`);
-  logVerbose(`Output root: ${outputRoot}`);
-  logVerbose(`Extensions: ${config.extensions.join(', ')}`);
-  logVerbose(`Context optimization: ${optimizeContextEnabled ? 'enabled' : 'disabled'}`);
-  logVerbose(`Safe sharing: ${safeSharingEnabled ? 'enabled' : 'disabled'}`);
-  logVerbose(`Structured diagnostics: ${emitDiagnostics ? 'enabled' : 'disabled'}`);
-  logVerbose(`Reproducible mode: ${reproducibility.enabled ? 'enabled' : 'disabled'}`);
-  logVerbose(`Test data extraction: ${skipTestData ? 'disabled' : `enabled (limit ${testDataLimit})`}`);
-  logVerbose(`Analysis limits: depth ${config.analysisLimits.maxProgramDepth}, programs ${config.analysisLimits.maxPrograms}, nodes ${config.analysisLimits.maxNodes}, edges ${config.analysisLimits.maxEdges}`);
-  logVerbose(`IFS path scan: ${scanIfsPathsEnabled ? 'enabled' : 'disabled'}`);
-  logVerbose(`Search terms: ${searchTerms.length > 0 ? searchTerms.join(', ') : 'none'}`);
-  logVerbose(`Diagnostic packs: ${diagnosticPacks.length > 0 ? diagnosticPacks.join(', ') : 'none'}`);
-  if (guidedMode) {
-    logVerbose(`Workflow mode: ${guidedMode.name}`);
-    logVerbose(`Workflow prompt templates: ${promptTemplates.length > 0 ? promptTemplates.join(', ') : 'none'}`);
-  }
-  if (workflowPreset) {
-    logVerbose(`Workflow preset: ${workflowPreset.name}`);
-  }
-
-  if (!fs.existsSync(sourceRoot)) {
-    console.error(`Source directory not found: ${sourceRoot}. Provide a valid --source path.`);
-    process.exit(2);
-  }
-
-  const outputProgramDir = path.join(outputRoot, program);
-  fs.mkdirSync(outputProgramDir, { recursive: true });
-  logVerbose(`Writing output to ${outputProgramDir}`);
-  const previousManifest = readAnalyzeRunManifest(outputProgramDir);
-  const startedAt = resolveTimestamp(reproducibility);
-  const startedNs = process.hrtime.bigint();
-
-  let result;
   try {
-    const coreResult = runAnalyzeCore({
-      program,
-      sourceRoot,
-      outputRoot,
-      outputProgramDir,
-      config,
-      testDataLimit,
-      skipTestData,
-      verbose,
-      optimizeContextEnabled,
-      workflowMode: guidedMode ? guidedMode.name : null,
-      workflowModeSettings: guidedMode,
-      promptTemplates,
-      workflowPreset,
-      scanIfsPathsEnabled,
-      searchTerms,
-      searchIgnorePatterns,
-      searchMaxResults,
-      diagnosticPacks,
-      diagnosticParameterString,
-      ibmiConfig: config.ibmi,
-      reproducibility,
-      logVerbose,
-    });
-    result = runAnalyzeArtifactAdapter({
-      ...coreResult,
-      emitDiagnostics,
-    });
-    const durationMs = resolveDurationMs(reproducibility, Number((process.hrtime.bigint() - startedNs) / 1000000n));
-    const manifest = buildAnalyzeRunManifest({
-      status: 'succeeded',
-      context: {
-        program,
-        sourceRoot,
-        outputRoot,
-        outputProgramDir,
-        cwd: process.cwd(),
-        startedAt,
-        completedAt: resolveTimestamp(reproducibility),
-        durationMs,
-        optimizeContextEnabled,
-        safeSharingEnabled,
-        emitDiagnosticsEnabled: emitDiagnostics,
-        skipTestData,
-        testDataLimit,
-        analysisLimits: config.analysisLimits,
-        testDataPolicy: config.testData,
-        tokenBudget: config.tokenBudget,
-        extensions: config.extensions,
-        reproducibility,
-        guidedMode,
-        workflowPreset,
-        investigation: {
-          scanIfsPathsEnabled,
-          searchTerms,
-          searchIgnorePatterns,
-          searchMaxResults,
-          diagnosticPacks,
-          diagnosticParameterString,
-        },
-      },
-      result,
-      previousManifest,
-    });
-    writeAnalyzeRunManifest(outputProgramDir, manifest);
-    if (safeSharingEnabled) {
-      buildSafeSharingArtifacts({
-        outputProgramDir,
-        analyzeManifest: manifest,
-        reproducibility,
-      });
-    }
-  } catch (error) {
-    const durationMs = resolveDurationMs(reproducibility, Number((process.hrtime.bigint() - startedNs) / 1000000n));
-    const manifest = buildAnalyzeRunManifest({
-      status: 'failed',
-      context: {
-        program,
-        sourceRoot,
-        outputRoot,
-        outputProgramDir,
-        cwd: process.cwd(),
-        startedAt,
-        completedAt: resolveTimestamp(reproducibility),
-        durationMs,
-        optimizeContextEnabled,
-        safeSharingEnabled,
-        emitDiagnosticsEnabled: emitDiagnostics,
-        skipTestData,
-        testDataLimit,
-        analysisLimits: config.analysisLimits,
-        testDataPolicy: config.testData,
-        tokenBudget: config.tokenBudget,
-        extensions: config.extensions,
-        reproducibility,
-        guidedMode,
-        workflowPreset,
-        investigation: {
-          scanIfsPathsEnabled,
-          searchTerms,
-          searchIgnorePatterns,
-          searchMaxResults,
-          diagnosticPacks,
-          diagnosticParameterString,
-        },
-      },
-      error,
-      previousManifest,
-    });
-    writeAnalyzeRunManifest(outputProgramDir, manifest);
-    throw error;
-  }
+    const execution = executeAnalyze(args);
+    const { result, program, outputProgramDir, guidedMode, workflowPreset, safeSharingEnabled, searchTerms, diagnosticPacks, emitDiagnostics } = execution;
 
-  console.log(`Analysis complete for program ${program}`);
-  if (guidedMode) {
-    console.log(`Guided mode: ${guidedMode.name}`);
-  }
-  if (workflowPreset) {
-    console.log(`Workflow preset: ${workflowPreset.name}`);
-  }
-  if (safeSharingEnabled) {
-    console.log(`Safe-sharing artifacts: ${path.join(outputProgramDir, 'safe-sharing')}`);
-  }
-  if (searchTerms.length > 0) {
-    console.log(`Search terms: ${searchTerms.join(', ')}`);
-  }
-  if (diagnosticPacks.length > 0) {
-    console.log(`Diagnostic packs: ${diagnosticPacks.join(', ')}`);
-  }
-  console.log(`Source files scanned: ${(result.scanSummary.sourceFiles || []).length}`);
-  if (result.cacheStatus && result.cacheStatus.sourceScan) {
-    console.log(`Source scan cache: ${result.cacheStatus.sourceScan.hits || 0} hits, ${result.cacheStatus.sourceScan.misses || 0} misses`);
-  }
-  if (result.cacheStatus && result.cacheStatus.db2Metadata && result.cacheStatus.db2Metadata.status !== 'disabled') {
-    console.log(`DB2 metadata cache: ${result.cacheStatus.db2Metadata.status}`);
-  }
-  if (result.cacheStatus && result.cacheStatus.testData && result.cacheStatus.testData.status !== 'disabled') {
-    console.log(`Test data cache: ${result.cacheStatus.testData.status}`);
-  }
-  if (result.optimizationReport.enabled) {
-    console.log(`Context tokens: ${result.optimizationReport.contextTokens}`);
-    console.log(`Optimized tokens: ${result.optimizationReport.optimizedTokens}`);
-    console.log(`Reduction: ${result.optimizationReport.reductionPercent}%`);
-    if (result.optimizationReport.warning) {
-      console.warn('Warning: optimized context may exceed safe prompt size.');
+    console.log(`Analysis complete for program ${program}`);
+    if (guidedMode) {
+      console.log(`Guided mode: ${guidedMode.name}`);
     }
-  } else {
-    console.log(`Context tokens: ${result.optimizationReport.contextTokens}`);
+    if (workflowPreset) {
+      console.log(`Workflow preset: ${workflowPreset.name}`);
+    }
+    if (safeSharingEnabled) {
+      console.log(`Safe-sharing artifacts: ${path.join(outputProgramDir, 'safe-sharing')}`);
+    }
+    if (searchTerms.length > 0) {
+      console.log(`Search terms: ${searchTerms.join(', ')}`);
+    }
+    if (diagnosticPacks.length > 0) {
+      console.log(`Diagnostic packs: ${diagnosticPacks.join(', ')}`);
+    }
+    console.log(`Source files scanned: ${(result.scanSummary.sourceFiles || []).length}`);
+    if (result.cacheStatus && result.cacheStatus.sourceScan) {
+      console.log(`Source scan cache: ${result.cacheStatus.sourceScan.hits || 0} hits, ${result.cacheStatus.sourceScan.misses || 0} misses`);
+    }
+    if (result.cacheStatus && result.cacheStatus.db2Metadata && result.cacheStatus.db2Metadata.status !== 'disabled') {
+      console.log(`DB2 metadata cache: ${result.cacheStatus.db2Metadata.status}`);
+    }
+    if (result.cacheStatus && result.cacheStatus.testData && result.cacheStatus.testData.status !== 'disabled') {
+      console.log(`Test data cache: ${result.cacheStatus.testData.status}`);
+    }
+    if (result.optimizationReport.enabled) {
+      console.log(`Context tokens: ${result.optimizationReport.contextTokens}`);
+      console.log(`Optimized tokens: ${result.optimizationReport.optimizedTokens}`);
+      console.log(`Reduction: ${result.optimizationReport.reductionPercent}%`);
+      if (result.optimizationReport.warning) {
+        console.warn('Warning: optimized context may exceed safe prompt size.');
+      }
+    } else {
+      console.log(`Context tokens: ${result.optimizationReport.contextTokens}`);
+    }
+    if (emitDiagnostics) {
+      console.log(`Diagnostics written to: ${path.join(outputProgramDir, 'analysis-diagnostics.json')}`);
+    }
+    console.log(`Output written to: ${outputProgramDir}`);
+  } catch (error) {
+    const message = args.mode
+      ? `${error.message}. Use --list-modes to inspect supported workflow modes.`
+      : error.message;
+    console.error(message);
+    process.exit(2);
   }
-  if (emitDiagnostics) {
-    console.log(`Diagnostics written to: ${path.join(outputProgramDir, 'analysis-diagnostics.json')}`);
-  }
-  console.log(`Output written to: ${outputProgramDir}`);
 }
 
 module.exports = {

--- a/src/cli/commands/copyToWorkspaceCommand.js
+++ b/src/cli/commands/copyToWorkspaceCommand.js
@@ -11,47 +11,19 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
-const fs = require('fs');
-const path = require('path');
-const {
-  loadProfiles,
-  readWorkCopyConfig,
-  resolveProfile,
-  resolveFetchConfig,
-} = require('../../config/runtimeConfig');
 const { renderAsciiTable } = require('../helpers/asciiTable');
-const {
-  copyFetchedSourcesToWorkspace,
-  parseMembersCsv,
-} = require('../../workspace/workCopyService');
+const { executeCopyToWorkspace } = require('../../core/workCopyService');
 
 async function runCopyToWorkspace(args) {
-  if (!args.profile || !String(args.profile).trim()) {
-    console.error('Missing required option: --profile <name>');
+  let execution;
+  try {
+    execution = executeCopyToWorkspace(args);
+  } catch (error) {
+    console.error(error.message);
     process.exit(2);
   }
 
-  const cwd = process.cwd();
-  const env = process.env;
-  const profiles = loadProfiles({ cwd, env, args });
-  const profile = resolveProfile(profiles, args.profile, { env });
-  const fetchConfig = resolveFetchConfig(args, { cwd, env });
-  const workCopyConfig = readWorkCopyConfig(profile, env);
-  const sourceRoot = path.resolve(cwd, fetchConfig.out);
-  const targetRoot = path.resolve(cwd, workCopyConfig.root);
-
-  if (!fs.existsSync(sourceRoot)) {
-    console.error(`Fetch output directory not found: ${sourceRoot}`);
-    process.exit(2);
-  }
-
-  const result = copyFetchedSourcesToWorkspace({
-    sourceRoot,
-    targetRoot,
-    workCopyMode: workCopyConfig.extension,
-    force: Boolean(args.force),
-    members: parseMembersCsv(args.members),
-  });
+  const { result } = execution;
 
   console.log(renderAsciiTable(
     ['Status', 'Member', 'Source', 'Target', 'Note'],

--- a/src/cli/commands/fetchCommand.js
+++ b/src/cli/commands/fetchCommand.js
@@ -12,60 +12,43 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const path = require('path');
-const { resolveFetchConfig } = require('../../config/runtimeConfig');
-const { fetchSources, describeEncodingPolicy } = require('../../fetch/fetchService');
+const { executeFetch } = require('../../core/fetchService');
 
 async function runFetch(args) {
   const verbose = Boolean(args.verbose);
-  const config = resolveFetchConfig(args);
+  try {
+    const { config, summary } = await executeFetch(args);
 
-  const required = [
-    ['host', '--host <hostname>'],
-    ['user', '--user <username>'],
-    ['password', '--password <password>'],
-    ['sourceLib', '--source-lib <lib>'],
-    ['ifsDir', '--ifs-dir <ifsPath>'],
-    ['out', '--out <localPath>'],
-  ];
-
-  for (const [key, flag] of required) {
-    if (!config[key] || !String(config[key]).trim()) {
-      console.error(`Missing required option: ${flag}`);
-      process.exit(2);
+    if (verbose) {
+      console.log(`[verbose] Fetch host: ${config.host}`);
+      console.log(`[verbose] Source library: ${config.sourceLib}`);
+      console.log(`[verbose] IFS dir: ${config.ifsDir}`);
+      console.log(`[verbose] Local out: ${path.resolve(process.cwd(), config.out)}`);
+      console.log(`[verbose] Source files: ${config.files.join(', ')}`);
+      console.log(`[verbose] Stream file encoding: ${summary.encodingPolicy}`);
+      console.log(`[verbose] Download transport: ${config.transport}`);
+      if (config.members.length > 0) {
+        console.log(`[verbose] Members (global filter): ${config.members.join(', ')}`);
+      }
     }
-  }
 
-  if (verbose) {
-    console.log(`[verbose] Fetch host: ${config.host}`);
-    console.log(`[verbose] Source library: ${config.sourceLib}`);
-    console.log(`[verbose] IFS dir: ${config.ifsDir}`);
-    console.log(`[verbose] Local out: ${path.resolve(process.cwd(), config.out)}`);
-    console.log(`[verbose] Source files: ${config.files.join(', ')}`);
-    console.log(`[verbose] Stream file encoding: ${describeEncodingPolicy(config.streamFileCcsid)}`);
-    console.log(`[verbose] Download transport: ${config.transport}`);
-    if (config.members.length > 0) {
-      console.log(`[verbose] Members (global filter): ${config.members.join(', ')}`);
+    console.log(`Exported streamfiles: ${summary.exportedSuccess}/${summary.exportedTotal}`);
+    console.log(`Downloaded files: ${summary.downloadedCount}`);
+    console.log(`Download transport used: ${summary.transportUsed}`);
+    console.log(`Source encoding policy: ${summary.encodingPolicy}`);
+    console.log(`Local destination: ${summary.localDestination}`);
+    if (summary.importManifestPath) {
+      console.log(`Import manifest: ${summary.importManifestPath}`);
     }
-  }
-
-  const summary = await fetchSources({
-    ...config,
-    verbose,
-  });
-
-  console.log(`Exported streamfiles: ${summary.exportedSuccess}/${summary.exportedTotal}`);
-  console.log(`Downloaded files: ${summary.downloadedCount}`);
-  console.log(`Download transport used: ${summary.transportUsed}`);
-  console.log(`Source encoding policy: ${summary.encodingPolicy}`);
-  console.log(`Local destination: ${summary.localDestination}`);
-  if (summary.importManifestPath) {
-    console.log(`Import manifest: ${summary.importManifestPath}`);
-  }
-  if (summary.notes.length > 0) {
-    console.log('Notes:');
-    for (const note of summary.notes) {
-      console.log(`- ${note}`);
+    if (summary.notes.length > 0) {
+      console.log('Notes:');
+      for (const note of summary.notes) {
+        console.log(`- ${note}`);
+      }
     }
+  } catch (error) {
+    console.error(error.message);
+    process.exit(2);
   }
 }
 

--- a/src/cli/commands/impactCommand.js
+++ b/src/cli/commands/impactCommand.js
@@ -12,72 +12,30 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const path = require('path');
-const { generateImpactAnalysis, normalizeId } = require('../../impact/impactAnalyzer');
-const { resolveAnalyzeConfig } = require('../../config/runtimeConfig');
-const { findImpactGraph } = require('../helpers/impactGraphResolver');
-const { resolveMemberProgram } = require('../helpers/memberResolver');
-const { normalizeReproducibilitySettings } = require('../../reproducibility/reproducibility');
+const { executeImpact } = require('../../core/impactService');
 
 function runImpact(args) {
   const verbose = Boolean(args.verbose);
-  const logVerbose = (message) => {
-    if (verbose) {
-      console.log(`[verbose] ${message}`);
-    }
-  };
-
-  if (!args.target && args.field) {
-    args.target = args.field;
-  }
-
-  if (!args.target || !String(args.target).trim()) {
-    console.error('Missing required option: --target <name>');
+  let execution;
+  try {
+    execution = executeImpact(args);
+  } catch (error) {
+    console.error(error.message);
     process.exit(2);
   }
 
-  const config = resolveAnalyzeConfig(args);
-  let resolvedProgram = args.program;
-  if ((!resolvedProgram || !String(resolvedProgram).trim()) && args.member) {
-    if (!config.sourceRoot || !String(config.sourceRoot).trim()) {
-      console.error('Missing required option: --source <path>');
-      process.exit(2);
-    }
-    try {
-      const memberResolution = resolveMemberProgram({
-        member: args.member,
-        sourceRoot: config.sourceRoot,
-        extensions: config.extensions,
-      });
-      resolvedProgram = memberResolution.program;
-    } catch (error) {
-      console.error(error.message);
-      process.exit(2);
-    }
+  const { result, graphPath, program, outputProgramDir, target } = execution;
+
+  if (verbose) {
+    console.log(`[verbose] Target: ${target}`);
+    console.log(`[verbose] Graph path: ${graphPath}`);
+    console.log(`[verbose] Output program: ${program}`);
   }
-
-  const outputRoot = path.resolve(process.cwd(), config.outputRoot);
-  const resolved = findImpactGraph({
-    outputRoot,
-    target: args.target,
-    program: resolvedProgram,
-  });
-
-  logVerbose(`Target: ${normalizeId(args.target)}`);
-  logVerbose(`Graph path: ${resolved.graphPath}`);
-  logVerbose(`Output program: ${resolved.program}`);
-
-  const result = generateImpactAnalysis({
-    graphPath: resolved.graphPath,
-    target: args.target,
-    jsonOutputPath: path.join(resolved.outputProgramDir, 'impact-analysis.json'),
-    markdownOutputPath: path.join(resolved.outputProgramDir, 'impact-analysis.md'),
-    reproducibility: normalizeReproducibilitySettings(Boolean(args.reproducible)),
-  });
 
   console.log(`Impact analysis complete for target ${result.target}`);
   console.log(`Type: ${result.type}`);
   console.log(`Total affected programs: ${result.totalAffectedPrograms || 0}`);
-  console.log(`Output written to: ${resolved.outputProgramDir}`);
+  console.log(`Output written to: ${outputProgramDir}`);
 }
 
 module.exports = {

--- a/src/cli/commands/querySqlCommand.js
+++ b/src/cli/commands/querySqlCommand.js
@@ -11,65 +11,26 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
-const { resolveAnalyzeConfig } = require('../../config/runtimeConfig');
-const { isDbConfigured } = require('../../db2/db2Config');
-const { runReadOnlyDb2Query, validateReadOnlySql } = require('../../db2/readOnlyQueryService');
 const { renderAsciiTable } = require('../helpers/asciiTable');
 const { renderCsv } = require('../helpers/csvRenderer');
-
-const DEFAULT_MAX_ROWS = 200;
-
-function parseMaxRows(value) {
-  if (value === undefined || value === null || value === true) {
-    return DEFAULT_MAX_ROWS;
-  }
-  const parsed = Number.parseInt(String(value).trim(), 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error('Invalid option: --max-rows must be a positive integer');
-  }
-  return parsed;
-}
-
-function normalizeOutput(value) {
-  const normalized = String(value || 'table').trim().toLowerCase();
-  if (normalized === 'table' || normalized === 'csv') {
-    return normalized;
-  }
-  throw new Error('Invalid option: --output must be one of: table, csv');
-}
-
-function toRowMatrix(columns, rows) {
-  return (rows || []).map((row) => (columns || []).map((column) => row && typeof row === 'object' ? row[column] : ''));
-}
+const {
+  DEFAULT_MAX_ROWS,
+  executeQuerySql,
+  normalizeOutput,
+  parseMaxRows,
+  toRowMatrix,
+} = require('../../core/queryService');
 
 async function runQuerySql(args) {
-  if (!args.profile || !String(args.profile).trim()) {
-    console.error('Missing required option: --profile <name>');
-    process.exit(2);
-  }
-  if (!args.sql || !String(args.sql).trim()) {
-    console.error('Missing required option: --sql "SELECT ..."');
-    process.exit(2);
-  }
-
-  const sql = String(args.sql).trim();
-  const maxRows = parseMaxRows(args['max-rows']);
-  const output = normalizeOutput(args.output);
-  const config = resolveAnalyzeConfig(args);
-
-  if (!isDbConfigured(config.db)) {
-    console.error('DB2 connection configuration is incomplete for the selected profile.');
+  let execution;
+  try {
+    execution = executeQuerySql(args);
+  } catch (error) {
+    console.error(error.message);
     process.exit(2);
   }
 
-  validateReadOnlySql(sql);
-  const result = runReadOnlyDb2Query({
-    dbConfig: config.db,
-    query: sql,
-    maxRows,
-  });
-  const columns = Array.isArray(result.columns) ? result.columns : [];
-  const matrix = toRowMatrix(columns, result.rows);
+  const { sql, output, columns, matrix } = execution;
 
   if (output === 'csv') {
     process.stdout.write(renderCsv(columns, matrix));

--- a/src/cli/commands/queryTableCommand.js
+++ b/src/cli/commands/queryTableCommand.js
@@ -11,130 +11,32 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
-const {
-  resolveAnalyzeConfig,
-} = require('../../config/runtimeConfig');
-const { isDbConfigured } = require('../../db2/db2Config');
-const {
-  escapeSqlLiteral,
-  executeReadOnlyDb2QueryWithFallback,
-  validateSqlIdentifier,
-} = require('../../db2/readOnlyQueryService');
 const { renderAsciiTable } = require('../helpers/asciiTable');
-const { discoverSchema } = require('../../db2/schemaDiscovery');
-
-function validateFilterPattern(value) {
-  const normalized = String(value || '').trim().toUpperCase();
-  if (!normalized) {
-    return '';
-  }
-  if (!/^[A-Z0-9_%$#@]+$/.test(normalized)) {
-    throw new Error(`Invalid --filter pattern: ${value}`);
-  }
-  return normalized;
-}
-
-function buildQueryTableQueries({ schema, table, filter }) {
-  const whereClauses = [`TABLE_NAME = ${escapeSqlLiteral(table)}`];
-  const columnClauses = [`TABLE_NAME = ${escapeSqlLiteral(table)}`];
-
-  if (schema) {
-    whereClauses.push(`TABLE_SCHEMA = ${escapeSqlLiteral(schema)}`);
-    columnClauses.push(`TABLE_SCHEMA = ${escapeSqlLiteral(schema)}`);
-  }
-
-  if (filter) {
-    columnClauses.push(`COLUMN_NAME LIKE ${escapeSqlLiteral(filter)}`);
-  }
-
-  return {
-    tableInfo: `SELECT TABLE_SCHEMA, TABLE_NAME
-FROM QSYS2.SYSTABLES
-WHERE ${whereClauses.join(' AND ')}
-ORDER BY TABLE_SCHEMA, TABLE_NAME`,
-    columns: `SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, LENGTH, NUMERIC_SCALE, IS_NULLABLE
-FROM QSYS2.SYSCOLUMNS
-WHERE ${columnClauses.join(' AND ')}
-ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION`,
-  };
-}
+const {
+  buildQueryTableQueries,
+  executeQueryTable,
+  validateFilterPattern,
+} = require('../../core/queryService');
 
 async function runQueryTable(args) {
-  if (!args.profile || !String(args.profile).trim()) {
-    console.error('Missing required option: --profile <name>');
-    process.exit(2);
-  }
-  if (!args.table || !String(args.table).trim()) {
-    console.error('Missing required option: --table <name>');
-    process.exit(2);
-  }
-
-  const config = resolveAnalyzeConfig(args);
-  if (!isDbConfigured(config.db)) {
-    console.error('DB2 connection configuration is incomplete for the selected profile.');
+  let execution;
+  try {
+    execution = executeQueryTable(args);
+  } catch (error) {
+    console.error(error.message);
     process.exit(2);
   }
 
-  const table = validateSqlIdentifier(args.table, '--table');
-  const schema = args.schema
-    ? validateSqlIdentifier(args.schema, '--schema')
-    : null;
-  const filter = args.filter ? validateFilterPattern(args.filter) : '';
-  const discovered = !schema ? discoverSchema(config.db, table) : null;
-  const effectiveSchema = schema || (discovered && discovered.TABLE_SCHEMA ? String(discovered.TABLE_SCHEMA).trim().toUpperCase() : '');
-  const queries = buildQueryTableQueries({ schema: effectiveSchema, table, filter });
-  const tableInfo = executeReadOnlyDb2QueryWithFallback({
-    dbConfig: config.db,
-    query: queries.tableInfo,
-    maxRows: 50,
-    context: {
-      table,
-      schema: effectiveSchema,
-    },
-    retryHandlers: {
-      SQL0204: ({ context }) => {
-        const fallbackSchema = discoverSchema(config.db, context.table);
-        if (!fallbackSchema || !fallbackSchema.TABLE_SCHEMA) {
-          return null;
-        }
-        return {
-          query: buildQueryTableQueries({
-            schema: String(fallbackSchema.TABLE_SCHEMA).trim().toUpperCase(),
-            table: context.table,
-            filter,
-          }).tableInfo,
-        };
-      },
-    },
-  });
-  const columns = executeReadOnlyDb2QueryWithFallback({
-    dbConfig: config.db,
-    query: queries.columns,
-    maxRows: 500,
-    context: {
-      table,
-      schema: effectiveSchema,
-      filter,
-    },
-    retryHandlers: {
-      SQL0204: ({ context }) => {
-        const fallbackSchema = discoverSchema(config.db, context.table);
-        if (!fallbackSchema || !fallbackSchema.TABLE_SCHEMA) {
-          return null;
-        }
-        return {
-          query: buildQueryTableQueries({
-            schema: String(fallbackSchema.TABLE_SCHEMA).trim().toUpperCase(),
-            table: context.table,
-            filter: context.filter,
-          }).columns,
-        };
-      },
-    },
-  });
+  const {
+    table,
+    schema: effectiveSchema,
+    requestedSchema,
+    tableInfo,
+    columns,
+  } = execution;
 
   console.log(`Table lookup: ${effectiveSchema ? `${effectiveSchema}.${table}` : table}`);
-  if (!schema && effectiveSchema) {
+  if (!requestedSchema && effectiveSchema) {
     console.log(`Schema discovery: ${table} -> ${effectiveSchema}`);
   }
   console.log('');

--- a/src/cli/commands/workflowCommand.js
+++ b/src/cli/commands/workflowCommand.js
@@ -15,10 +15,16 @@ const path = require('path');
 const { readAnalyzeRunManifest } = require('../../analyze/analyzeRunManifest');
 const { runAnalyze } = require('./analyzeCommand');
 const { runBundle } = require('./bundleCommand');
-const { resolveAnalyzeConfig } = require('../../config/runtimeConfig');
+const {
+  loadProfiles,
+  readWorkflowConfig,
+  resolveAnalyzeConfig,
+  resolveProfile,
+} = require('../../config/runtimeConfig');
 const { resolveWorkflowPresetSettings, listWorkflowPresets } = require('../../workflow/workflowPresetRegistry');
 const { buildWorkflowRunManifest, writeWorkflowRunManifest } = require('../../workflow/workflowRunManifest');
 const { normalizeReproducibilitySettings } = require('../../reproducibility/reproducibility');
+const { runWorkflowEngine } = require('../../workflow/workflowRunner');
 
 function printWorkflowPresets() {
   console.log('Supported workflow presets:');
@@ -35,7 +41,30 @@ function printWorkflowPresets() {
   }
 }
 
-function runWorkflow(args) {
+function printConfiguredWorkflowPresets(args) {
+  if (!args.profile || !String(args.profile).trim()) {
+    console.error('Missing required option: --profile <name>');
+    process.exit(2);
+  }
+  const cwd = process.cwd();
+  const env = process.env;
+  const profiles = loadProfiles({ cwd, env, args });
+  const profile = resolveProfile(profiles, args.profile, { env });
+  const workflowConfig = readWorkflowConfig(profiles, profile, env);
+
+  console.log(`Configured workflow presets for profile ${args.profile}:`);
+  const presetNames = Object.keys(workflowConfig.presets).sort((a, b) => a.localeCompare(b));
+  if (presetNames.length === 0) {
+    console.log('- none');
+    return;
+  }
+  for (const name of presetNames) {
+    const preset = workflowConfig.presets[name];
+    console.log(`- ${name}: ${preset.steps.join(', ')}`);
+  }
+}
+
+function runLegacyWorkflowPreset(args) {
   if (args['list-presets']) {
     printWorkflowPresets();
     return;
@@ -93,6 +122,37 @@ function runWorkflow(args) {
 
   console.log(`Workflow preset complete: ${preset.name}`);
   console.log(`Workflow manifest written to: ${path.join(outputProgramDir, 'workflow-run-manifest.json')}`);
+}
+
+async function runWorkflow(args) {
+  const subcommand = Array.isArray(args._) && args._.length > 0 ? String(args._[0]).trim().toLowerCase() : '';
+  if (subcommand === 'run') {
+    if (args['list-presets']) {
+      try {
+        printConfiguredWorkflowPresets(args);
+      } catch (error) {
+        console.error(error.message);
+        process.exit(2);
+      }
+      return;
+    }
+    try {
+      const state = await runWorkflowEngine(args);
+      console.log(`Workflow run complete: ${state.status}`);
+      console.log(`Run ID: ${state.runId}`);
+      console.log(`Run root: ${state.paths.runRoot}`);
+      console.log(`Context: ${state.paths.contextPath}`);
+      if (state.status !== 'succeeded') {
+        process.exitCode = 1;
+      }
+      return;
+    } catch (error) {
+      console.error(error.message);
+      process.exit(2);
+    }
+  }
+
+  runLegacyWorkflowPreset(args);
 }
 
 module.exports = {

--- a/src/config/runtimeConfig.js
+++ b/src/config/runtimeConfig.js
@@ -22,13 +22,16 @@ const { DEFAULT_ANALYSIS_LIMITS } = require('../analyze/analysisLimits');
 const DEFAULT_EXTENSIONS = ['.rpg', '.rpgle', '.sqlrpgle', '.rpgile', '.bnd', '.binder', '.bndsrc', '.clp', '.clle', '.dds', '.dspf', '.prtf', '.pf', '.lf'];
 const ALLOWED_FETCH_TRANSPORTS = new Set(['auto', 'sftp', 'jt400', 'ftp']);
 const ALLOWED_WORK_COPY_EXTENSIONS = new Set(['txt', 'original', 'suffixed']);
-const GLOBAL_PROFILE_KEYS = new Set(['contextOptimizer', 'testData', 'analysisLimits']);
+const ALLOWED_WORKFLOW_STEPS = new Set(['fetch', 'copy', 'analyze', 'impact', 'query-table', 'report']);
+const GLOBAL_PROFILE_KEYS = new Set(['contextOptimizer', 'testData', 'analysisLimits', 'presets']);
 const PROFILES_METADATA_KEY = Symbol('zeusProfilesMetadata');
 const DEFAULT_WORK_COPY = Object.freeze({
   root: 'source/',
   extension: 'txt',
 });
 const DEFAULT_TOKEN_BUDGET = 2200;
+const DEFAULT_WORKFLOW_STEPS = Object.freeze(['fetch', 'copy', 'analyze', 'report']);
+const DEFAULT_WORKFLOW_ANALYZE_MODES = Object.freeze(['documentation', 'defect-analysis']);
 const TOKEN_BUDGET_KEY_ALIASES = Object.freeze({
   documentation: 'documentation',
   'error-analysis': 'errorAnalysis',
@@ -235,6 +238,108 @@ function validateTokenBudgetConfig(value, label) {
   }
 }
 
+function validateWorkflowTableConfig(value, label) {
+  if (!isPlainObject(value)) {
+    failValidation(`${label} must be an object`);
+  }
+  assertOptionalString(value.schema, `${label}.schema`);
+  assertOptionalString(value.table, `${label}.table`);
+  assertOptionalString(value.filter, `${label}.filter`);
+  if (!value.table || !String(value.table).trim()) {
+    failValidation(`${label}.table must be a non-empty string`);
+  }
+}
+
+function validateWorkflowImpactConfig(value, label) {
+  if (!isPlainObject(value)) {
+    failValidation(`${label} must be an object`);
+  }
+  assertOptionalString(value.target, `${label}.target`);
+  assertOptionalString(value.field, `${label}.field`);
+  assertOptionalString(value.program, `${label}.program`);
+  assertOptionalString(value.member, `${label}.member`);
+  if (!value.target && !value.field) {
+    failValidation(`${label} must define at least one of .target or .field`);
+  }
+}
+
+function validateWorkflowPresetDefinition(value, label) {
+  if (!isPlainObject(value)) {
+    failValidation(`${label} must be an object`);
+  }
+  if (!Array.isArray(value.steps) || value.steps.length === 0) {
+    failValidation(`${label}.steps must be a non-empty array`);
+  }
+  for (const step of value.steps) {
+    const normalized = String(step || '').trim().toLowerCase();
+    if (!ALLOWED_WORKFLOW_STEPS.has(normalized)) {
+      failValidation(`${label}.steps contains an unsupported value: ${step}`);
+    }
+  }
+  if (value.members !== undefined) {
+    assertStringArray(value.members, `${label}.members`);
+  }
+  if (value.analyzeModes !== undefined) {
+    assertStringArray(value.analyzeModes, `${label}.analyzeModes`);
+  }
+  if (value.tables !== undefined) {
+    if (!Array.isArray(value.tables)) {
+      failValidation(`${label}.tables must be an array`);
+    }
+    value.tables.forEach((entry, index) => validateWorkflowTableConfig(entry, `${label}.tables[${index}]`));
+  }
+  if (value.impact !== undefined) {
+    if (!Array.isArray(value.impact)) {
+      failValidation(`${label}.impact must be an array`);
+    }
+    value.impact.forEach((entry, index) => validateWorkflowImpactConfig(entry, `${label}.impact[${index}]`));
+  }
+  if (value.continueOnError !== undefined && typeof value.continueOnError !== 'boolean') {
+    failValidation(`${label}.continueOnError must be a boolean`);
+  }
+}
+
+function validateWorkflowPresetCollection(value, label) {
+  if (!isPlainObject(value)) {
+    failValidation(`${label} must be an object`);
+  }
+  for (const [key, preset] of Object.entries(value)) {
+    validateWorkflowPresetDefinition(preset, `${label}.${key}`);
+  }
+}
+
+function validateWorkflowConfig(value, label) {
+  if (!isPlainObject(value)) {
+    failValidation(`${label} must be an object`);
+  }
+  assertOptionalString(value.outputRoot, `${label}.outputRoot`);
+  assertOptionalString(value.defaultPreset, `${label}.defaultPreset`);
+  if (value.members !== undefined) {
+    assertStringArray(value.members, `${label}.members`);
+  }
+  if (value.analyzeModes !== undefined) {
+    assertStringArray(value.analyzeModes, `${label}.analyzeModes`);
+  }
+  if (value.tables !== undefined) {
+    if (!Array.isArray(value.tables)) {
+      failValidation(`${label}.tables must be an array`);
+    }
+    value.tables.forEach((entry, index) => validateWorkflowTableConfig(entry, `${label}.tables[${index}]`));
+  }
+  if (value.impact !== undefined) {
+    if (!Array.isArray(value.impact)) {
+      failValidation(`${label}.impact must be an array`);
+    }
+    value.impact.forEach((entry, index) => validateWorkflowImpactConfig(entry, `${label}.impact[${index}]`));
+  }
+  if (value.continueOnError !== undefined && typeof value.continueOnError !== 'boolean') {
+    failValidation(`${label}.continueOnError must be a boolean`);
+  }
+  if (value.presets !== undefined) {
+    validateWorkflowPresetCollection(value.presets, `${label}.presets`);
+  }
+}
+
 function validateNamedProfile(profile, label) {
   if (!isPlainObject(profile)) {
     failValidation(`${label} must be an object`);
@@ -266,6 +371,12 @@ function validateNamedProfile(profile, label) {
   if (profile.tokenBudget !== undefined) {
     validateTokenBudgetConfig(profile.tokenBudget, `${label}.tokenBudget`);
   }
+  if (profile.workflow !== undefined) {
+    validateWorkflowConfig(profile.workflow, `${label}.workflow`);
+  }
+  if (profile.presets !== undefined) {
+    validateWorkflowPresetCollection(profile.presets, `${label}.presets`);
+  }
 }
 
 function validateProfiles(profiles) {
@@ -281,6 +392,9 @@ function validateProfiles(profiles) {
   }
   if (profiles.analysisLimits !== undefined) {
     validateAnalysisLimitsConfig(profiles.analysisLimits, 'analysisLimits');
+  }
+  if (profiles.presets !== undefined) {
+    validateWorkflowPresetCollection(profiles.presets, 'presets');
   }
 
   for (const [key, value] of Object.entries(profiles)) {
@@ -558,6 +672,109 @@ function readTokenBudgetConfig(profile, env) {
   return resolved;
 }
 
+function normalizeWorkflowStepList(steps) {
+  return Array.from(new Set((steps || [])
+    .map((entry) => String(entry || '').trim().toLowerCase())
+    .filter(Boolean)))
+    .filter((entry) => ALLOWED_WORKFLOW_STEPS.has(entry));
+}
+
+function normalizeWorkflowMemberList(values) {
+  return Array.from(new Set((values || [])
+    .map((entry) => String(entry || '').trim().toUpperCase())
+    .filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function normalizeWorkflowAnalyzeModes(values) {
+  const normalized = Array.from(new Set((values || [])
+    .map((entry) => String(entry || '').trim())
+    .filter(Boolean)));
+  return normalized.length > 0 ? normalized : [...DEFAULT_WORKFLOW_ANALYZE_MODES];
+}
+
+function normalizeWorkflowTables(values) {
+  return (Array.isArray(values) ? values : [])
+    .map((entry) => ({
+      schema: entry && entry.schema ? String(entry.schema).trim().toUpperCase() : '',
+      table: entry && entry.table ? String(entry.table).trim().toUpperCase() : '',
+      filter: entry && entry.filter ? String(entry.filter).trim().toUpperCase() : '',
+    }))
+    .filter((entry) => entry.table);
+}
+
+function normalizeWorkflowImpact(values) {
+  return (Array.isArray(values) ? values : [])
+    .map((entry) => ({
+      target: entry && entry.target ? String(entry.target).trim().toUpperCase() : '',
+      field: entry && entry.field ? String(entry.field).trim().toUpperCase() : '',
+      program: entry && entry.program ? String(entry.program).trim().toUpperCase() : '',
+      member: entry && entry.member ? String(entry.member).trim().toUpperCase() : '',
+    }))
+    .filter((entry) => entry.target || entry.field);
+}
+
+function normalizeWorkflowPresetMap(value) {
+  if (!isPlainObject(value)) {
+    return {};
+  }
+  const entries = Object.entries(value).map(([name, preset]) => {
+    const normalizedName = String(name || '').trim();
+    return [normalizedName, {
+      name: normalizedName,
+      steps: normalizeWorkflowStepList(preset && preset.steps),
+      members: normalizeWorkflowMemberList(preset && preset.members),
+      analyzeModes: normalizeWorkflowAnalyzeModes(preset && preset.analyzeModes),
+      tables: normalizeWorkflowTables(preset && preset.tables),
+      impact: normalizeWorkflowImpact(preset && preset.impact),
+      continueOnError: Boolean(preset && preset.continueOnError),
+    }];
+  });
+  return Object.fromEntries(entries.filter(([name, preset]) => name && preset.steps.length > 0));
+}
+
+function readWorkflowConfig(profiles, profile, env) {
+  const globalPresets = profiles && typeof profiles.presets === 'object'
+    ? resolveEnvPlaceholdersDeep(profiles.presets, env)
+    : {};
+  const profilePresets = profile && typeof profile.presets === 'object'
+    ? resolveEnvPlaceholdersDeep(profile.presets, env)
+    : {};
+  const workflowConfig = profile && typeof profile.workflow === 'object'
+    ? resolveEnvPlaceholdersDeep(profile.workflow, env)
+    : {};
+  const workflowPresets = workflowConfig && typeof workflowConfig.presets === 'object'
+    ? workflowConfig.presets
+    : {};
+
+  return {
+    outputRoot: workflowConfig.outputRoot || (profile && profile.outputRoot) || 'analysis',
+    defaultPreset: String(workflowConfig.defaultPreset || '').trim(),
+    continueOnError: Boolean(workflowConfig.continueOnError),
+    members: normalizeWorkflowMemberList(workflowConfig.members),
+    analyzeModes: normalizeWorkflowAnalyzeModes(workflowConfig.analyzeModes),
+    tables: normalizeWorkflowTables(workflowConfig.tables),
+    impact: normalizeWorkflowImpact(workflowConfig.impact),
+    presets: normalizeWorkflowPresetMap(mergeConfigLayers(
+      mergeConfigLayers(globalPresets, profilePresets),
+      workflowPresets,
+    )),
+  };
+}
+
+function resolveWorkflowPresetConfig(profiles, profile, presetName, env = process.env) {
+  const workflowConfig = readWorkflowConfig(profiles, profile, env);
+  if (!presetName) {
+    return null;
+  }
+  const key = String(presetName).trim();
+  const preset = workflowConfig.presets[key];
+  if (!preset) {
+    throw new Error(`Workflow preset "${presetName}" not found in ${describeProfilesLocation(profiles)}`);
+  }
+  return preset;
+}
+
 function readContextOptimizerConfig(profiles, profile, env) {
   const globalConfig = profiles && typeof profiles.contextOptimizer === 'object'
     ? resolveEnvPlaceholdersDeep(profiles.contextOptimizer, env)
@@ -705,18 +922,23 @@ module.exports = {
   DEFAULT_EXTENSIONS,
   ALLOWED_FETCH_TRANSPORTS,
   ALLOWED_WORK_COPY_EXTENSIONS,
+  ALLOWED_WORKFLOW_STEPS,
   DEFAULT_ANALYSIS_LIMITS,
   DEFAULT_TOKEN_BUDGET,
   DEFAULT_WORK_COPY,
+  DEFAULT_WORKFLOW_ANALYZE_MODES,
+  DEFAULT_WORKFLOW_STEPS,
   describeProfilesLocation,
   getProfilesMetadata,
   loadProfiles,
   normalizeTokenBudgetKey,
+  readWorkflowConfig,
   readTokenBudgetConfig,
   readWorkCopyConfig,
   resolveAnalyzeConfig,
   resolveBundleConfig,
   resolveFetchConfig,
+  resolveWorkflowPresetConfig,
   resolveProfilesConfigPaths,
   resolveProfile,
   validateProfiles,

--- a/src/core/analyzeService.js
+++ b/src/core/analyzeService.js
@@ -1,0 +1,285 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+const { DEFAULT_TEST_DATA_LIMIT } = require('../db2/testDataExportService');
+const { resolveAnalyzeConfig } = require('../config/runtimeConfig');
+const {
+  runAnalyzeArtifactAdapter,
+  runAnalyzeCore,
+} = require('../analyze/analyzePipeline');
+const {
+  buildAnalyzeRunManifest,
+  readAnalyzeRunManifest,
+  writeAnalyzeRunManifest,
+} = require('../analyze/analyzeRunManifest');
+const { buildSafeSharingArtifacts } = require('../sharing/safeSharingArtifactBuilder');
+const { resolveWorkflowModeSettings } = require('../workflow/workflowModeRegistry');
+const { resolvePromptTemplates } = require('../prompt/promptBuilder');
+const { resolveMemberProgram } = require('../cli/helpers/memberResolver');
+const {
+  normalizeReproducibilitySettings,
+  resolveDurationMs,
+  resolveTimestamp,
+} = require('../reproducibility/reproducibility');
+
+function parsePositiveInteger(value, fallback) {
+  if (value === undefined || value === null || value === true) return fallback;
+  const parsed = Number.parseInt(String(value).trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+function parseCsv(value) {
+  if (value === undefined || value === null || value === true) {
+    return [];
+  }
+  return Array.from(new Set(String(value)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function executeAnalyze(args, { cwd = process.cwd() } = {}) {
+  const verbose = Boolean(args.verbose);
+  const logVerbose = (message) => {
+    if (verbose) {
+      console.log(`[verbose] ${message}`);
+    }
+  };
+
+  const config = resolveAnalyzeConfig(args, { cwd });
+  const resolvedSourceRoot = config.sourceRoot ? path.resolve(cwd, config.sourceRoot) : '';
+  let resolvedProgram = args.program;
+
+  if ((!resolvedProgram || !String(resolvedProgram).trim()) && args.member) {
+    if (!resolvedSourceRoot || !String(resolvedSourceRoot).trim()) {
+      const error = new Error('Missing required option: --source <path>');
+      error.code = 'SOURCE_REQUIRED';
+      throw error;
+    }
+    resolvedProgram = resolveMemberProgram({
+      member: args.member,
+      sourceRoot: resolvedSourceRoot,
+      extensions: config.extensions,
+    }).program;
+  }
+
+  if (!resolvedProgram || !String(resolvedProgram).trim()) {
+    const error = new Error('Missing required option: --program <name>');
+    error.code = 'PROGRAM_REQUIRED';
+    throw error;
+  }
+
+  if (!resolvedSourceRoot || !String(resolvedSourceRoot).trim()) {
+    const error = new Error('Missing required option: --source <path>');
+    error.code = 'SOURCE_REQUIRED';
+    throw error;
+  }
+
+  const sourceRoot = resolvedSourceRoot;
+  const outputRoot = path.resolve(cwd, config.outputRoot);
+  const program = String(resolvedProgram).trim();
+  const workflowPreset = args['workflow-preset-settings'] && typeof args['workflow-preset-settings'] === 'object'
+    ? {
+      ...args['workflow-preset-settings'],
+      promptTemplates: [...(args['workflow-preset-settings'].promptTemplates || [])],
+      workflowKeys: [...(args['workflow-preset-settings'].workflowKeys || [])],
+      bundleArtifacts: [...(args['workflow-preset-settings'].bundleArtifacts || [])],
+    }
+    : null;
+  let workflowModeSettings = null;
+  if (args.mode) {
+    workflowModeSettings = resolveWorkflowModeSettings(args.mode);
+  }
+  const optimizeContextEnabled = Boolean(args['optimize-context'])
+    || Boolean(workflowModeSettings && workflowModeSettings.autoOptimizeContext);
+  const guidedMode = workflowModeSettings
+    ? {
+      ...workflowModeSettings,
+      effectiveOptimizeContext: optimizeContextEnabled,
+    }
+    : null;
+  const promptTemplates = workflowModeSettings
+    ? resolvePromptTemplates(workflowModeSettings.promptTemplates)
+    : resolvePromptTemplates();
+  const testDataLimit = parsePositiveInteger(args['test-data-limit'], Number(config.testData.limit) || DEFAULT_TEST_DATA_LIMIT);
+  const searchMaxResults = parsePositiveInteger(args['search-max-results'], 200);
+  const skipTestData = Boolean(args['skip-test-data']);
+  const safeSharingEnabled = Boolean(args['safe-sharing']);
+  const emitDiagnostics = Boolean(args['emit-diagnostics']);
+  const scanIfsPathsEnabled = Boolean(args['scan-ifs-paths']);
+  const searchTerms = parseCsv(args['search-terms']);
+  const searchIgnorePatterns = parseCsv(args['search-ignore']);
+  const diagnosticPacks = parseCsv(args['diagnostic-packs']);
+  const diagnosticParameterString = typeof args['diagnostic-params'] === 'string' ? args['diagnostic-params'] : '';
+  const reproducibility = normalizeReproducibilitySettings(Boolean(args.reproducible));
+
+  if (testDataLimit === null) {
+    throw new Error('Invalid option: --test-data-limit must be a positive integer');
+  }
+  if (searchMaxResults === null) {
+    throw new Error('Invalid option: --search-max-results must be a positive integer');
+  }
+
+  if (!fs.existsSync(sourceRoot)) {
+    const error = new Error(`Source directory not found: ${sourceRoot}. Provide a valid --source path.`);
+    error.code = 'SOURCE_ROOT_MISSING';
+    throw error;
+  }
+
+  const outputProgramDir = path.join(outputRoot, program);
+  fs.mkdirSync(outputProgramDir, { recursive: true });
+  logVerbose(`Writing output to ${outputProgramDir}`);
+  const previousManifest = readAnalyzeRunManifest(outputProgramDir);
+  const startedAt = resolveTimestamp(reproducibility);
+  const startedNs = process.hrtime.bigint();
+
+  try {
+    const coreResult = runAnalyzeCore({
+      program,
+      sourceRoot,
+      outputRoot,
+      outputProgramDir,
+      config,
+      testDataLimit,
+      skipTestData,
+      verbose,
+      optimizeContextEnabled,
+      workflowMode: guidedMode ? guidedMode.name : null,
+      workflowModeSettings: guidedMode,
+      promptTemplates,
+      workflowPreset,
+      scanIfsPathsEnabled,
+      searchTerms,
+      searchIgnorePatterns,
+      searchMaxResults,
+      diagnosticPacks,
+      diagnosticParameterString,
+      ibmiConfig: config.ibmi,
+      reproducibility,
+      logVerbose,
+    });
+    const result = runAnalyzeArtifactAdapter({
+      ...coreResult,
+      emitDiagnostics,
+    });
+    const durationMs = resolveDurationMs(reproducibility, Number((process.hrtime.bigint() - startedNs) / 1000000n));
+    const manifest = buildAnalyzeRunManifest({
+      status: 'succeeded',
+      context: {
+        program,
+        sourceRoot,
+        outputRoot,
+        outputProgramDir,
+        cwd,
+        startedAt,
+        completedAt: resolveTimestamp(reproducibility),
+        durationMs,
+        optimizeContextEnabled,
+        safeSharingEnabled,
+        emitDiagnosticsEnabled: emitDiagnostics,
+        skipTestData,
+        testDataLimit,
+        analysisLimits: config.analysisLimits,
+        testDataPolicy: config.testData,
+        tokenBudget: config.tokenBudget,
+        extensions: config.extensions,
+        reproducibility,
+        guidedMode,
+        workflowPreset,
+        investigation: {
+          scanIfsPathsEnabled,
+          searchTerms,
+          searchIgnorePatterns,
+          searchMaxResults,
+          diagnosticPacks,
+          diagnosticParameterString,
+        },
+      },
+      result,
+      previousManifest,
+    });
+    writeAnalyzeRunManifest(outputProgramDir, manifest);
+    if (safeSharingEnabled) {
+      buildSafeSharingArtifacts({
+        outputProgramDir,
+        analyzeManifest: manifest,
+        reproducibility,
+      });
+    }
+
+    return {
+      program,
+      config,
+      sourceRoot,
+      outputRoot,
+      outputProgramDir,
+      result,
+      analyzeManifest: manifest,
+      guidedMode,
+      workflowPreset,
+      safeSharingEnabled,
+      emitDiagnostics,
+      searchTerms,
+      diagnosticPacks,
+      reproducibility,
+    };
+  } catch (error) {
+    const durationMs = resolveDurationMs(reproducibility, Number((process.hrtime.bigint() - startedNs) / 1000000n));
+    const manifest = buildAnalyzeRunManifest({
+      status: 'failed',
+      context: {
+        program,
+        sourceRoot,
+        outputRoot,
+        outputProgramDir,
+        cwd,
+        startedAt,
+        completedAt: resolveTimestamp(reproducibility),
+        durationMs,
+        optimizeContextEnabled,
+        safeSharingEnabled,
+        emitDiagnosticsEnabled: emitDiagnostics,
+        skipTestData,
+        testDataLimit,
+        analysisLimits: config.analysisLimits,
+        testDataPolicy: config.testData,
+        tokenBudget: config.tokenBudget,
+        extensions: config.extensions,
+        reproducibility,
+        guidedMode,
+        workflowPreset,
+        investigation: {
+          scanIfsPathsEnabled,
+          searchTerms,
+          searchIgnorePatterns,
+          searchMaxResults,
+          diagnosticPacks,
+          diagnosticParameterString,
+        },
+      },
+      error,
+      previousManifest,
+    });
+    writeAnalyzeRunManifest(outputProgramDir, manifest);
+    error.analyzeManifest = manifest;
+    throw error;
+  }
+}
+
+module.exports = {
+  executeAnalyze,
+};

--- a/src/core/fetchService.js
+++ b/src/core/fetchService.js
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const path = require('path');
+const { resolveFetchConfig } = require('../config/runtimeConfig');
+const { fetchSources, describeEncodingPolicy } = require('../fetch/fetchService');
+
+const REQUIRED_FETCH_FIELDS = Object.freeze([
+  ['host', '--host <hostname>'],
+  ['user', '--user <username>'],
+  ['password', '--password <password>'],
+  ['sourceLib', '--source-lib <lib>'],
+  ['ifsDir', '--ifs-dir <ifsPath>'],
+  ['out', '--out <localPath>'],
+]);
+
+function findMissingFetchFields(config) {
+  return REQUIRED_FETCH_FIELDS
+    .filter(([key]) => !config[key] || !String(config[key]).trim())
+    .map(([, flag]) => flag);
+}
+
+async function executeFetch(args, { cwd = process.cwd(), env = process.env } = {}) {
+  const config = resolveFetchConfig(args, { cwd, env });
+  const missing = findMissingFetchFields(config);
+
+  if (missing.length > 0) {
+    const error = new Error(`Missing required option: ${missing[0]}`);
+    error.code = 'FETCH_CONFIG_INCOMPLETE';
+    error.missing = missing;
+    error.config = config;
+    throw error;
+  }
+
+  const summary = await fetchSources({
+    ...config,
+    verbose: Boolean(args.verbose),
+  });
+
+  return {
+    config,
+    summary: {
+      ...summary,
+      localDestination: path.resolve(cwd, summary.localDestination || config.out),
+      encodingPolicy: summary.encodingPolicy || describeEncodingPolicy(config.streamFileCcsid),
+    },
+  };
+}
+
+module.exports = {
+  REQUIRED_FETCH_FIELDS,
+  executeFetch,
+  findMissingFetchFields,
+};

--- a/src/core/impactService.js
+++ b/src/core/impactService.js
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const path = require('path');
+const { generateImpactAnalysis, normalizeId } = require('../impact/impactAnalyzer');
+const { resolveAnalyzeConfig } = require('../config/runtimeConfig');
+const { findImpactGraph } = require('../cli/helpers/impactGraphResolver');
+const { resolveMemberProgram } = require('../cli/helpers/memberResolver');
+const { normalizeReproducibilitySettings } = require('../reproducibility/reproducibility');
+
+function executeImpact(args, { cwd = process.cwd() } = {}) {
+  const normalizedArgs = { ...args };
+  if (!normalizedArgs.target && normalizedArgs.field) {
+    normalizedArgs.target = normalizedArgs.field;
+  }
+  if (!normalizedArgs.target || !String(normalizedArgs.target).trim()) {
+    const error = new Error('Missing required option: --target <name>');
+    error.code = 'TARGET_REQUIRED';
+    throw error;
+  }
+
+  const config = resolveAnalyzeConfig(normalizedArgs, { cwd });
+  const resolvedSourceRoot = config.sourceRoot ? path.resolve(cwd, config.sourceRoot) : '';
+  let resolvedProgram = normalizedArgs.program;
+  if ((!resolvedProgram || !String(resolvedProgram).trim()) && normalizedArgs.member) {
+    if (!resolvedSourceRoot || !String(resolvedSourceRoot).trim()) {
+      const error = new Error('Missing required option: --source <path>');
+      error.code = 'SOURCE_REQUIRED';
+      throw error;
+    }
+    resolvedProgram = resolveMemberProgram({
+      member: normalizedArgs.member,
+      sourceRoot: resolvedSourceRoot,
+      extensions: config.extensions,
+    }).program;
+  }
+
+  const outputRoot = path.resolve(cwd, config.outputRoot);
+  const resolved = findImpactGraph({
+    outputRoot,
+    target: normalizedArgs.target,
+    program: resolvedProgram,
+  });
+
+  const result = generateImpactAnalysis({
+    graphPath: resolved.graphPath,
+    target: normalizedArgs.target,
+    jsonOutputPath: path.join(resolved.outputProgramDir, 'impact-analysis.json'),
+    markdownOutputPath: path.join(resolved.outputProgramDir, 'impact-analysis.md'),
+    reproducibility: normalizeReproducibilitySettings(Boolean(normalizedArgs.reproducible)),
+  });
+
+  return {
+    config,
+    target: normalizeId(normalizedArgs.target),
+    outputRoot,
+    outputProgramDir: resolved.outputProgramDir,
+    graphPath: resolved.graphPath,
+    program: resolved.program,
+    result,
+  };
+}
+
+module.exports = {
+  executeImpact,
+};

--- a/src/core/queryService.js
+++ b/src/core/queryService.js
@@ -1,0 +1,224 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const { resolveAnalyzeConfig } = require('../config/runtimeConfig');
+const { isDbConfigured } = require('../db2/db2Config');
+const {
+  escapeSqlLiteral,
+  executeReadOnlyDb2QueryWithFallback,
+  runReadOnlyDb2Query,
+  validateReadOnlySql,
+  validateSqlIdentifier,
+} = require('../db2/readOnlyQueryService');
+const { discoverSchema } = require('../db2/schemaDiscovery');
+
+const DEFAULT_MAX_ROWS = 200;
+
+function validateFilterPattern(value) {
+  const normalized = String(value || '').trim().toUpperCase();
+  if (!normalized) {
+    return '';
+  }
+  if (!/^[A-Z0-9_%$#@]+$/.test(normalized)) {
+    throw new Error(`Invalid --filter pattern: ${value}`);
+  }
+  return normalized;
+}
+
+function buildQueryTableQueries({ schema, table, filter }) {
+  const whereClauses = [`TABLE_NAME = ${escapeSqlLiteral(table)}`];
+  const columnClauses = [`TABLE_NAME = ${escapeSqlLiteral(table)}`];
+
+  if (schema) {
+    whereClauses.push(`TABLE_SCHEMA = ${escapeSqlLiteral(schema)}`);
+    columnClauses.push(`TABLE_SCHEMA = ${escapeSqlLiteral(schema)}`);
+  }
+
+  if (filter) {
+    columnClauses.push(`COLUMN_NAME LIKE ${escapeSqlLiteral(filter)}`);
+  }
+
+  return {
+    tableInfo: `SELECT TABLE_SCHEMA, TABLE_NAME
+FROM QSYS2.SYSTABLES
+WHERE ${whereClauses.join(' AND ')}
+ORDER BY TABLE_SCHEMA, TABLE_NAME`,
+    columns: `SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, LENGTH, NUMERIC_SCALE, IS_NULLABLE
+FROM QSYS2.SYSCOLUMNS
+WHERE ${columnClauses.join(' AND ')}
+ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION`,
+  };
+}
+
+function parseMaxRows(value) {
+  if (value === undefined || value === null || value === true) {
+    return DEFAULT_MAX_ROWS;
+  }
+  const parsed = Number.parseInt(String(value).trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error('Invalid option: --max-rows must be a positive integer');
+  }
+  return parsed;
+}
+
+function normalizeOutput(value) {
+  const normalized = String(value || 'table').trim().toLowerCase();
+  if (normalized === 'table' || normalized === 'csv') {
+    return normalized;
+  }
+  throw new Error('Invalid option: --output must be one of: table, csv');
+}
+
+function toRowMatrix(columns, rows) {
+  return (rows || []).map((row) => (columns || []).map((column) => (row && typeof row === 'object' ? row[column] : '')));
+}
+
+function requireDbConfig(config) {
+  if (!isDbConfigured(config.db)) {
+    const error = new Error('DB2 connection configuration is incomplete for the selected profile.');
+    error.code = 'DB2_CONFIG_INCOMPLETE';
+    throw error;
+  }
+}
+
+function executeQueryTable(args, { cwd = process.cwd() } = {}) {
+  if (!args.profile || !String(args.profile).trim()) {
+    const error = new Error('Missing required option: --profile <name>');
+    error.code = 'PROFILE_REQUIRED';
+    throw error;
+  }
+  if (!args.table || !String(args.table).trim()) {
+    const error = new Error('Missing required option: --table <name>');
+    error.code = 'TABLE_REQUIRED';
+    throw error;
+  }
+
+  const config = resolveAnalyzeConfig(args, { cwd });
+  requireDbConfig(config);
+
+  const table = validateSqlIdentifier(args.table, '--table');
+  const schema = args.schema ? validateSqlIdentifier(args.schema, '--schema') : null;
+  const filter = args.filter ? validateFilterPattern(args.filter) : '';
+  const discovered = !schema ? discoverSchema(config.db, table) : null;
+  const effectiveSchema = schema || (discovered && discovered.TABLE_SCHEMA ? String(discovered.TABLE_SCHEMA).trim().toUpperCase() : '');
+  const queries = buildQueryTableQueries({ schema: effectiveSchema, table, filter });
+  const tableInfo = executeReadOnlyDb2QueryWithFallback({
+    dbConfig: config.db,
+    query: queries.tableInfo,
+    maxRows: 50,
+    context: {
+      table,
+      schema: effectiveSchema,
+    },
+    retryHandlers: {
+      SQL0204: ({ context }) => {
+        const fallbackSchema = discoverSchema(config.db, context.table);
+        if (!fallbackSchema || !fallbackSchema.TABLE_SCHEMA) {
+          return null;
+        }
+        return {
+          query: buildQueryTableQueries({
+            schema: String(fallbackSchema.TABLE_SCHEMA).trim().toUpperCase(),
+            table: context.table,
+            filter,
+          }).tableInfo,
+        };
+      },
+    },
+  });
+  const columns = executeReadOnlyDb2QueryWithFallback({
+    dbConfig: config.db,
+    query: queries.columns,
+    maxRows: 500,
+    context: {
+      table,
+      schema: effectiveSchema,
+      filter,
+    },
+    retryHandlers: {
+      SQL0204: ({ context }) => {
+        const fallbackSchema = discoverSchema(config.db, context.table);
+        if (!fallbackSchema || !fallbackSchema.TABLE_SCHEMA) {
+          return null;
+        }
+        return {
+          query: buildQueryTableQueries({
+            schema: String(fallbackSchema.TABLE_SCHEMA).trim().toUpperCase(),
+            table: context.table,
+            filter: context.filter,
+          }).columns,
+        };
+      },
+    },
+  });
+
+  return {
+    config,
+    table,
+    schema: effectiveSchema,
+    requestedSchema: schema,
+    filter,
+    discoveredSchema: !schema && effectiveSchema ? effectiveSchema : '',
+    tableInfo,
+    columns,
+  };
+}
+
+function executeQuerySql(args, { cwd = process.cwd() } = {}) {
+  if (!args.profile || !String(args.profile).trim()) {
+    const error = new Error('Missing required option: --profile <name>');
+    error.code = 'PROFILE_REQUIRED';
+    throw error;
+  }
+  if (!args.sql || !String(args.sql).trim()) {
+    const error = new Error('Missing required option: --sql "SELECT ..."');
+    error.code = 'SQL_REQUIRED';
+    throw error;
+  }
+
+  const sql = String(args.sql).trim();
+  const maxRows = parseMaxRows(args['max-rows']);
+  const output = normalizeOutput(args.output);
+  const config = resolveAnalyzeConfig(args, { cwd });
+  requireDbConfig(config);
+
+  validateReadOnlySql(sql);
+  const result = runReadOnlyDb2Query({
+    dbConfig: config.db,
+    query: sql,
+    maxRows,
+  });
+  const columns = Array.isArray(result.columns) ? result.columns : [];
+
+  return {
+    config,
+    sql,
+    maxRows,
+    output,
+    columns,
+    rows: result.rows || [],
+    rowCount: Number(result.rowCount || (result.rows || []).length || 0),
+    matrix: toRowMatrix(columns, result.rows),
+  };
+}
+
+module.exports = {
+  DEFAULT_MAX_ROWS,
+  buildQueryTableQueries,
+  executeQuerySql,
+  executeQueryTable,
+  normalizeOutput,
+  parseMaxRows,
+  toRowMatrix,
+  validateFilterPattern,
+};

--- a/src/core/workCopyService.js
+++ b/src/core/workCopyService.js
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+const {
+  loadProfiles,
+  readWorkCopyConfig,
+  resolveProfile,
+  resolveFetchConfig,
+} = require('../config/runtimeConfig');
+const {
+  copyFetchedSourcesToWorkspace,
+  parseMembersCsv,
+} = require('../workspace/workCopyService');
+
+function executeCopyToWorkspace(args, options = {}) {
+  const cwd = options.cwd || process.cwd();
+  const env = options.env || process.env;
+  if (!args.profile || !String(args.profile).trim()) {
+    const error = new Error('Missing required option: --profile <name>');
+    error.code = 'PROFILE_REQUIRED';
+    throw error;
+  }
+
+  const profiles = loadProfiles({ cwd, env, args });
+  const profile = resolveProfile(profiles, args.profile, { env });
+  const fetchConfig = resolveFetchConfig(args, { cwd, env });
+  const workCopyConfig = readWorkCopyConfig(profile, env);
+  const sourceRoot = path.resolve(cwd, options.sourceRoot || fetchConfig.out);
+  const targetRoot = path.resolve(cwd, options.targetRoot || workCopyConfig.root);
+  const workCopyMode = String(options.workCopyMode || workCopyConfig.extension).trim().toLowerCase();
+
+  if (!fs.existsSync(sourceRoot)) {
+    const error = new Error(`Fetch output directory not found: ${sourceRoot}`);
+    error.code = 'FETCH_OUTPUT_MISSING';
+    throw error;
+  }
+
+  return {
+    sourceRoot,
+    targetRoot,
+    workCopyMode,
+    result: copyFetchedSourcesToWorkspace({
+      sourceRoot,
+      targetRoot,
+      workCopyMode,
+      force: options.force !== undefined ? Boolean(options.force) : Boolean(args.force),
+      members: options.members || parseMembersCsv(args.members),
+    }),
+  };
+}
+
+module.exports = {
+  executeCopyToWorkspace,
+};

--- a/src/workflow/workflowRunner.js
+++ b/src/workflow/workflowRunner.js
@@ -1,0 +1,277 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+const {
+  DEFAULT_EXTENSIONS,
+  DEFAULT_WORKFLOW_ANALYZE_MODES,
+  DEFAULT_WORKFLOW_STEPS,
+  loadProfiles,
+  readWorkflowConfig,
+  resolveFetchConfig,
+  resolveProfile,
+  resolveWorkflowPresetConfig,
+} = require('../config/runtimeConfig');
+const { workflowStepHandlers, WORKFLOW_STEP_ORDER, summarizeError } = require('./workflowSteps');
+
+function buildRunId(now = new Date()) {
+  const iso = now.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+  return iso.replace('T', 'T');
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function parseMembersArg(value) {
+  if (value === undefined || value === null || value === true) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => String(entry).trim().toUpperCase()).filter(Boolean);
+  }
+  return String(value)
+    .split(',')
+    .map((entry) => entry.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+function normalizeWorkflowPlan({ workflowConfig, preset, args, fetchConfig }) {
+  const requestedSteps = preset && preset.steps.length > 0
+    ? preset.steps
+    : [...DEFAULT_WORKFLOW_STEPS];
+  const included = new Set(requestedSteps);
+  if (!preset && Array.isArray(workflowConfig.impact) && workflowConfig.impact.length > 0) {
+    included.add('impact');
+  }
+  if (!preset && Array.isArray(workflowConfig.tables) && workflowConfig.tables.length > 0) {
+    included.add('query-table');
+  }
+
+  return {
+    presetName: preset ? preset.name : '',
+    steps: WORKFLOW_STEP_ORDER.filter((step) => included.has(step)),
+    analyzeModes: preset && preset.analyzeModes.length > 0
+      ? preset.analyzeModes
+      : (workflowConfig.analyzeModes.length > 0 ? workflowConfig.analyzeModes : [...DEFAULT_WORKFLOW_ANALYZE_MODES]),
+    members: parseMembersArg(args.members).length > 0
+      ? parseMembersArg(args.members)
+      : (preset && preset.members.length > 0 ? preset.members : workflowConfig.members),
+    tables: preset && preset.tables.length > 0 ? preset.tables : workflowConfig.tables,
+    impact: preset && preset.impact.length > 0 ? preset.impact : workflowConfig.impact,
+    continueOnError: Boolean(args['continue-on-error']) || Boolean((preset && preset.continueOnError) || workflowConfig.continueOnError),
+    fetchConfigured: Boolean(fetchConfig && fetchConfig.host && fetchConfig.user && fetchConfig.password),
+  };
+}
+
+function createWorkflowPaths(cwd, baseOutputRoot, runId) {
+  const runRoot = path.resolve(cwd, baseOutputRoot, 'runs', runId);
+  return {
+    baseOutputRoot: path.resolve(cwd, baseOutputRoot),
+    runRoot,
+    fetchRoot: path.join(runRoot, 'fetch'),
+    workspaceRoot: path.join(runRoot, 'workspace'),
+    analyzeRoot: path.join(runRoot, 'analyze'),
+    dbRoot: path.join(runRoot, 'db'),
+    reportPath: path.join(runRoot, 'report.md'),
+    contextPath: path.join(runRoot, 'context.json'),
+    logPath: path.join(runRoot, 'workflow-log.json'),
+  };
+}
+
+function buildInitialState({ args, cwd, env, profiles, profileName, profile, workflowConfig, plan, fetchConfig, runId, paths }) {
+  return {
+    args,
+    cwd,
+    env,
+    profiles,
+    profileName,
+    profile,
+    workflowConfig,
+    plan,
+    fetchConfig,
+    runId,
+    paths,
+    runtime: {
+      fetchRoot: paths.fetchRoot,
+      workspaceRoot: paths.workspaceRoot,
+      analyzeExtensions: Array.from(new Set([...(profile.extensions || DEFAULT_EXTENSIONS), '.txt', '.work'])),
+      primaryAnalyzeMode: '',
+      analyzeSourceRoot: '',
+    },
+    status: 'running',
+    results: {},
+    stepResults: [],
+    log: [],
+    startedAt: new Date().toISOString(),
+    completedAt: null,
+  };
+}
+
+function writeWorkflowState(state) {
+  writeJson(state.paths.contextPath, {
+    runId: state.runId,
+    profile: state.profileName,
+    preset: state.plan.presetName || null,
+    status: state.status,
+    startedAt: state.startedAt,
+    completedAt: state.completedAt,
+    plan: state.plan,
+    paths: state.paths,
+    steps: state.stepResults,
+    results: state.results,
+  });
+  writeJson(state.paths.logPath, state.log);
+}
+
+function logWorkflowEvent(state, event) {
+  state.log.push({
+    at: new Date().toISOString(),
+    ...event,
+  });
+}
+
+async function runWorkflowEngine(args, { cwd = process.cwd(), env = process.env } = {}) {
+  if (!args.profile || !String(args.profile).trim()) {
+    const error = new Error('Missing required option: --profile <name>');
+    error.code = 'PROFILE_REQUIRED';
+    throw error;
+  }
+
+  const profiles = loadProfiles({ cwd, env, args });
+  const profile = resolveProfile(profiles, args.profile, { env });
+  const workflowConfig = readWorkflowConfig(profiles, profile, env);
+  const presetName = args.preset || workflowConfig.defaultPreset || '';
+  const preset = presetName ? resolveWorkflowPresetConfig(profiles, profile, presetName, env) : null;
+  const fetchConfig = resolveFetchConfig({
+    ...args,
+    out: path.join(args.out || workflowConfig.outputRoot || profile.outputRoot || 'analysis', 'runs', 'placeholder'),
+  }, { cwd, env });
+  const plan = normalizeWorkflowPlan({
+    workflowConfig,
+    preset,
+    args,
+    fetchConfig,
+  });
+  const runId = buildRunId();
+  const paths = createWorkflowPaths(cwd, args.out || workflowConfig.outputRoot || profile.outputRoot || 'analysis', runId);
+
+  ensureDir(paths.runRoot);
+  ensureDir(paths.fetchRoot);
+  ensureDir(paths.workspaceRoot);
+  ensureDir(paths.analyzeRoot);
+  ensureDir(paths.dbRoot);
+
+  const state = buildInitialState({
+    args,
+    cwd,
+    env,
+    profiles,
+    profileName: args.profile,
+    profile,
+    workflowConfig,
+    plan,
+    fetchConfig: resolveFetchConfig({
+      ...args,
+      out: paths.fetchRoot,
+    }, { cwd, env }),
+    runId,
+    paths,
+  });
+  writeWorkflowState(state);
+
+  for (const stepName of plan.steps) {
+    const handler = workflowStepHandlers[stepName];
+    if (typeof handler !== 'function') {
+      throw new Error(`Workflow step "${stepName}" is not implemented.`);
+    }
+
+    const started = Date.now();
+    logWorkflowEvent(state, {
+      type: 'step-start',
+      step: stepName,
+    });
+    console.log(`[workflow] start ${stepName}`);
+
+    try {
+      const stepResult = await handler(state);
+      const durationMs = Date.now() - started;
+      const entry = {
+        name: stepName,
+        status: stepResult.status,
+        note: stepResult.note || '',
+        durationMs,
+      };
+      state.stepResults.push(entry);
+      state.results[stepName] = stepResult.data || {};
+      logWorkflowEvent(state, {
+        type: 'step-end',
+        step: stepName,
+        status: stepResult.status,
+        durationMs,
+      });
+      writeWorkflowState(state);
+      console.log(`[workflow] ${stepResult.status} ${stepName} (${durationMs} ms)`);
+
+      if (stepResult.status === 'failed' && !plan.continueOnError && stepName !== 'report') {
+        state.status = 'failed';
+        state.completedAt = new Date().toISOString();
+        writeWorkflowState(state);
+        return state;
+      }
+    } catch (error) {
+      const durationMs = Date.now() - started;
+      const summary = summarizeError(error);
+      state.stepResults.push({
+        name: stepName,
+        status: 'failed',
+        note: summary.message,
+        durationMs,
+      });
+      state.results[stepName] = {
+        error: summary,
+        partial: error.workflowPartial || null,
+      };
+      logWorkflowEvent(state, {
+        type: 'step-error',
+        step: stepName,
+        durationMs,
+        error: summary,
+      });
+      writeWorkflowState(state);
+      console.log(`[workflow] failed ${stepName} (${durationMs} ms)`);
+      if (!plan.continueOnError) {
+        state.status = 'failed';
+        state.completedAt = new Date().toISOString();
+        writeWorkflowState(state);
+        return state;
+      }
+    }
+  }
+
+  state.status = state.stepResults.some((entry) => entry.status === 'failed') ? 'failed' : 'succeeded';
+  state.completedAt = new Date().toISOString();
+  writeWorkflowState(state);
+  return state;
+}
+
+module.exports = {
+  buildRunId,
+  createWorkflowPaths,
+  runWorkflowEngine,
+};

--- a/src/workflow/workflowSteps.js
+++ b/src/workflow/workflowSteps.js
@@ -1,0 +1,462 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+const { collectSourceFiles } = require('../collector/sourceCollector');
+const { buildSourceCatalog } = require('../source/sourceCatalog');
+const { executeFetch, findMissingFetchFields } = require('../core/fetchService');
+const { executeCopyToWorkspace } = require('../core/workCopyService');
+const { executeAnalyze } = require('../core/analyzeService');
+const { executeImpact } = require('../core/impactService');
+const { executeQueryTable } = require('../core/queryService');
+const { resolveFetchConfig } = require('../config/runtimeConfig');
+
+const WORKFLOW_STEP_ORDER = Object.freeze(['fetch', 'copy', 'analyze', 'impact', 'query-table', 'report']);
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function sanitizeFilePart(value) {
+  return String(value || '')
+    .trim()
+    .replace(/[^A-Z0-9._-]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+    || 'entry';
+}
+
+function directoryHasFiles(rootDir) {
+  if (!rootDir || !fs.existsSync(rootDir)) {
+    return false;
+  }
+  const pending = [rootDir];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.isFile()) {
+        return true;
+      }
+      if (entry.isDirectory()) {
+        pending.push(path.join(current, entry.name));
+      }
+    }
+  }
+  return false;
+}
+
+function summarizeError(error) {
+  return {
+    message: String(error && error.message ? error.message : error || 'Unknown error'),
+    code: error && error.code ? String(error.code) : '',
+  };
+}
+
+function resolveAnalyzeSourceRoot(state) {
+  if (state.runtime.workspaceRoot && directoryHasFiles(state.runtime.workspaceRoot)) {
+    return state.runtime.workspaceRoot;
+  }
+  if (state.runtime.fetchRoot && directoryHasFiles(state.runtime.fetchRoot)) {
+    return state.runtime.fetchRoot;
+  }
+  if (state.profile && state.profile.sourceRoot) {
+    return path.resolve(state.cwd, state.profile.sourceRoot);
+  }
+  return '';
+}
+
+function discoverMembersForSourceRoot(sourceRoot, extensions) {
+  if (!sourceRoot || !fs.existsSync(sourceRoot)) {
+    return [];
+  }
+  const sourceFiles = collectSourceFiles(sourceRoot, extensions);
+  const catalog = buildSourceCatalog({
+    sourceRoot,
+    sourceFiles,
+  });
+  return Array.from(catalog.byMemberName.keys()).sort((a, b) => a.localeCompare(b));
+}
+
+function resolveWorkflowMembers(state, sourceRoot) {
+  const configuredMembers = state.plan.members && state.plan.members.length > 0
+    ? state.plan.members
+    : [];
+  if (configuredMembers.length > 0) {
+    return configuredMembers;
+  }
+  const fetchMembers = state.fetchConfig && Array.isArray(state.fetchConfig.members) && state.fetchConfig.members.length > 0
+    ? state.fetchConfig.members
+    : [];
+  if (fetchMembers.length > 0) {
+    return fetchMembers;
+  }
+  return discoverMembersForSourceRoot(sourceRoot, state.runtime.analyzeExtensions);
+}
+
+function buildWorkflowReport(state) {
+  const stepLines = state.stepResults.map((step) => `- ${step.name}: ${step.status} (${step.durationMs} ms)${step.note ? ` — ${step.note}` : ''}`).join('\n');
+  const analyzeEntries = Array.isArray(state.results.analyze && state.results.analyze.entries)
+    ? state.results.analyze.entries
+    : [];
+  const impactEntries = Array.isArray(state.results.impact && state.results.impact.entries)
+    ? state.results.impact.entries
+    : [];
+  const queryEntries = Array.isArray(state.results['query-table'] && state.results['query-table'].entries)
+    ? state.results['query-table'].entries
+    : [];
+
+  return `# Zeus Workflow Report
+
+## Run
+- Run ID: ${state.runId}
+- Profile: ${state.profileName}
+- Preset: ${state.plan.presetName || 'none'}
+- Status: ${state.status}
+- Run Root: ${state.paths.runRoot}
+
+## Steps
+${stepLines || '- none'}
+
+## Analyze
+${analyzeEntries.length === 0
+    ? '- No analyze entries.'
+    : analyzeEntries.map((entry) => `- ${entry.member} [${entry.mode}] -> ${entry.outputProgramDir}`).join('\n')}
+
+## Impact
+${impactEntries.length === 0
+    ? '- No impact entries.'
+    : impactEntries.map((entry) => `- ${entry.target} -> ${entry.outputProgramDir}`).join('\n')}
+
+## DB
+${queryEntries.length === 0
+    ? '- No DB catalog queries.'
+    : queryEntries.map((entry) => `- ${entry.tableLookup} -> ${entry.outputPath}`).join('\n')}
+
+## Paths
+- Fetch: ${state.paths.fetchRoot}
+- Workspace: ${state.paths.workspaceRoot}
+- Analyze: ${state.paths.analyzeRoot}
+- DB: ${state.paths.dbRoot}
+- Context: ${state.paths.contextPath}
+`;
+}
+
+async function runFetchStep(state) {
+  const missing = findMissingFetchFields(state.fetchConfig);
+  if (missing.length > 0) {
+    return {
+      status: 'skipped',
+      note: `Fetch configuration incomplete: ${missing.join(', ')}`,
+      data: {
+        missing,
+      },
+    };
+  }
+
+  ensureDir(state.paths.fetchRoot);
+  const execution = await executeFetch({
+    ...state.args,
+    profile: state.profileName,
+    out: state.paths.fetchRoot,
+  }, {
+    cwd: state.cwd,
+    env: state.env,
+  });
+  state.runtime.fetchRoot = execution.summary.localDestination;
+
+  return {
+    status: 'passed',
+    note: `Downloaded ${execution.summary.downloadedCount} file(s)`,
+    data: execution,
+  };
+}
+
+async function runCopyStep(state) {
+  const sourceRoot = fs.existsSync(state.paths.fetchRoot)
+    ? state.paths.fetchRoot
+    : path.resolve(state.cwd, state.fetchConfig.out);
+
+  if (!sourceRoot || !fs.existsSync(sourceRoot)) {
+    return {
+      status: 'skipped',
+      note: `Copy source not found: ${sourceRoot || 'n/a'}`,
+      data: {
+        sourceRoot,
+      },
+    };
+  }
+
+  ensureDir(state.paths.workspaceRoot);
+  const execution = executeCopyToWorkspace({
+    ...state.args,
+    profile: state.profileName,
+  }, {
+    cwd: state.cwd,
+    env: state.env,
+    sourceRoot,
+    targetRoot: state.paths.workspaceRoot,
+    workCopyMode: 'original',
+    force: true,
+  });
+  state.runtime.workspaceRoot = execution.targetRoot;
+
+  return {
+    status: execution.result.errorCount > 0 ? 'failed' : 'passed',
+    note: `Copied ${execution.result.copiedCount} member(s)`,
+    data: execution,
+  };
+}
+
+async function runAnalyzeStep(state) {
+  const sourceRoot = resolveAnalyzeSourceRoot(state);
+  if (!sourceRoot || !fs.existsSync(sourceRoot)) {
+    return {
+      status: 'skipped',
+      note: 'No analyze source root available.',
+      data: {
+        sourceRoot,
+      },
+    };
+  }
+
+  const members = resolveWorkflowMembers(state, sourceRoot);
+  if (members.length === 0) {
+    return {
+      status: 'skipped',
+      note: 'No members resolved for analysis.',
+      data: {
+        sourceRoot,
+        members,
+      },
+    };
+  }
+
+  const entries = [];
+  const errors = [];
+
+  for (const mode of state.plan.analyzeModes) {
+    const modeOutputRoot = path.join(state.paths.analyzeRoot, sanitizeFilePart(mode));
+    ensureDir(modeOutputRoot);
+
+    for (const member of members) {
+      try {
+        const execution = executeAnalyze({
+          ...state.args,
+          profile: state.profileName,
+          source: sourceRoot,
+          out: modeOutputRoot,
+          member,
+          mode,
+        }, {
+          cwd: state.cwd,
+        });
+        entries.push({
+          member,
+          mode,
+          program: execution.program,
+          outputProgramDir: execution.outputProgramDir,
+          manifestStatus: execution.analyzeManifest && execution.analyzeManifest.run
+            ? execution.analyzeManifest.run.status
+            : 'succeeded',
+        });
+      } catch (error) {
+        const summary = summarizeError(error);
+        errors.push({
+          member,
+          mode,
+          ...summary,
+        });
+        if (!state.plan.continueOnError) {
+          error.workflowPartial = {
+            entries,
+            errors,
+          };
+          throw error;
+        }
+      }
+    }
+  }
+
+  state.runtime.analyzeSourceRoot = sourceRoot;
+  state.runtime.primaryAnalyzeMode = sanitizeFilePart(state.plan.analyzeModes[0] || 'documentation');
+
+  return {
+    status: errors.length > 0 ? 'failed' : 'passed',
+    note: `Analyze runs: ${entries.length}, errors: ${errors.length}`,
+    data: {
+      sourceRoot,
+      members,
+      analyzeModes: [...state.plan.analyzeModes],
+      entries,
+      errors,
+    },
+  };
+}
+
+async function runImpactStep(state) {
+  const configured = Array.isArray(state.plan.impact) ? state.plan.impact : [];
+  if (configured.length === 0) {
+    return {
+      status: 'skipped',
+      note: 'No impact targets configured.',
+      data: {
+        entries: [],
+      },
+    };
+  }
+
+  const outputRoot = path.join(state.paths.analyzeRoot, state.runtime.primaryAnalyzeMode || 'documentation');
+  if (!fs.existsSync(outputRoot)) {
+    return {
+      status: 'skipped',
+      note: `Analyze output not found for impact: ${outputRoot}`,
+      data: {
+        entries: [],
+      },
+    };
+  }
+
+  const entries = [];
+  const errors = [];
+
+  for (const definition of configured) {
+    try {
+      const execution = executeImpact({
+        ...state.args,
+        profile: state.profileName,
+        source: state.runtime.analyzeSourceRoot,
+        out: outputRoot,
+        target: definition.target || definition.field,
+        field: definition.field || definition.target,
+        program: definition.program,
+        member: definition.member,
+      }, {
+        cwd: state.cwd,
+      });
+      entries.push({
+        target: execution.target,
+        program: execution.program,
+        outputProgramDir: execution.outputProgramDir,
+      });
+    } catch (error) {
+      errors.push({
+        target: definition.target || definition.field,
+        ...summarizeError(error),
+      });
+      if (!state.plan.continueOnError) {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    status: errors.length > 0 ? 'failed' : 'passed',
+    note: `Impact runs: ${entries.length}, errors: ${errors.length}`,
+    data: {
+      entries,
+      errors,
+    },
+  };
+}
+
+async function runQueryTableStep(state) {
+  const definitions = Array.isArray(state.plan.tables) ? state.plan.tables : [];
+  if (definitions.length === 0) {
+    return {
+      status: 'skipped',
+      note: 'No tables configured.',
+      data: {
+        entries: [],
+      },
+    };
+  }
+
+  ensureDir(state.paths.dbRoot);
+  const entries = [];
+  const errors = [];
+
+  for (const definition of definitions) {
+    try {
+      const execution = executeQueryTable({
+        ...state.args,
+        profile: state.profileName,
+        table: definition.table,
+        schema: definition.schema || undefined,
+        filter: definition.filter || undefined,
+      }, {
+        cwd: state.cwd,
+      });
+      const baseName = sanitizeFilePart(`${execution.schema || 'AUTO'}-${execution.table}`);
+      const outputPath = path.join(state.paths.dbRoot, `${baseName}.json`);
+      fs.writeFileSync(outputPath, `${JSON.stringify({
+        table: execution.table,
+        schema: execution.schema,
+        requestedSchema: execution.requestedSchema,
+        filter: execution.filter,
+        tableInfo: execution.tableInfo.rows || [],
+        columns: execution.columns.rows || [],
+      }, null, 2)}\n`, 'utf8');
+      entries.push({
+        tableLookup: execution.schema ? `${execution.schema}.${execution.table}` : execution.table,
+        rowCount: (execution.columns.rows || []).length,
+        outputPath,
+      });
+    } catch (error) {
+      errors.push({
+        table: definition.table,
+        ...summarizeError(error),
+      });
+      if (!state.plan.continueOnError) {
+        throw error;
+      }
+    }
+  }
+
+  return {
+    status: errors.length > 0 ? 'failed' : 'passed',
+    note: `DB queries: ${entries.length}, errors: ${errors.length}`,
+    data: {
+      entries,
+      errors,
+    },
+  };
+}
+
+async function runReportStep(state) {
+  const content = buildWorkflowReport(state);
+  fs.writeFileSync(state.paths.reportPath, content, 'utf8');
+  return {
+    status: 'passed',
+    note: `Report written to ${state.paths.reportPath}`,
+    data: {
+      reportPath: state.paths.reportPath,
+    },
+  };
+}
+
+const workflowStepHandlers = Object.freeze({
+  fetch: runFetchStep,
+  copy: runCopyStep,
+  analyze: runAnalyzeStep,
+  impact: runImpactStep,
+  'query-table': runQueryTableStep,
+  report: runReportStep,
+});
+
+module.exports = {
+  WORKFLOW_STEP_ORDER,
+  buildWorkflowReport,
+  discoverMembersForSourceRoot,
+  summarizeError,
+  workflowStepHandlers,
+};

--- a/tests/runtime-config.test.js
+++ b/tests/runtime-config.test.js
@@ -11,12 +11,14 @@ const {
   getProfilesMetadata,
   loadProfiles,
   readTokenBudgetConfig,
+  readWorkflowConfig,
   readWorkCopyConfig,
   resolveAnalyzeConfig,
   resolveProfile,
   resolveProfilesConfigPaths,
   resolveFetchConfig,
   resolveBundleConfig,
+  resolveWorkflowPresetConfig,
 } = require('../src/config/runtimeConfig');
 
 function createTempProject(profiles) {
@@ -228,6 +230,67 @@ test('resolveAnalyzeConfig exposes profile token budgets and work-copy defaults'
 
 test('readWorkCopyConfig falls back to project defaults', () => {
   assert.deepEqual(readWorkCopyConfig(null, {}), DEFAULT_WORK_COPY);
+});
+
+test('readWorkflowConfig merges global, profile, and workflow preset definitions', () => {
+  const tempRoot = createTempProject({
+    presets: {
+      shared: {
+        steps: ['analyze', 'report'],
+        analyzeModes: ['documentation'],
+      },
+    },
+    sample: {
+      sourceRoot: './src',
+      presets: {
+        local: {
+          steps: ['copy', 'analyze', 'report'],
+          members: ['ORDERPGM'],
+        },
+      },
+      workflow: {
+        outputRoot: './analysis',
+        defaultPreset: 'local',
+        analyzeModes: ['documentation', 'defect-analysis'],
+        tables: [{
+          table: 'ORDERS',
+          schema: 'APP',
+        }],
+        presets: {
+          local: {
+            steps: ['fetch', 'copy', 'analyze', 'report'],
+            impact: [{
+              field: 'CUSTOMER_ID',
+              member: 'ORDERPGM',
+            }],
+          },
+        },
+      },
+    },
+  });
+
+  try {
+    const profiles = loadProfiles({ cwd: tempRoot });
+    const profile = resolveProfile(profiles, 'sample', { env: {} });
+    const workflowConfig = readWorkflowConfig(profiles, profile, {});
+    const preset = resolveWorkflowPresetConfig(profiles, profile, 'local', {});
+
+    assert.equal(workflowConfig.outputRoot, './analysis');
+    assert.equal(workflowConfig.defaultPreset, 'local');
+    assert.deepEqual(workflowConfig.analyzeModes, ['documentation', 'defect-analysis']);
+    assert.deepEqual(workflowConfig.tables, [{
+      table: 'ORDERS',
+      schema: 'APP',
+      filter: '',
+    }]);
+    assert.deepEqual(Object.keys(workflowConfig.presets).sort(), ['local', 'shared']);
+    assert.deepEqual(preset.steps, ['fetch', 'copy', 'analyze', 'report']);
+    assert.deepEqual(preset.members, ['ORDERPGM']);
+    assert.equal(preset.impact[0].field, 'CUSTOMER_ID');
+    assert.equal(preset.impact[0].member, 'ORDERPGM');
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test('resolveAnalyzeConfig applies environment overrides for DB credentials', () => {

--- a/tests/workflow-runner.test.js
+++ b/tests/workflow-runner.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { runWorkflowEngine } = require('../src/workflow/workflowRunner');
+
+const fixtureRoot = path.join(__dirname, 'fixtures', 'v1-smoke', 'src');
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+test('runWorkflowEngine writes a standardized run directory with context and report', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-workflow-runner-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const configRoot = path.join(tempRoot, 'config');
+
+  fs.cpSync(fixtureRoot, sourceRoot, { recursive: true });
+  fs.mkdirSync(configRoot, { recursive: true });
+  fs.writeFileSync(path.join(configRoot, 'profiles.json'), `${JSON.stringify({
+    local: {
+      sourceRoot: './src',
+      outputRoot: './output',
+      extensions: ['.rpgle', '.clle', '.dds', '.pf', '.lf'],
+      workflow: {
+        outputRoot: './analysis',
+        defaultPreset: 'legacy-rpg-analysis',
+        analyzeModes: ['documentation'],
+        members: ['ORDERPGM'],
+        presets: {
+          'legacy-rpg-analysis': {
+            steps: ['analyze', 'report'],
+          },
+        },
+      },
+    },
+  }, null, 2)}\n`, 'utf8');
+
+  try {
+    const state = await runWorkflowEngine({
+      profile: 'local',
+      preset: 'legacy-rpg-analysis',
+    }, {
+      cwd: tempRoot,
+      env: {},
+    });
+
+    assert.equal(state.status, 'succeeded');
+    assert.equal(fs.existsSync(state.paths.contextPath), true);
+    assert.equal(fs.existsSync(state.paths.reportPath), true);
+    assert.equal(fs.existsSync(path.join(state.paths.analyzeRoot, 'documentation', 'ORDERPGM', 'context.json')), true);
+
+    const context = readJson(state.paths.contextPath);
+    assert.equal(context.profile, 'local');
+    assert.equal(context.preset, 'legacy-rpg-analysis');
+    assert.equal(context.status, 'succeeded');
+    assert.equal(context.steps.some((entry) => entry.name === 'analyze' && entry.status === 'passed'), true);
+    assert.equal(context.results.analyze.entries[0].member, 'ORDERPGM');
+
+    const report = fs.readFileSync(state.paths.reportPath, 'utf8');
+    assert.match(report, /Zeus Workflow Report/);
+    assert.match(report, /ORDERPGM/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/zeus-api.test.js
+++ b/tests/zeus-api.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { analyze, runWorkflow } = require('../src/api/zeusApi');
+
+const fixtureRoot = path.join(__dirname, 'fixtures', 'v1-smoke', 'src');
+
+test('zeusApi exposes reusable analyze and workflow entry points', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-api-'));
+  const sourceRoot = path.join(tempRoot, 'src');
+  const configRoot = path.join(tempRoot, 'config');
+
+  fs.cpSync(fixtureRoot, sourceRoot, { recursive: true });
+  fs.mkdirSync(configRoot, { recursive: true });
+  fs.writeFileSync(path.join(configRoot, 'profiles.json'), `${JSON.stringify({
+    local: {
+      sourceRoot: './src',
+      outputRoot: './output',
+      extensions: ['.rpgle', '.clle', '.dds', '.pf', '.lf'],
+      workflow: {
+        outputRoot: './analysis',
+        defaultPreset: 'legacy-rpg-analysis',
+        members: ['ORDERPGM'],
+        analyzeModes: ['documentation'],
+        presets: {
+          'legacy-rpg-analysis': {
+            steps: ['analyze', 'report'],
+          },
+        },
+      },
+    },
+  }, null, 2)}\n`, 'utf8');
+
+  try {
+    const analyzeResult = analyze('local', {
+      member: 'ORDERPGM',
+      mode: 'documentation',
+      runtime: {
+        cwd: tempRoot,
+        env: {},
+      },
+    });
+    assert.equal(analyzeResult.program, 'ORDERPGM');
+    assert.equal(fs.existsSync(path.join(analyzeResult.outputProgramDir, 'context.json')), true);
+
+    const workflowResult = await runWorkflow('local', 'legacy-rpg-analysis', {
+      runtime: {
+        cwd: tempRoot,
+        env: {},
+      },
+    });
+    assert.equal(workflowResult.status, 'succeeded');
+    assert.equal(fs.existsSync(workflowResult.paths.reportPath), true);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a reusable workflow engine with zeus workflow run and per-run output folders
- extract fetch/analyze/impact/query/copy logic into reusable core services and add src/api/zeusApi.js
- extend runtime profile config with workflow presets and add tests for workflow runs and API reuse

## Testing
- 
ode --test tests\\runtime-config.test.js tests\\query-sql-command.test.js tests\\query-table-command.test.js tests\\workflow-runner.test.js tests\\zeus-api.test.js tests\\workflow-presets.test.js tests\\work-copy-service.test.js tests\\doctor-command.test.js tests\\read-only-query-service.test.js tests\\member-resolver.test.js
