### PR TITLE
feat: add explorer service integration and doctor config checks

### DIFF
--- a/config/profiles.example.json
+++ b/config/profiles.example.json
@@ -39,6 +39,24 @@
       "password": "${env:ZEUS_DB_PASSWORD}",
       "defaultLibrary": "${env:ZEUS_DB_DEFAULT_LIBRARY}",
       "defaultSchema": "${env:ZEUS_DB_DEFAULT_SCHEMA}"
+    },
+    "dbRoles": {
+      "metadata": {
+        "host": "${env:ZEUS_METADATA_DB_HOST}",
+        "url": "${env:ZEUS_METADATA_DB_URL}",
+        "user": "${env:ZEUS_METADATA_DB_USER}",
+        "password": "${env:ZEUS_METADATA_DB_PASSWORD}",
+        "defaultLibrary": "${env:ZEUS_METADATA_DB_DEFAULT_LIBRARY}",
+        "defaultSchema": "${env:ZEUS_METADATA_DB_DEFAULT_SCHEMA}"
+      },
+      "testData": {
+        "host": "${env:ZEUS_TESTDATA_DB_HOST}",
+        "url": "${env:ZEUS_TESTDATA_DB_URL}",
+        "user": "${env:ZEUS_TESTDATA_DB_USER}",
+        "password": "${env:ZEUS_TESTDATA_DB_PASSWORD}",
+        "defaultLibrary": "${env:ZEUS_TESTDATA_DB_DEFAULT_LIBRARY}",
+        "defaultSchema": "${env:ZEUS_TESTDATA_DB_DEFAULT_SCHEMA}"
+      }
     }
   },
   "default-fetch": {
@@ -110,6 +128,20 @@
       "user": "MYUSER",
       "password": "MYPASSWORD",
       "defaultSchema": "MYLIB"
+    },
+    "dbRoles": {
+      "metadata": {
+        "host": "catalog.myibmi.example.com",
+        "user": "METAUSER",
+        "password": "METAPASSWORD",
+        "defaultSchema": "MYLIB"
+      },
+      "testData": {
+        "host": "testdata.myibmi.example.com",
+        "user": "TESTUSER",
+        "password": "TESTPASSWORD",
+        "defaultSchema": "MYLIB"
+      }
     },
     "testData": {
       "limit": 50,

--- a/src/analyze/analyzePipeline.js
+++ b/src/analyze/analyzePipeline.js
@@ -38,6 +38,7 @@ const { validateSourceFiles } = require('../source/sourceIntegrity');
 const { scanIfsPaths } = require('../investigation/ifsPathScanner');
 const { runFullTextSearch } = require('../investigation/fullTextSearch');
 const { runDiagnosticPacks } = require('../investigation/diagnosticPackRunner');
+const { resolveAnalyzeDbConfig } = require('../config/runtimeConfig');
 const {
   ANALYSIS_ARTIFACT_CACHE_FILE,
   buildDb2MetadataCacheKey,
@@ -513,11 +514,12 @@ function exportDb2Stage(state) {
   const currentDb2Cache = mergeObject(currentCacheStatus.db2Metadata, {});
   const currentDb2Hits = Number(currentDb2Cache.hits) || 0;
   const currentDb2Misses = Number(currentDb2Cache.misses) || 0;
+  const metadataDbConfig = resolveAnalyzeDbConfig(config, 'metadata');
   const cacheKey = outputProgramDir
     ? buildDb2MetadataCacheKey({
       program,
       dependencies: context.dependencies,
-      dbConfig: config.db,
+      dbConfig: metadataDbConfig,
     })
     : null;
   const cachedArtifact = cacheKey && outputProgramDir
@@ -556,7 +558,7 @@ function exportDb2Stage(state) {
     db2Export = exportDb2Metadata({
       program,
       dependencies: context.dependencies,
-      dbConfig: config.db,
+      dbConfig: metadataDbConfig,
       outputDir: outputProgramDir,
       verbose,
       canonicalAnalysis,
@@ -619,6 +621,7 @@ function exportDb2Stage(state) {
     db2Export,
     stageMetadata: {
       ...db2Export.summary,
+      connectionRole: 'metadata',
       cache: db2CacheMetadata,
     },
     stageDiagnostics: [
@@ -655,6 +658,7 @@ function exportTestDataStage(state) {
   const currentTestDataCache = mergeObject(currentCacheStatus.testData, {});
   const currentTestDataHits = Number(currentTestDataCache.hits) || 0;
   const currentTestDataMisses = Number(currentTestDataCache.misses) || 0;
+  const testDataDbConfig = resolveAnalyzeDbConfig(config, 'testData');
   const testDataConfig = {
     ...config.testData,
     limit: testDataLimit,
@@ -663,7 +667,7 @@ function exportTestDataStage(state) {
     ? buildTestDataCacheKey({
       program,
       metadataPayload: db2Export && db2Export.payload ? db2Export.payload : null,
-      dbConfig: config.db,
+      dbConfig: testDataDbConfig,
       testDataConfig,
     })
     : null;
@@ -698,7 +702,7 @@ function exportTestDataStage(state) {
     testDataExport = exportTestData({
       program,
       dependencies: context.dependencies,
-      dbConfig: config.db,
+      dbConfig: testDataDbConfig,
       outputDir: outputProgramDir,
       metadataPayload: db2Export ? db2Export.payload : null,
       canonicalAnalysis,
@@ -762,6 +766,7 @@ function exportTestDataStage(state) {
     testDataExport,
     stageMetadata: {
       ...testDataExport.summary,
+      connectionRole: 'testData',
       cache: testDataCacheMetadata,
     },
     stageDiagnostics: (testDataExport.notes || []).map((message) => ({
@@ -787,7 +792,7 @@ function runDiagnosticPacksStage(state) {
   const diagnosticResult = runDiagnosticPacks({
     packNames: diagnosticPacks,
     parameterString: diagnosticParameterString,
-    dbConfig: config.db,
+    dbConfig: resolveAnalyzeDbConfig(config, 'metadata'),
     ibmiConfig,
     reproducibility,
     verbose,

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -15,6 +15,12 @@ const { runWorkflowEngine } = require('../workflow/workflowRunner');
 const { executeFetch } = require('../core/fetchService');
 const { executeAnalyze } = require('../core/analyzeService');
 const { executeQueryTable } = require('../core/queryService');
+const {
+  executeListRuns,
+  executeReadArtifact,
+  executeReadRun,
+  executeReadRunViews,
+} = require('../core/runExplorerService');
 
 async function runWorkflow(profile, preset, options = {}) {
   const { runtime = {}, ...args } = options;
@@ -50,9 +56,49 @@ function queryTable(profile, table, options = {}) {
   }, runtime);
 }
 
+function listRuns(profile, options = {}) {
+  const { runtime = {}, ...args } = options;
+  return executeListRuns({
+    profile,
+    ...args,
+  }, runtime);
+}
+
+function readRun(profile, program, options = {}) {
+  const { runtime = {}, ...args } = options;
+  return executeReadRun({
+    profile,
+    program,
+    ...args,
+  }, runtime);
+}
+
+function readRunViews(profile, program, options = {}) {
+  const { runtime = {}, ...args } = options;
+  return executeReadRunViews({
+    profile,
+    program,
+    ...args,
+  }, runtime);
+}
+
+function readArtifact(profile, program, artifactPath, options = {}) {
+  const { runtime = {}, ...args } = options;
+  return executeReadArtifact({
+    profile,
+    program,
+    artifactPath,
+    ...args,
+  }, runtime);
+}
+
 module.exports = {
   analyze,
   fetch,
+  listRuns,
   queryTable,
+  readArtifact,
+  readRun,
+  readRunViews,
   runWorkflow,
 };

--- a/src/cli/commands/doctorCommand.js
+++ b/src/cli/commands/doctorCommand.js
@@ -17,6 +17,7 @@ const { spawnSync } = require('child_process');
 const {
   getProfilesMetadata,
   loadProfiles,
+  resolveAnalyzeDbConfig,
   resolveAnalyzeConfig,
   resolveFetchConfig,
   resolveProfile,
@@ -88,62 +89,96 @@ function addEnvCheck(checks, { name, expected = true, envValue, fallbackValue = 
   });
 }
 
+function addDbEnvironmentChecks(checks, {
+  env,
+  envPrefix,
+  fallbackConfig,
+  requiredLabelPrefix,
+}) {
+  const usesUrl = isSet(env[`${envPrefix}_URL`]);
+  addEnvCheck(checks, {
+    name: `${envPrefix}_URL`,
+    expected: true,
+    envValue: env[`${envPrefix}_URL`],
+    fallbackValue: fallbackConfig && fallbackConfig.url,
+    required: false,
+    hint: 'jdbc:as400://mein-ibmi-host;naming=system;libraries=DATEIEN',
+  });
+  addEnvCheck(checks, {
+    name: `${envPrefix}_HOST`,
+    expected: true,
+    envValue: env[`${envPrefix}_HOST`],
+    fallbackValue: fallbackConfig && fallbackConfig.host,
+    required: !usesUrl,
+    hint: 'mein-ibmi-host',
+  });
+  addEnvCheck(checks, {
+    name: `${envPrefix}_USER`,
+    expected: true,
+    envValue: env[`${envPrefix}_USER`],
+    fallbackValue: fallbackConfig && fallbackConfig.user,
+    required: true,
+    hint: 'MEINUSER',
+  });
+  addEnvCheck(checks, {
+    name: `${envPrefix}_PASSWORD`,
+    expected: true,
+    envValue: env[`${envPrefix}_PASSWORD`],
+    fallbackValue: fallbackConfig && fallbackConfig.password,
+    required: true,
+    hint: 'mein-passwort',
+  });
+  addEnvCheck(checks, {
+    name: `${envPrefix}_DEFAULT_LIBRARY`,
+    expected: true,
+    envValue: env[`${envPrefix}_DEFAULT_LIBRARY`],
+    fallbackValue: fallbackConfig && fallbackConfig.defaultLibrary,
+    required: false,
+    hint: requiredLabelPrefix || 'DATEIEN',
+  });
+  addEnvCheck(checks, {
+    name: `${envPrefix}_DEFAULT_SCHEMA`,
+    expected: true,
+    envValue: env[`${envPrefix}_DEFAULT_SCHEMA`],
+    fallbackValue: fallbackConfig && fallbackConfig.defaultSchema,
+    required: false,
+    hint: requiredLabelPrefix || 'DATEIEN',
+  });
+}
+
 function buildEnvironmentChecks({ profile, analyzeConfig, fetchConfig, env }) {
   const checks = [];
   const profileHasDb = Boolean(profile && profile.db);
+  const profileHasMetadataDb = Boolean(profile && profile.dbRoles && profile.dbRoles.metadata);
+  const profileHasTestDataDb = Boolean(profile && profile.dbRoles && profile.dbRoles.testData);
   const profileHasFetch = Boolean(profile && profile.fetch);
-  const dbUsesUrl = isSet(env.ZEUS_DB_URL);
   const dbProfile = profile && profile.db ? profile.db : {};
   const fetchProfile = profile && profile.fetch ? profile.fetch : {};
 
   if (profileHasDb) {
-    addEnvCheck(checks, {
-      name: 'ZEUS_DB_URL',
-      expected: true,
-      envValue: env.ZEUS_DB_URL,
-      fallbackValue: dbProfile.url,
-      required: false,
-      hint: 'jdbc:as400://mein-ibmi-host;naming=system;libraries=DATEIEN',
+    addDbEnvironmentChecks(checks, {
+      env,
+      envPrefix: 'ZEUS_DB',
+      fallbackConfig: dbProfile,
+      requiredLabelPrefix: 'DATEIEN',
     });
-    addEnvCheck(checks, {
-      name: 'ZEUS_DB_HOST',
-      expected: true,
-      envValue: env.ZEUS_DB_HOST,
-      fallbackValue: dbProfile.host,
-      required: !dbUsesUrl,
-      hint: 'mein-ibmi-host',
+  }
+
+  if (profileHasMetadataDb) {
+    addDbEnvironmentChecks(checks, {
+      env,
+      envPrefix: 'ZEUS_METADATA_DB',
+      fallbackConfig: analyzeConfig && analyzeConfig.dbRoles ? analyzeConfig.dbRoles.metadata : {},
+      requiredLabelPrefix: 'DATEIEN',
     });
-    addEnvCheck(checks, {
-      name: 'ZEUS_DB_USER',
-      expected: true,
-      envValue: env.ZEUS_DB_USER,
-      fallbackValue: dbProfile.user,
-      required: true,
-      hint: 'MEINUSER',
-    });
-    addEnvCheck(checks, {
-      name: 'ZEUS_DB_PASSWORD',
-      expected: true,
-      envValue: env.ZEUS_DB_PASSWORD,
-      fallbackValue: dbProfile.password,
-      required: true,
-      hint: 'mein-passwort',
-    });
-    addEnvCheck(checks, {
-      name: 'ZEUS_DB_DEFAULT_LIBRARY',
-      expected: true,
-      envValue: env.ZEUS_DB_DEFAULT_LIBRARY,
-      fallbackValue: dbProfile.defaultLibrary,
-      required: false,
-      hint: 'DATEIEN',
-    });
-    addEnvCheck(checks, {
-      name: 'ZEUS_DB_DEFAULT_SCHEMA',
-      expected: true,
-      envValue: env.ZEUS_DB_DEFAULT_SCHEMA,
-      fallbackValue: dbProfile.defaultSchema,
-      required: false,
-      hint: 'DATEIEN',
+  }
+
+  if (profileHasTestDataDb) {
+    addDbEnvironmentChecks(checks, {
+      env,
+      envPrefix: 'ZEUS_TESTDATA_DB',
+      fallbackConfig: analyzeConfig && analyzeConfig.dbRoles ? analyzeConfig.dbRoles.testData : {},
+      requiredLabelPrefix: 'DATEIEN',
     });
   }
 
@@ -316,31 +351,71 @@ function runDoctorChecks(args, { cwd = process.cwd(), env = process.env } = {}) 
       status: 'SKIP',
       details: 'Skipped because config/profile validation already failed.',
     });
-  } else if (!isDbConfigured(resolvedAnalyzeConfig.db)) {
+  } else if (!isDbConfigured(resolveAnalyzeDbConfig(resolvedAnalyzeConfig, 'metadata'))) {
     checks.push({
-      name: 'JDBC',
+      name: 'JDBC Metadata',
       status: 'SKIP',
       details: 'DB2 credentials are not fully configured.',
     });
   } else {
     try {
+      const metadataDbConfig = resolveAnalyzeDbConfig(resolvedAnalyzeConfig, 'metadata');
       runReadOnlyDb2Query({
-        dbConfig: resolvedAnalyzeConfig.db,
+        dbConfig: metadataDbConfig,
         query: 'SELECT 1 AS HEALTHCHECK FROM SYSIBM.SYSDUMMY1',
         maxRows: 1,
       });
       checks.push({
-        name: 'JDBC',
+        name: 'JDBC Metadata',
         status: 'PASS',
-        details: `Read-only query succeeded${resolveDefaultSchema(resolvedAnalyzeConfig.db) ? ` (default schema ${resolveDefaultSchema(resolvedAnalyzeConfig.db)})` : ''}.`,
+        details: `Read-only query succeeded${resolveDefaultSchema(metadataDbConfig) ? ` (default schema ${resolveDefaultSchema(metadataDbConfig)})` : ''}.`,
       });
     } catch (error) {
       hasCriticalFailure = true;
       checks.push({
-        name: 'JDBC',
+        name: 'JDBC Metadata',
         status: 'FAIL',
         details: error.message,
       });
+    }
+  }
+
+  const hasExplicitTestDataRole = Boolean(
+    (resolvedProfile && resolvedProfile.dbRoles && resolvedProfile.dbRoles.testData)
+    || env.ZEUS_TESTDATA_DB_HOST
+    || env.ZEUS_TESTDATA_DB_URL
+    || env.ZEUS_TESTDATA_DB_USER
+    || env.ZEUS_TESTDATA_DB_PASSWORD !== undefined,
+  );
+
+  if (resolvedAnalyzeConfig && hasExplicitTestDataRole) {
+    const testDataDbConfig = resolveAnalyzeDbConfig(resolvedAnalyzeConfig, 'testData');
+    if (!isDbConfigured(testDataDbConfig)) {
+      checks.push({
+        name: 'JDBC Test Data',
+        status: 'SKIP',
+        details: 'Test-data DB2 credentials are not fully configured.',
+      });
+    } else {
+      try {
+        runReadOnlyDb2Query({
+          dbConfig: testDataDbConfig,
+          query: 'SELECT 1 AS HEALTHCHECK FROM SYSIBM.SYSDUMMY1',
+          maxRows: 1,
+        });
+        checks.push({
+          name: 'JDBC Test Data',
+          status: 'PASS',
+          details: `Read-only query succeeded${resolveDefaultSchema(testDataDbConfig) ? ` (default schema ${resolveDefaultSchema(testDataDbConfig)})` : ''}.`,
+        });
+      } catch (error) {
+        hasCriticalFailure = true;
+        checks.push({
+          name: 'JDBC Test Data',
+          status: 'FAIL',
+          details: error.message,
+        });
+      }
     }
   }
 

--- a/src/config/runtimeConfig.js
+++ b/src/config/runtimeConfig.js
@@ -184,6 +184,22 @@ function validateDbConfig(value, label) {
   assertOptionalString(value.library, `${label}.library`);
 }
 
+function validateDbRoleConfig(value, label) {
+  if (!isPlainObject(value)) {
+    failValidation(`${label} must be an object`);
+  }
+
+  for (const [key, roleConfig] of Object.entries(value)) {
+    if (key !== 'metadata' && key !== 'testData') {
+      failValidation(`${label}.${key} is not supported; valid roles are metadata and testData`);
+    }
+    if (roleConfig === undefined || roleConfig === null) {
+      continue;
+    }
+    validateDbConfig(roleConfig, `${label}.${key}`);
+  }
+}
+
 function validateFetchProfile(value, label) {
   if (!isPlainObject(value)) {
     failValidation(`${label} must be an object`);
@@ -362,6 +378,9 @@ function validateNamedProfile(profile, label) {
   if (profile.db !== undefined) {
     validateDbConfig(profile.db, `${label}.db`);
   }
+  if (profile.dbRoles !== undefined) {
+    validateDbRoleConfig(profile.dbRoles, `${label}.dbRoles`);
+  }
   if (profile.fetch !== undefined) {
     validateFetchProfile(profile.fetch, `${label}.fetch`);
   }
@@ -425,6 +444,9 @@ function validateAnalyzeConfig(config) {
   }
   if (config.db !== null && config.db !== undefined) {
     validateDbConfig(config.db, 'analyze.db');
+  }
+  if (config.dbRoles && typeof config.dbRoles === 'object') {
+    validateDbRoleConfig(config.dbRoles, 'analyze.dbRoles');
   }
 }
 
@@ -829,23 +851,83 @@ function readTestDataConfig(profiles, profile, env) {
   };
 }
 
-function applyDbEnvOverrides(dbConfig, env) {
+function applyDbEnvOverrides(dbConfig, env, prefix = 'ZEUS_DB') {
   const merged = { ...(dbConfig || {}) };
-  const schemaOverride = env.ZEUS_DB_DEFAULT_SCHEMA || env.ZEUS_DB_DEFAULT_LIBRARY || env.ZEUS_DB_SCHEMA || env.ZEUS_DB_LIBRARY;
+  const schemaOverride = env[`${prefix}_DEFAULT_SCHEMA`] || env[`${prefix}_DEFAULT_LIBRARY`] || env[`${prefix}_SCHEMA`] || env[`${prefix}_LIBRARY`];
 
-  if (env.ZEUS_DB_HOST) merged.host = env.ZEUS_DB_HOST;
-  if (env.ZEUS_DB_URL) merged.url = env.ZEUS_DB_URL;
-  if (env.ZEUS_DB_USER) merged.user = env.ZEUS_DB_USER;
-  if (env.ZEUS_DB_PASSWORD !== undefined) merged.password = env.ZEUS_DB_PASSWORD;
+  if (env[`${prefix}_HOST`]) merged.host = env[`${prefix}_HOST`];
+  if (env[`${prefix}_URL`]) merged.url = env[`${prefix}_URL`];
+  if (env[`${prefix}_USER`]) merged.user = env[`${prefix}_USER`];
+  if (env[`${prefix}_PASSWORD`] !== undefined) merged.password = env[`${prefix}_PASSWORD`];
   if (schemaOverride) merged.defaultSchema = schemaOverride;
 
   return Object.keys(merged).length > 0 ? merged : null;
+}
+
+function resolveAnalyzeDbRoleConfigs(profile, env) {
+  const baseDbConfig = applyDbEnvOverrides(
+    profile && profile.db ? resolveEnvPlaceholdersDeep(profile.db, env) : null,
+    env,
+    'ZEUS_DB',
+  );
+  const roleConfigs = profile && profile.dbRoles ? resolveEnvPlaceholdersDeep(profile.dbRoles, env) : {};
+  const metadataDb = applyDbEnvOverrides(
+    mergeConfigLayers(baseDbConfig || {}, roleConfigs && roleConfigs.metadata ? roleConfigs.metadata : undefined),
+    env,
+    'ZEUS_METADATA_DB',
+  );
+  const testDataDb = applyDbEnvOverrides(
+    mergeConfigLayers(metadataDb || baseDbConfig || {}, roleConfigs && roleConfigs.testData ? roleConfigs.testData : undefined),
+    env,
+    'ZEUS_TESTDATA_DB',
+  );
+
+  return {
+    metadata: metadataDb,
+    testData: testDataDb,
+  };
+}
+
+function buildAnalyzeConnectionRoles(profile, analyzeDbRoles) {
+  const hasFetchProfile = Boolean(profile && profile.fetch);
+  return {
+    source: {
+      kind: hasFetchProfile ? 'fetch' : 'local',
+      profileKey: hasFetchProfile ? 'fetch' : 'sourceRoot',
+    },
+    metadata: {
+      kind: 'db2',
+      profileKey: profile && profile.dbRoles && profile.dbRoles.metadata ? 'dbRoles.metadata' : 'db',
+      dbConfig: analyzeDbRoles.metadata,
+    },
+    testData: {
+      kind: 'db2',
+      profileKey: profile && profile.dbRoles && profile.dbRoles.testData
+        ? 'dbRoles.testData'
+        : (profile && profile.dbRoles && profile.dbRoles.metadata ? 'dbRoles.metadata' : 'db'),
+      dbConfig: analyzeDbRoles.testData,
+    },
+  };
+}
+
+function resolveAnalyzeDbConfig(config, role = 'metadata') {
+  if (!config || typeof config !== 'object') {
+    return null;
+  }
+  if (role === 'testData' && config.dbRoles && config.dbRoles.testData) {
+    return config.dbRoles.testData;
+  }
+  if (config.dbRoles && config.dbRoles.metadata) {
+    return config.dbRoles.metadata;
+  }
+  return config.db || null;
 }
 
 function resolveAnalyzeConfig(args, { cwd = process.cwd(), env = process.env } = {}) {
   const profiles = loadProfiles({ cwd, env, args });
   const profile = resolveProfile(profiles, args.profile, { env });
   const fetchProfile = profile ? (profile.fetch || {}) : {};
+  const analyzeDbRoles = resolveAnalyzeDbRoleConfigs(profile, env);
 
   const extensions = args.extensions
     ? parseCsv(args.extensions, DEFAULT_EXTENSIONS)
@@ -855,10 +937,9 @@ function resolveAnalyzeConfig(args, { cwd = process.cwd(), env = process.env } =
     sourceRoot: args.source || (profile && profile.sourceRoot),
     outputRoot: args.out || args.output || (profile && profile.outputRoot) || 'output',
     extensions,
-    db: applyDbEnvOverrides(
-      profile && profile.db ? resolveEnvPlaceholdersDeep(profile.db, env) : null,
-      env,
-    ),
+    db: analyzeDbRoles.metadata,
+    dbRoles: analyzeDbRoles,
+    connections: buildAnalyzeConnectionRoles(profile, analyzeDbRoles),
     ibmi: {
       host: args.host || env.ZEUS_FETCH_HOST || fetchProfile.host || null,
       user: args.user || env.ZEUS_FETCH_USER || fetchProfile.user || null,
@@ -932,6 +1013,7 @@ module.exports = {
   getProfilesMetadata,
   loadProfiles,
   normalizeTokenBudgetKey,
+  resolveAnalyzeDbConfig,
   readWorkflowConfig,
   readTokenBudgetConfig,
   readWorkCopyConfig,

--- a/src/core/analyzeService.js
+++ b/src/core/analyzeService.js
@@ -197,6 +197,20 @@ function executeAnalyze(args, { cwd = process.cwd() } = {}) {
         testDataPolicy: config.testData,
         tokenBudget: config.tokenBudget,
         extensions: config.extensions,
+        connectionRoles: config.connections ? {
+          source: config.connections.source ? {
+            kind: config.connections.source.kind,
+            profileKey: config.connections.source.profileKey,
+          } : null,
+          metadata: config.connections.metadata ? {
+            kind: config.connections.metadata.kind,
+            profileKey: config.connections.metadata.profileKey,
+          } : null,
+          testData: config.connections.testData ? {
+            kind: config.connections.testData.kind,
+            profileKey: config.connections.testData.profileKey,
+          } : null,
+        } : null,
         reproducibility,
         guidedMode,
         workflowPreset,
@@ -259,6 +273,20 @@ function executeAnalyze(args, { cwd = process.cwd() } = {}) {
         testDataPolicy: config.testData,
         tokenBudget: config.tokenBudget,
         extensions: config.extensions,
+        connectionRoles: config.connections ? {
+          source: config.connections.source ? {
+            kind: config.connections.source.kind,
+            profileKey: config.connections.source.profileKey,
+          } : null,
+          metadata: config.connections.metadata ? {
+            kind: config.connections.metadata.kind,
+            profileKey: config.connections.metadata.profileKey,
+          } : null,
+          testData: config.connections.testData ? {
+            kind: config.connections.testData.kind,
+            profileKey: config.connections.testData.profileKey,
+          } : null,
+        } : null,
         reproducibility,
         guidedMode,
         workflowPreset,

--- a/src/core/queryService.js
+++ b/src/core/queryService.js
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
-const { resolveAnalyzeConfig } = require('../config/runtimeConfig');
+const { resolveAnalyzeConfig, resolveAnalyzeDbConfig } = require('../config/runtimeConfig');
 const { isDbConfigured } = require('../db2/db2Config');
 const {
   escapeSqlLiteral,
@@ -84,11 +84,13 @@ function toRowMatrix(columns, rows) {
 }
 
 function requireDbConfig(config) {
-  if (!isDbConfigured(config.db)) {
+  const metadataDb = resolveAnalyzeDbConfig(config, 'metadata');
+  if (!isDbConfigured(metadataDb)) {
     const error = new Error('DB2 connection configuration is incomplete for the selected profile.');
     error.code = 'DB2_CONFIG_INCOMPLETE';
     throw error;
   }
+  return metadataDb;
 }
 
 function executeQueryTable(args, { cwd = process.cwd() } = {}) {
@@ -104,16 +106,16 @@ function executeQueryTable(args, { cwd = process.cwd() } = {}) {
   }
 
   const config = resolveAnalyzeConfig(args, { cwd });
-  requireDbConfig(config);
+  const dbConfig = requireDbConfig(config);
 
   const table = validateSqlIdentifier(args.table, '--table');
   const schema = args.schema ? validateSqlIdentifier(args.schema, '--schema') : null;
   const filter = args.filter ? validateFilterPattern(args.filter) : '';
-  const discovered = !schema ? discoverSchema(config.db, table) : null;
+  const discovered = !schema ? discoverSchema(dbConfig, table) : null;
   const effectiveSchema = schema || (discovered && discovered.TABLE_SCHEMA ? String(discovered.TABLE_SCHEMA).trim().toUpperCase() : '');
   const queries = buildQueryTableQueries({ schema: effectiveSchema, table, filter });
   const tableInfo = executeReadOnlyDb2QueryWithFallback({
-    dbConfig: config.db,
+    dbConfig,
     query: queries.tableInfo,
     maxRows: 50,
     context: {
@@ -122,7 +124,7 @@ function executeQueryTable(args, { cwd = process.cwd() } = {}) {
     },
     retryHandlers: {
       SQL0204: ({ context }) => {
-        const fallbackSchema = discoverSchema(config.db, context.table);
+        const fallbackSchema = discoverSchema(dbConfig, context.table);
         if (!fallbackSchema || !fallbackSchema.TABLE_SCHEMA) {
           return null;
         }
@@ -137,7 +139,7 @@ function executeQueryTable(args, { cwd = process.cwd() } = {}) {
     },
   });
   const columns = executeReadOnlyDb2QueryWithFallback({
-    dbConfig: config.db,
+    dbConfig,
     query: queries.columns,
     maxRows: 500,
     context: {
@@ -147,7 +149,7 @@ function executeQueryTable(args, { cwd = process.cwd() } = {}) {
     },
     retryHandlers: {
       SQL0204: ({ context }) => {
-        const fallbackSchema = discoverSchema(config.db, context.table);
+        const fallbackSchema = discoverSchema(dbConfig, context.table);
         if (!fallbackSchema || !fallbackSchema.TABLE_SCHEMA) {
           return null;
         }
@@ -171,6 +173,7 @@ function executeQueryTable(args, { cwd = process.cwd() } = {}) {
     discoveredSchema: !schema && effectiveSchema ? effectiveSchema : '',
     tableInfo,
     columns,
+    dbConfig,
   };
 }
 
@@ -190,11 +193,11 @@ function executeQuerySql(args, { cwd = process.cwd() } = {}) {
   const maxRows = parseMaxRows(args['max-rows']);
   const output = normalizeOutput(args.output);
   const config = resolveAnalyzeConfig(args, { cwd });
-  requireDbConfig(config);
+  const dbConfig = requireDbConfig(config);
 
   validateReadOnlySql(sql);
   const result = runReadOnlyDb2Query({
-    dbConfig: config.db,
+    dbConfig,
     query: sql,
     maxRows,
   });
@@ -205,6 +208,7 @@ function executeQuerySql(args, { cwd = process.cwd() } = {}) {
     sql,
     maxRows,
     output,
+    dbConfig,
     columns,
     rows: result.rows || [],
     rowCount: Number(result.rowCount || (result.rows || []).length || 0),

--- a/src/core/runExplorerService.js
+++ b/src/core/runExplorerService.js
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 Guido Zeuner
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const path = require('path');
+
+const { resolveBundleConfig } = require('../config/runtimeConfig');
+const {
+  listAnalysisRuns,
+  readAnalysisRun,
+  readArtifactContent,
+} = require('../ui/localUiDataApi');
+
+function resolveExplorerOutputRoot(args = {}, { cwd = process.cwd(), env = process.env } = {}) {
+  const explicitOutputRoot = args.outputRoot || args.sourceOutputRoot || args['source-output-root'];
+  if (explicitOutputRoot) {
+    return path.resolve(cwd, explicitOutputRoot);
+  }
+
+  const config = resolveBundleConfig({
+    profile: args.profile,
+  }, { cwd, env });
+  return path.resolve(cwd, config.sourceOutputRoot);
+}
+
+function executeListRuns(args = {}, runtime = {}) {
+  const outputRoot = resolveExplorerOutputRoot(args, runtime);
+  return {
+    outputRoot,
+    runs: listAnalysisRuns(outputRoot),
+  };
+}
+
+function executeReadRun(args = {}, runtime = {}) {
+  const outputRoot = resolveExplorerOutputRoot(args, runtime);
+  return {
+    outputRoot,
+    run: readAnalysisRun(outputRoot, args.program),
+  };
+}
+
+function executeReadRunViews(args = {}, runtime = {}) {
+  const outputRoot = resolveExplorerOutputRoot(args, runtime);
+  return {
+    outputRoot,
+    program: String(args.program || '').trim(),
+    views: readAnalysisRun(outputRoot, args.program).views,
+  };
+}
+
+function executeReadArtifact(args = {}, runtime = {}) {
+  const outputRoot = resolveExplorerOutputRoot(args, runtime);
+  return {
+    outputRoot,
+    artifact: readArtifactContent(outputRoot, args.program, args.path || args.artifactPath),
+  };
+}
+
+module.exports = {
+  executeListRuns,
+  executeReadArtifact,
+  executeReadRun,
+  executeReadRunViews,
+  resolveExplorerOutputRoot,
+};

--- a/src/ui/localUiServer.js
+++ b/src/ui/localUiServer.js
@@ -15,10 +15,11 @@ const http = require('http');
 const path = require('path');
 
 const {
-  listAnalysisRuns,
-  readAnalysisRun,
-  readArtifactContent,
-} = require('./localUiDataApi');
+  executeListRuns,
+  executeReadArtifact,
+  executeReadRun,
+  executeReadRunViews,
+} = require('../core/runExplorerService');
 const { renderLocalUiShell } = require('./localUiShell');
 
 const DEFAULT_UI_HOST = '127.0.0.1';
@@ -97,30 +98,43 @@ function createLocalUiRequestHandler({ outputRoot }) {
       }
 
       if (pathname === '/api/runs') {
-        sendJson(response, 200, listAnalysisRuns(resolvedOutputRoot));
+        sendJson(response, 200, executeListRuns({
+          sourceOutputRoot: resolvedOutputRoot,
+        }).runs);
         return;
       }
 
       if (segments[0] === 'api' && segments[1] === 'runs' && segments.length === 3) {
-        sendJson(response, 200, readAnalysisRun(resolvedOutputRoot, segments[2]));
+        sendJson(response, 200, executeReadRun({
+          sourceOutputRoot: resolvedOutputRoot,
+          program: segments[2],
+        }).run);
         return;
       }
 
       if (segments[0] === 'api' && segments[1] === 'runs' && segments[3] === 'views' && segments.length === 4) {
-        sendJson(response, 200, readAnalysisRun(resolvedOutputRoot, segments[2]).views);
+        sendJson(response, 200, executeReadRunViews({
+          sourceOutputRoot: resolvedOutputRoot,
+          program: segments[2],
+        }).views);
         return;
       }
 
       if (segments[0] === 'api' && segments[1] === 'runs' && segments[3] === 'artifacts' && segments[4] === 'content') {
-        const artifactPath = url.searchParams.get('path');
-        const artifact = readArtifactContent(resolvedOutputRoot, segments[2], artifactPath);
-        sendJson(response, 200, artifact);
+        sendJson(response, 200, executeReadArtifact({
+          sourceOutputRoot: resolvedOutputRoot,
+          program: segments[2],
+          path: url.searchParams.get('path'),
+        }).artifact);
         return;
       }
 
       if (segments[0] === 'runs' && segments[2] === 'artifacts' && segments[3] === 'raw') {
-        const artifactPath = url.searchParams.get('path');
-        const artifact = readArtifactContent(resolvedOutputRoot, segments[1], artifactPath);
+        const artifact = executeReadArtifact({
+          sourceOutputRoot: resolvedOutputRoot,
+          program: segments[1],
+          path: url.searchParams.get('path'),
+        }).artifact;
         sendText(response, 200, artifact.content, artifact.contentType);
         return;
       }

--- a/tests/doctor-command.test.js
+++ b/tests/doctor-command.test.js
@@ -41,3 +41,44 @@ test('buildEnvironmentChecks downgrades to warnings when the profile already pro
   assert.ok(checks.some((entry) => entry.name === 'ZEUS_FETCH_OUT' && entry.status === 'WARN'));
   assert.ok(checks.some((entry) => entry.name === 'ZEUS_OUTPUT_ROOT' && entry.status === 'WARN'));
 });
+
+test('buildEnvironmentChecks includes dedicated metadata and test-data DB role variables when configured', () => {
+  const checks = buildEnvironmentChecks({
+    profile: {
+      db: {
+        host: 'base-host',
+        user: 'base-user',
+        password: 'base-pass',
+      },
+      dbRoles: {
+        metadata: {
+          host: '${env:ZEUS_METADATA_DB_HOST}',
+        },
+        testData: {
+          host: '${env:ZEUS_TESTDATA_DB_HOST}',
+        },
+      },
+    },
+    analyzeConfig: {
+      dbRoles: {
+        metadata: {
+          host: 'meta-host',
+          user: 'meta-user',
+          password: 'meta-pass',
+        },
+        testData: {
+          host: 'test-host',
+          user: 'test-user',
+          password: 'test-pass',
+        },
+      },
+    },
+    fetchConfig: null,
+    env: {},
+  });
+
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_METADATA_DB_HOST' && entry.status === 'WARN'));
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_TESTDATA_DB_HOST' && entry.status === 'WARN'));
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_METADATA_DB_PASSWORD' && entry.status === 'WARN'));
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_TESTDATA_DB_PASSWORD' && entry.status === 'WARN'));
+});

--- a/tests/runtime-config.test.js
+++ b/tests/runtime-config.test.js
@@ -13,6 +13,7 @@ const {
   readTokenBudgetConfig,
   readWorkflowConfig,
   readWorkCopyConfig,
+  resolveAnalyzeDbConfig,
   resolveAnalyzeConfig,
   resolveProfile,
   resolveProfilesConfigPaths,
@@ -325,6 +326,60 @@ test('resolveAnalyzeConfig applies environment overrides for DB credentials', ()
       password: 'env-pass',
       defaultSchema: 'ENVLIB',
     });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('resolveAnalyzeConfig supports dedicated metadata and test-data DB roles with fallback inheritance', () => {
+  const tempRoot = createTempProject({
+    sample: {
+      db: {
+        host: 'base-host',
+        user: 'base-user',
+        password: 'base-pass',
+        defaultSchema: 'BASELIB',
+      },
+      dbRoles: {
+        metadata: {
+          host: 'meta-host',
+          user: 'meta-user',
+        },
+        testData: {
+          defaultSchema: 'TESTLIB',
+        },
+      },
+    },
+  });
+
+  try {
+    const config = resolveAnalyzeConfig(
+      { profile: 'sample' },
+      {
+        cwd: tempRoot,
+        env: {
+          ZEUS_METADATA_DB_PASSWORD: 'meta-pass',
+          ZEUS_TESTDATA_DB_HOST: 'test-host',
+          ZEUS_TESTDATA_DB_USER: 'test-user',
+          ZEUS_TESTDATA_DB_PASSWORD: 'test-pass',
+        },
+      },
+    );
+
+    assert.deepEqual(resolveAnalyzeDbConfig(config, 'metadata'), {
+      host: 'meta-host',
+      user: 'meta-user',
+      password: 'meta-pass',
+      defaultSchema: 'BASELIB',
+    });
+    assert.deepEqual(resolveAnalyzeDbConfig(config, 'testData'), {
+      host: 'test-host',
+      user: 'test-user',
+      password: 'test-pass',
+      defaultSchema: 'TESTLIB',
+    });
+    assert.equal(config.connections.metadata.profileKey, 'dbRoles.metadata');
+    assert.equal(config.connections.testData.profileKey, 'dbRoles.testData');
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/tests/zeus-api.test.js
+++ b/tests/zeus-api.test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { analyze, runWorkflow } = require('../src/api/zeusApi');
+const { analyze, listRuns, runWorkflow } = require('../src/api/zeusApi');
 
 const fixtureRoot = path.join(__dirname, 'fixtures', 'v1-smoke', 'src');
 
@@ -54,6 +54,41 @@ test('zeusApi exposes reusable analyze and workflow entry points', async () => {
     });
     assert.equal(workflowResult.status, 'succeeded');
     assert.equal(fs.existsSync(workflowResult.paths.reportPath), true);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('zeusApi resolves run explorer output roots from the selected profile', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-api-runs-'));
+  const configRoot = path.join(tempRoot, 'config');
+  const outputRoot = path.join(tempRoot, 'output');
+  const programDir = path.join(outputRoot, 'ORDERPGM');
+
+  fs.mkdirSync(configRoot, { recursive: true });
+  fs.mkdirSync(programDir, { recursive: true });
+  fs.writeFileSync(path.join(configRoot, 'profiles.json'), `${JSON.stringify({
+    local: {
+      outputRoot: './output',
+    },
+  }, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(path.join(programDir, 'analyze-run-manifest.json'), `${JSON.stringify({
+    schemaVersion: 1,
+    tool: { name: 'zeus-rpg-promptkit', command: 'analyze' },
+    run: { status: 'succeeded', completedAt: '2026-04-13T12:00:00.000Z' },
+    inputs: { sourceRoot: './src', options: {} },
+  }, null, 2)}\n`, 'utf8');
+
+  try {
+    const result = listRuns('local', {
+      runtime: {
+        cwd: tempRoot,
+        env: {},
+      },
+    });
+    assert.equal(result.outputRoot, outputRoot);
+    assert.equal(result.runs.length, 1);
+    assert.equal(result.runs[0].program, 'ORDERPGM');
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/tests/zeus-explorer-api.test.js
+++ b/tests/zeus-explorer-api.test.js
@@ -1,0 +1,127 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  listRuns,
+  readArtifact,
+  readRun,
+  readRunViews,
+} = require('../src/api/zeusApi');
+
+function createUiFixture() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-explorer-api-'));
+  const outputRoot = path.join(tempRoot, 'output');
+  const programDir = path.join(outputRoot, 'ORDERPGM');
+  const safeDir = path.join(programDir, 'safe-sharing');
+  fs.mkdirSync(safeDir, { recursive: true });
+
+  fs.writeFileSync(path.join(programDir, 'report.md'), '# Report\n\nSummary.\n', 'utf8');
+  fs.writeFileSync(path.join(programDir, 'context.json'), `${JSON.stringify({
+    program: 'ORDERPGM',
+    dependencies: {
+      tables: [{ name: 'ORDERS' }],
+      programCalls: [{ name: 'INVPGM' }],
+    },
+  }, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(path.join(programDir, 'architecture.html'), '<!doctype html><title>Architecture Viewer</title>', 'utf8');
+  fs.writeFileSync(path.join(programDir, 'program-call-tree.json'), `${JSON.stringify({
+    rootProgram: 'ORDERPGM',
+    nodes: [
+      { id: 'ORDERPGM', type: 'PROGRAM' },
+      { id: 'ORDERS', type: 'TABLE' },
+    ],
+    edges: [
+      { from: 'ORDERPGM', to: 'ORDERS', type: 'USES_TABLE' },
+    ],
+  }, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(path.join(programDir, 'db2-metadata.json'), `${JSON.stringify({
+    tables: [{
+      schema: 'MYLIB',
+      table: 'ORDERS',
+      sourceLink: {
+        matchStatus: 'resolved',
+        sourceEvidence: [{ file: 'ORDERPGM.rpgle', startLine: 1 }],
+      },
+    }],
+    summary: {
+      tableCount: 1,
+    },
+  }, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(path.join(programDir, 'test-data.json'), `${JSON.stringify({
+    tables: [{
+      schema: 'MYLIB',
+      table: 'ORDERS',
+      rows: [{ ORDER_ID: '1001' }],
+      policyDecision: {
+        eligibility: 'allowed',
+        maskedColumns: ['EMAIL'],
+      },
+      sourceLink: {
+        matchStatus: 'resolved',
+        sourceEvidence: [{ file: 'ORDERPGM.rpgle', startLine: 1 }],
+      },
+    }],
+    summary: {
+      tableCount: 1,
+    },
+  }, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(path.join(programDir, 'ai_prompt_documentation.md'), '# Documentation Prompt\n', 'utf8');
+  fs.writeFileSync(path.join(safeDir, 'report.md'), '# Safe Report\n', 'utf8');
+  fs.writeFileSync(path.join(programDir, 'analyze-run-manifest.json'), `${JSON.stringify({
+    schemaVersion: 1,
+    tool: { name: 'zeus-rpg-promptkit', command: 'analyze' },
+    run: {
+      status: 'succeeded',
+      completedAt: '2026-04-13T12:00:00.000Z',
+    },
+    inputs: {
+      sourceRoot: 'C:/temp/src',
+      options: {
+        guidedMode: { name: 'documentation' },
+        workflowPreset: { name: 'onboarding' },
+        reproducibleEnabled: false,
+      },
+    },
+  }, null, 2)}\n`, 'utf8');
+
+  return {
+    tempRoot,
+    outputRoot,
+  };
+}
+
+test('zeusApi exposes direct explorer access for runs, views, and artifacts', () => {
+  const { tempRoot, outputRoot } = createUiFixture();
+
+  try {
+    const listed = listRuns('unused', {
+      sourceOutputRoot: outputRoot,
+    });
+    assert.equal(listed.runs.length, 1);
+    assert.equal(listed.runs[0].program, 'ORDERPGM');
+
+    const run = readRun('unused', 'ORDERPGM', {
+      sourceOutputRoot: outputRoot,
+    });
+    assert.equal(run.run.summary.program, 'ORDERPGM');
+    assert.equal(run.run.views.graph.available, true);
+    assert.equal(run.run.views.db2.tables.length, 1);
+
+    const views = readRunViews('unused', 'ORDERPGM', {
+      sourceOutputRoot: outputRoot,
+    });
+    assert.equal(views.views.summary.graphNodeCount, 2);
+    assert.equal(views.views.prompts.artifacts.length, 1);
+
+    const artifact = readArtifact('unused', 'ORDERPGM', 'report.md', {
+      sourceOutputRoot: outputRoot,
+    });
+    assert.equal(artifact.artifact.kind, 'markdown');
+    assert.match(artifact.artifact.content, /Summary\./);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add unExplorerService and integrate explorer-oriented API coverage
- extend doctor command and runtime config validation paths
- update analyzer/query/UI flows for explorer service handling
- add and update tests for doctor, runtime config, zeus API, and explorer API

## Notes
- includes example profile config updates for new explorer-related settings