### PR TITLE
Add safe VS Code agent bridge for Zeus RPG Toolkit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Zeus Copilot Agent Instructions
+
+Use Zeus VS Code commands and Zeus agent tools for evidence-first, read-only workflows.
+
+## Workflow
+
+1. Run `Zeus: Show Active Environment`.
+2. If profile is unknown, run `Zeus: Select Profile` and then `Zeus: Run Doctor`.
+3. Before editing RPG-related code, run `Zeus: Generate AI Context`.
+4. Use read-only Zeus operations first: doctor, fetch sources, analyze workspace, query table, latest report.
+5. Use generated reports and context artifacts as evidence.
+
+## Safety
+
+- Keep default mode read-only.
+- Never deploy.
+- Never run IBM i write operations.
+- Never expose credentials, connection strings, tokens, passwords, or secrets.
+- Never print secret values in terminal output, logs, or copied prompts.
+- Do not edit fetched originals unless explicitly requested; prefer workspace copies.
+- Ask for user confirmation before risky actions.
+
+## Zeus Agent Tool Names
+
+- `zeus_doctor`
+- `zeus_fetch_sources`
+- `zeus_analyze_workspace`
+- `zeus_query_table`
+- `zeus_generate_ai_context`
+- `zeus_get_latest_report`
+
+If a tool returns `BLOCKED`, stop and ask for user confirmation.

--- a/README.md
+++ b/README.md
@@ -1164,6 +1164,78 @@ The context bundle is sanitized:
 6. Run `Zeus: Generate AI Context`, then `Zeus: Copy AI Prompt to Clipboard`, and verify `ai_prompt.md`, `context.json`, and `safety_rules.md`.
 7. Confirm secret masking in output and generated artifacts.
 
+## VS Code Agent Integration
+
+The VS Code integration now includes a safe command gateway for extension commands and agent-facing tool calls.
+
+### Environment resolution
+
+Zeus subprocess and terminal environments merge:
+
+1. `process.env`
+2. `zeusRpgToolkit.env.*` settings
+3. legacy extension settings (`configPath`, `defaultProfile`, `outputRoot`, `readOnlyMode`, `cliPath`, `javaPath`)
+4. active selected profile
+
+New `zeusRpgToolkit.env.*` settings:
+
+- `zeusRpgToolkit.env.ZEUS_CONFIG_DIR`
+- `zeusRpgToolkit.env.ZEUS_PROFILE`
+- `zeusRpgToolkit.env.ZEUS_OUTPUT_ROOT`
+- `zeusRpgToolkit.env.ZEUS_READ_ONLY`
+- `zeusRpgToolkit.env.ZEUS_CLI_PATH`
+- `zeusRpgToolkit.env.ZEUS_JAVA_PATH`
+
+### Copilot-friendly commands
+
+- `Zeus: Select Profile`
+- `Zeus: Show Active Environment`
+- `Zeus: Create Agent Terminal`
+- `Zeus: Run Doctor`
+- `Zeus: Fetch Sources`
+- `Zeus: Analyze Workspace`
+- `Zeus: Query Table`
+- `Zeus: Generate AI Context`
+- `Zeus: Copy AI Prompt to Clipboard`
+- `Zeus: Open Latest Report`
+
+### Agent tool bridge
+
+Internal stable tool names:
+
+- `zeus_doctor`
+- `zeus_fetch_sources`
+- `zeus_analyze_workspace`
+- `zeus_query_table`
+- `zeus_generate_ai_context`
+- `zeus_get_latest_report`
+
+All return sanitized structured results. Unsupported/risky operations return `BLOCKED` with confirmation required.
+
+### Language Model Tool API
+
+For this branch, Language Model Tool contribution wiring is deferred because the extension target remains `^1.90.0` and the minimal safe path is implemented through internal tool-command bridging first.
+
+### Agent terminal
+
+`Zeus: Create Agent Terminal` opens `Zeus Agent Terminal` with ZEUS_* values injected and prints:
+
+- `Zeus RPG Toolkit environment loaded.`
+- `Active profile: <profile>`
+- `Read-only mode: true|false`
+- `Config: <workspace-relative path>`
+
+### Safety model
+
+- default mode remains read-only
+- no deployment features
+- no IBM i write operations exposed
+- secrets are masked in output channel logs, tool results, and generated AI context
+
+### Detailed guide
+
+See [`docs/agent-mode.md`](docs/agent-mode.md) for full behavior and test workflow.
+
 ## Project structure
 
 ### Main entry points and notable modules

--- a/docs/agent-mode.md
+++ b/docs/agent-mode.md
@@ -1,0 +1,96 @@
+# VS Code Agent Integration
+
+This document explains the Zeus RPG Toolkit VS Code integration layer for Copilot/Agent workflows.
+
+## Scope
+
+- CLI behavior stays unchanged.
+- VS Code integration is additive.
+- Default mode is read-only.
+- No deployment features.
+- No IBM i write operations.
+
+## Profile and environment resolution
+
+Zeus subprocesses and agent terminals merge environment values in this order:
+
+1. `process.env`
+2. VS Code `zeusRpgToolkit.env.*` settings
+3. legacy VS Code settings (`configPath`, `defaultProfile`, `outputRoot`, `readOnlyMode`, `cliPath`, `javaPath`)
+4. active selected profile
+
+Supported environment settings:
+
+- `zeusRpgToolkit.env.ZEUS_CONFIG_DIR`
+- `zeusRpgToolkit.env.ZEUS_PROFILE`
+- `zeusRpgToolkit.env.ZEUS_OUTPUT_ROOT`
+- `zeusRpgToolkit.env.ZEUS_READ_ONLY`
+- `zeusRpgToolkit.env.ZEUS_CLI_PATH`
+- `zeusRpgToolkit.env.ZEUS_JAVA_PATH`
+
+## Commands
+
+- `Zeus: Select Profile`
+- `Zeus: Show Active Environment`
+- `Zeus: Create Agent Terminal`
+- `Zeus: Run Doctor`
+- `Zeus: Fetch Sources`
+- `Zeus: Analyze Workspace`
+- `Zeus: Query Table`
+- `Zeus: Generate AI Context`
+- `Zeus: Copy AI Prompt to Clipboard`
+- `Zeus: Open Latest Report`
+
+## Agent-accessible Zeus tools
+
+Stable internal tool names:
+
+- `zeus_doctor`
+- `zeus_fetch_sources`
+- `zeus_analyze_workspace`
+- `zeus_query_table`
+- `zeus_generate_ai_context`
+- `zeus_get_latest_report`
+
+Tools return structured JSON-like objects and sanitized summaries.
+
+## Language Model Tool API status
+
+The extension currently targets VS Code engine `^1.90.0`. Language Model Tool contribution wiring is deferred in this branch to avoid relying on API surface not guaranteed by that engine target. Internal stable tool commands are implemented now as a safe bridge.
+
+## Terminal behavior
+
+`Zeus: Create Agent Terminal` creates `Zeus Agent Terminal` with resolved ZEUS_* values and safe banner output:
+
+- `Zeus RPG Toolkit environment loaded.`
+- `Active profile: <profile>`
+- `Read-only mode: true|false`
+- `Config: <workspace-relative path>`
+
+The extension also refreshes VS Code environment variable collection for Zeus keys when available.
+
+## Safety model
+
+- Secret masking is applied to logs and structured results.
+- Masked key/value categories include password/pass/pwd/token/secret/api_key/key/credential/auth/authorization and JDBC credential patterns.
+- User fields are masked when credentials are present.
+- Agent tools are read-only guarded.
+- Unsupported or risky operations return `BLOCKED` with `requiresUserConfirmation=true`.
+
+## Limitations
+
+- No chat participant (`@zeus`) in this minimal slice.
+- No deployment command exposure.
+- No IBM i write command exposure.
+
+## Manual test steps
+
+1. Open project in VS Code.
+2. Run `Zeus: Select Profile`.
+3. Run `Zeus: Show Active Environment`.
+4. Run `Zeus: Create Agent Terminal`.
+5. In the terminal, verify `ZEUS_PROFILE` and `ZEUS_CONFIG_DIR` exist.
+6. Run `Zeus: Run Doctor`.
+7. Run `Zeus: Generate AI Context`.
+8. In Copilot Agent Mode, invoke Zeus tools/commands.
+9. Confirm no secrets are shown in output channel, terminal banners, or generated context files.

--- a/src/security/secretMasking.js
+++ b/src/security/secretMasking.js
@@ -12,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const REDACTED_VALUE = '[REDACTED]';
-const SENSITIVE_KEY_PATTERN = /(^|[_-])(password|passwd|pwd|pass|secret|token|api[_-]?key|key|authorization|auth)$/i;
+const SENSITIVE_KEY_PATTERN = /(^|[_-])(password|passwd|pwd|pass|secret|token|api[_-]?key|key|authorization|auth|credential|credentials)$/i;
 const USER_KEY_PATTERN = /^(user|username)$/i;
 
 function isPlainObject(value) {
@@ -32,16 +32,19 @@ function maskSecretsInText(value) {
 
   text = text
     .replace(/(\bjdbc:[a-z0-9]+:\/\/)([^:\s/;,@]+):([^@\s/;]+)@/gi, `$1${REDACTED_VALUE}:${REDACTED_VALUE}@`)
+    .replace(/(\bjdbc:[^\s?;]+[?;][^\r\n]*?\buser\s*=\s*)([^;&\s]+)/gi, `$1${REDACTED_VALUE}`)
+    .replace(/(\bjdbc:[^\s?;]+[?;][^\r\n]*?\b(password|passwd|pwd|pass)\s*=\s*)([^;&\s]+)/gi, `$1${REDACTED_VALUE}`)
     .replace(/(\bjdbc:[^\r\n]*?\b(user|username)\s*=\s*)([^;\s]+)/gi, `$1${REDACTED_VALUE}`)
     .replace(/(\bjdbc:[^\r\n]*?\b(password|passwd|pwd|pass)\s*=\s*)([^;\s]+)/gi, `$1${REDACTED_VALUE}`)
     .replace(/\b(password|passwd|pwd)\s*=\s*([^;\s]+)/gi, `$1=${REDACTED_VALUE}`)
     .replace(/\b(pass)\s*=\s*([^;\s]+)/gi, `$1=${REDACTED_VALUE}`)
+    .replace(/\b(credential|credentials)\s*[:=]\s*([^\s,;]+)/gi, `$1=${REDACTED_VALUE}`)
     .replace(/\b(password|passwd|pwd)\s*:\s*([^\s,]+)/gi, `$1: ${REDACTED_VALUE}`)
     .replace(/\b(pass)\s*:\s*([^\s,]+)/gi, `$1: ${REDACTED_VALUE}`)
     .replace(/\b(token|secret|api[_-]?key|authorization|auth|key)\s*[:=]\s*([^\s,;]+)/gi, `$1=${REDACTED_VALUE}`)
     .replace(/\b(authorization)\s+bearer\s+[a-z0-9._~+/-]+=*/gi, `$1 Bearer ${REDACTED_VALUE}`);
 
-  if (/\b(password|passwd|pwd|pass|token|secret|api[_-]?key|authorization|auth|key)\b/i.test(text)) {
+  if (/\b(password|passwd|pwd|pass|token|secret|api[_-]?key|authorization|auth|key|credential|credentials)\b/i.test(text)) {
     text = text.replace(/\b(user|username)\s*[:=]\s*([^\s,;]+)/gi, `$1=${REDACTED_VALUE}`);
   }
 

--- a/tests/secret-masking.test.js
+++ b/tests/secret-masking.test.js
@@ -38,3 +38,13 @@ test('maskSecretsInText redacts common inline secret patterns', () => {
   assert.doesNotMatch(output, /\bxyz\b/);
 });
 
+test('maskSecretsInText redacts credential fields and jdbc query credentials', () => {
+  const input = 'jdbc:db2://host/db?user=alice&password=secret123 credentials=top-secret username=alice';
+  const output = maskSecretsInText(input);
+
+  assert.match(output, /\[REDACTED\]/);
+  assert.doesNotMatch(output, /\balice\b/i);
+  assert.doesNotMatch(output, /\bsecret123\b/);
+  assert.doesNotMatch(output, /\btop-secret\b/);
+});
+

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -1,26 +1,26 @@
 /* eslint-disable no-console */
 const fs = require('fs');
 const path = require('path');
-const { spawn, spawnSync } = require('child_process');
 const vscode = require('vscode');
+const { runWorkflow } = require('../src/api/zeusApi');
 const {
-  analyze,
-  fetch,
-  queryTable,
-  runWorkflow,
-} = require('../src/api/zeusApi');
-const {
-  DEFAULT_EXTENSIONS,
-  loadProfiles,
   readWorkflowConfig,
   resolveProfile,
 } = require('../src/config/runtimeConfig');
-const { generateAiContextBundle } = require('../src/agent/aiContextService');
 const { maskSecretsInText, sanitizeValue } = require('../src/security/secretMasking');
-const { listSelectableProfiles, resolveActiveProfile } = require('../src/vscode/profileSelection');
+const { createZeusCommandGateway } = require('./src/zeusCommandGateway');
 
 const AI_CONTEXT_SELECTION_KEY = 'zeusRpgToolkit.aiContextSelection';
 const LAST_AI_PROMPT_KEY = 'zeusRpgToolkit.lastAiPromptPath';
+const AGENT_TOOL_COMMANDS = Object.freeze([
+  'zeus_doctor',
+  'zeus_fetch_sources',
+  'zeus_analyze_workspace',
+  'zeus_query_table',
+  'zeus_generate_ai_context',
+  'zeus_get_latest_report',
+  'zeus_open_latest_report',
+]);
 
 function ensureDir(dirPath) {
   fs.mkdirSync(dirPath, { recursive: true });
@@ -28,126 +28,6 @@ function ensureDir(dirPath) {
 
 function toPosix(filePath) {
   return String(filePath || '').split(path.sep).join('/');
-}
-
-function getWorkspaceRoot() {
-  const folder = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0];
-  return folder ? folder.uri.fsPath : '';
-}
-
-function getSettings(resource) {
-  return vscode.workspace.getConfiguration('zeusRpgToolkit', resource || null);
-}
-
-function resolveSettingPath(rootDir, settingValue, fallback) {
-  const raw = String(settingValue || '').trim() || fallback;
-  return path.resolve(rootDir, raw);
-}
-
-function createExtensionEnv(settings) {
-  const env = { ...process.env };
-  const javaPathSetting = String(settings.get('javaPath') || '').trim();
-  if (!javaPathSetting) {
-    return env;
-  }
-  const resolved = path.resolve(javaPathSetting);
-  const javaBinDir = fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()
-    ? resolved
-    : path.dirname(resolved);
-  env.PATH = `${javaBinDir}${path.delimiter}${env.PATH || ''}`;
-  return env;
-}
-
-function appendOutput(output, message) {
-  const line = typeof message === 'string'
-    ? message
-    : JSON.stringify(sanitizeValue(message), null, 2);
-  output.appendLine(maskSecretsInText(line));
-}
-
-function loadProfilesForWorkspace(rootDir, settings, env) {
-  const configPath = String(settings.get('configPath') || 'config/profiles.json').trim();
-  const profileLoadArgs = configPath ? { config: configPath } : {};
-  const profiles = loadProfiles({
-    cwd: rootDir,
-    env,
-    args: profileLoadArgs,
-  });
-  return {
-    profiles,
-    profileNames: listSelectableProfiles(profiles),
-  };
-}
-
-function getActiveProfileName(settings, profileNames) {
-  return resolveActiveProfile(settings.get('defaultProfile'), profileNames);
-}
-
-async function setActiveProfile(settings, profile) {
-  await settings.update('defaultProfile', profile, vscode.ConfigurationTarget.Workspace);
-}
-
-function findLatestFiles(rootDir, matcher, maxEntries = 20) {
-  if (!fs.existsSync(rootDir)) {
-    return [];
-  }
-  const results = [];
-  const pending = [rootDir];
-
-  while (pending.length > 0) {
-    const current = pending.pop();
-    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
-      const absolutePath = path.join(current, entry.name);
-      if (entry.isDirectory()) {
-        pending.push(absolutePath);
-        continue;
-      }
-      if (!entry.isFile()) {
-        continue;
-      }
-      if (!matcher(absolutePath)) {
-        continue;
-      }
-      results.push({
-        absolutePath,
-        modifiedAt: fs.statSync(absolutePath).mtimeMs,
-      });
-    }
-  }
-
-  return results
-    .sort((left, right) => right.modifiedAt - left.modifiedAt)
-    .slice(0, maxEntries);
-}
-
-function collectMembers(sourceRoot) {
-  if (!sourceRoot || !fs.existsSync(sourceRoot)) {
-    return [];
-  }
-  const extensionSet = new Set(DEFAULT_EXTENSIONS.map((entry) => entry.toLowerCase()));
-  const members = new Set();
-  const pending = [sourceRoot];
-
-  while (pending.length > 0) {
-    const current = pending.pop();
-    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
-      const absolutePath = path.join(current, entry.name);
-      if (entry.isDirectory()) {
-        pending.push(absolutePath);
-        continue;
-      }
-      if (!entry.isFile()) {
-        continue;
-      }
-      const ext = path.extname(entry.name).toLowerCase();
-      if (!extensionSet.has(ext)) {
-        continue;
-      }
-      members.add(path.basename(entry.name, ext).toUpperCase());
-    }
-  }
-
-  return Array.from(members).sort((left, right) => left.localeCompare(right));
 }
 
 function resolveSafeRelativePath(rootDir, inputPath) {
@@ -207,71 +87,37 @@ function buildExampleConfig() {
   };
 }
 
-function resolveConfigArg(settings) {
-  return String(settings.get('configPath') || 'config/profiles.json').trim();
-}
-
-function resolveCliInvocation(rootDir, settings) {
-  const cliPathSetting = String(settings.get('cliPath') || 'cli/zeus.js').trim() || 'cli/zeus.js';
-  const cliPath = path.resolve(rootDir, cliPathSetting);
-  return {
-    cliPath,
-    exists: fs.existsSync(cliPath),
-  };
-}
-
-function buildCliBaseArgs(settings) {
-  const args = [];
-  const configPath = resolveConfigArg(settings);
-  if (configPath) {
-    args.push('--config', configPath);
+function findLatestFiles(rootDir, matcher, maxEntries = 20) {
+  if (!fs.existsSync(rootDir)) {
+    return [];
   }
-  return args;
-}
+  const results = [];
+  const pending = [rootDir];
 
-function streamMaskedOutput(output, text) {
-  const chunks = String(text || '').split(/\r?\n/);
-  for (const chunk of chunks) {
-    if (!chunk) {
-      continue;
-    }
-    appendOutput(output, chunk);
-  }
-}
-
-async function runCliCommand({ output, rootDir, env, settings, cliArgs }) {
-  const cli = resolveCliInvocation(rootDir, settings);
-  if (!cli.exists) {
-    throw new Error(`CLI path not found: ${cli.cliPath}. Update zeusRpgToolkit.cliPath or open config first.`);
-  }
-
-  const args = [cli.cliPath, ...cliArgs];
-  appendOutput(output, `[cli] node ${args.join(' ')}`);
-
-  await new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, args, {
-      cwd: rootDir,
-      env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-
-    child.stdout.on('data', (chunk) => {
-      streamMaskedOutput(output, chunk.toString());
-    });
-    child.stderr.on('data', (chunk) => {
-      streamMaskedOutput(output, chunk.toString());
-    });
-    child.on('error', (error) => {
-      reject(error);
-    });
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve();
-      } else {
-        reject(new Error(`CLI command failed with exit code ${code}.`));
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const absolutePath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(absolutePath);
+        continue;
       }
-    });
-  });
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (!matcher(absolutePath)) {
+        continue;
+      }
+      results.push({
+        absolutePath,
+        modifiedAt: fs.statSync(absolutePath).mtimeMs,
+      });
+    }
+  }
+
+  return results
+    .sort((left, right) => right.modifiedAt - left.modifiedAt)
+    .slice(0, maxEntries);
 }
 
 class SimpleTreeProvider {
@@ -294,6 +140,23 @@ class SimpleTreeProvider {
   }
 }
 
+function createGuardedCommand(output, fn, successMessage) {
+  return async (...args) => {
+    try {
+      const result = await fn(...args);
+      if (successMessage) {
+        vscode.window.showInformationMessage(successMessage);
+      }
+      return result;
+    } catch (error) {
+      const masked = maskSecretsInText(error.message);
+      output.appendLine(`[error] ${masked}`);
+      vscode.window.showErrorMessage(masked);
+      return null;
+    }
+  };
+}
+
 async function activate(context) {
   const output = vscode.window.createOutputChannel('Zeus RPG Toolkit');
   const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
@@ -305,9 +168,16 @@ async function activate(context) {
     output,
     statusBar,
     selectionState,
-    lastDoctorChecks: [],
     providers: [],
+    lastDoctorChecks: [],
   };
+
+  const gateway = createZeusCommandGateway({
+    vscode,
+    outputChannel: output,
+    workspaceState: context.workspaceState,
+    lastAiPromptKey: LAST_AI_PROMPT_KEY,
+  });
 
   const refreshViews = () => {
     for (const provider of runtimeState.providers) {
@@ -316,99 +186,54 @@ async function activate(context) {
   };
 
   const persistSelectionState = async () => {
-    await context.workspaceState.update(AI_CONTEXT_SELECTION_KEY, Array.from(selectionState.values()).sort((a, b) => a.localeCompare(b)));
+    await context.workspaceState.update(
+      AI_CONTEXT_SELECTION_KEY,
+      Array.from(selectionState.values()).sort((a, b) => a.localeCompare(b)),
+    );
   };
 
-  const ensureWorkspace = () => {
-    const root = getWorkspaceRoot();
-    if (!root) {
-      throw new Error('Open a workspace folder before running Zeus commands.');
+  const updateStatusBar = () => {
+    try {
+      const ctx = gateway.resolveContext();
+      runtimeState.statusBar.text = ctx.activeProfile
+        ? `Zeus: ${ctx.activeProfile}`
+        : 'Zeus: <no profile>';
+    } catch (_) {
+      runtimeState.statusBar.text = 'Zeus: <no workspace>';
     }
-    return root;
   };
 
-  const getCurrentContext = () => {
-    const root = ensureWorkspace();
-    const settings = getSettings(vscode.Uri.file(root));
-    const env = createExtensionEnv(settings);
-    const loaded = loadProfilesForWorkspace(root, settings, env);
-    const activeProfile = getActiveProfileName(settings, loaded.profileNames);
-
-    runtimeState.statusBar.text = activeProfile
-      ? `Zeus: ${activeProfile}`
-      : 'Zeus: <no profile>';
-
-    return {
-      root,
-      settings,
-      env,
-      profiles: loaded.profiles,
-      profileNames: loaded.profileNames,
-      activeProfile,
-    };
+  const applyTerminalEnvironmentCollection = () => {
+    try {
+      const ctx = gateway.resolveContext();
+      const collection = context.environmentVariableCollection;
+      if (!collection || typeof collection.replace !== 'function') {
+        return;
+      }
+      collection.clear();
+      const keys = [
+        'ZEUS_CONFIG_DIR',
+        'ZEUS_PROFILE',
+        'ZEUS_OUTPUT_ROOT',
+        'ZEUS_READ_ONLY',
+        'ZEUS_CLI_PATH',
+        'ZEUS_JAVA_PATH',
+      ];
+      for (const key of keys) {
+        if (!ctx.zeusEnv[key]) {
+          continue;
+        }
+        collection.replace(key, String(ctx.zeusEnv[key]));
+      }
+      collection.description = 'Zeus RPG Toolkit session environment';
+      output.appendLine('[env] terminal environment collection refreshed.');
+    } catch (error) {
+      output.appendLine(`[env] could not refresh terminal environment collection: ${maskSecretsInText(error.message)}`);
+    }
   };
-
-  const resolveOutputRoot = (root, settings) => resolveSettingPath(root, settings.get('outputRoot'), 'analysis');
-
-  function runFallbackDoctorChecks(ctx) {
-    const checks = [];
-    const cli = resolveCliInvocation(ctx.root, ctx.settings);
-    const configPath = resolveSettingPath(ctx.root, resolveConfigArg(ctx.settings), 'config/profiles.json');
-    const nodeVersion = spawnSync(process.execPath, ['--version'], { encoding: 'utf8' });
-    const javaVersion = spawnSync('java', ['-version'], {
-      cwd: ctx.root,
-      env: ctx.env,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    const javaLibDir = path.join(ctx.root, 'java', 'lib');
-    const jarCount = fs.existsSync(javaLibDir)
-      ? fs.readdirSync(javaLibDir, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.jar')).length
-      : 0;
-
-    checks.push({
-      name: 'CLI',
-      status: cli.exists ? 'PASS' : 'FAIL',
-      details: cli.exists ? `Found ${cli.cliPath}` : `CLI path not found: ${cli.cliPath}`,
-    });
-    checks.push({
-      name: 'Config',
-      status: fs.existsSync(configPath) ? 'PASS' : 'FAIL',
-      details: fs.existsSync(configPath)
-        ? `Found ${toPosix(path.relative(ctx.root, configPath) || path.basename(configPath))}`
-        : `Missing config at ${configPath}. Run "Zeus: Open Config".`,
-    });
-    checks.push({
-      name: 'Profile',
-      status: ctx.profileNames.includes(ctx.activeProfile) ? 'PASS' : 'FAIL',
-      details: ctx.profileNames.includes(ctx.activeProfile)
-        ? `Selected profile "${ctx.activeProfile}" is available.`
-        : `Selected profile "${ctx.activeProfile}" not found in config.`,
-    });
-    checks.push({
-      name: 'Node Runtime',
-      status: nodeVersion.status === 0 ? 'PASS' : 'FAIL',
-      details: nodeVersion.status === 0
-        ? String(nodeVersion.stdout || '').trim()
-        : (nodeVersion.error ? nodeVersion.error.message : String(nodeVersion.stderr || '').trim()),
-    });
-    checks.push({
-      name: 'Java Runtime',
-      status: javaVersion.status === 0 ? 'PASS' : 'FAIL',
-      details: javaVersion.status === 0
-        ? String(javaVersion.stderr || javaVersion.stdout || '').split(/\r?\n/).find(Boolean) || 'java -version'
-        : (javaVersion.error ? javaVersion.error.message : String(javaVersion.stderr || javaVersion.stdout || '').trim()),
-    });
-    checks.push({
-      name: 'Classpath Hints',
-      status: jarCount > 0 ? 'PASS' : 'WARN',
-      details: `java/lib jars=${jarCount}${fs.existsSync(path.join(javaLibDir, 'jt400.jar')) ? ', jt400.jar detected' : ', jt400.jar not detected'}`,
-    });
-    return checks;
-  }
 
   async function selectProfile(explicitProfile) {
-    const ctx = getCurrentContext();
+    const ctx = gateway.resolveContext();
     if (ctx.profileNames.length === 0) {
       throw new Error('No profiles were found. Run "Zeus: Open Config" first.');
     }
@@ -420,119 +245,94 @@ async function activate(context) {
       });
     }
     if (!selected) {
-      return;
+      return null;
     }
-    await setActiveProfile(ctx.settings, selected);
-    runtimeState.statusBar.text = `Zeus: ${selected}`;
-    appendOutput(output, `[profile] active profile set to ${selected}`);
+
+    const result = await gateway.setActiveProfile(selected);
+    runtimeState.statusBar.text = `Zeus: ${result.profile}`;
+    output.appendLine(`[profile] active profile set to ${result.profile}`);
+    applyTerminalEnvironmentCollection();
     refreshViews();
+    return result;
   }
 
-  async function openConfig() {
-    const root = ensureWorkspace();
-    const settings = getSettings(vscode.Uri.file(root));
-    const configPath = resolveSettingPath(root, settings.get('configPath'), 'config/profiles.json');
-    if (!fs.existsSync(configPath)) {
-      ensureDir(path.dirname(configPath));
-      fs.writeFileSync(configPath, `${JSON.stringify(buildExampleConfig(), null, 2)}\n`, 'utf8');
-      appendOutput(output, `[config] created example config at ${configPath}`);
+  async function showActiveEnvironmentCommand() {
+    const summary = gateway.buildEnvironmentSummary();
+    output.appendLine('[env] active environment');
+    output.appendLine(JSON.stringify(summary, null, 2));
+
+    const details = [
+      `Profile: ${summary.activeProfile || '<none>'}`,
+      `Read-only: ${summary.readOnlyMode ? 'true' : 'false'}`,
+      `Config: ${summary.configPath}`,
+      `Output: ${summary.outputRoot}`,
+    ].join(' | ');
+    vscode.window.showInformationMessage(details);
+    return summary;
+  }
+
+  async function createAgentTerminalCommand() {
+    const result = gateway.createAgentTerminal();
+    applyTerminalEnvironmentCollection();
+    output.appendLine('[terminal] Zeus Agent Terminal created.');
+    return result;
+  }
+
+  async function openConfigCommand() {
+    const ctx = gateway.resolveContext();
+    if (!fs.existsSync(ctx.configPath)) {
+      ensureDir(path.dirname(ctx.configPath));
+      fs.writeFileSync(ctx.configPath, `${JSON.stringify(buildExampleConfig(), null, 2)}\n`, 'utf8');
+      output.appendLine(`[config] created example config at ${ctx.configPath}`);
     }
-    const document = await vscode.workspace.openTextDocument(configPath);
+
+    const document = await vscode.workspace.openTextDocument(ctx.configPath);
     await vscode.window.showTextDocument(document, { preview: false });
   }
 
   async function runDoctorCommand() {
-    const ctx = getCurrentContext();
+    const ctx = gateway.resolveContext();
     if (!ctx.activeProfile) {
       throw new Error('No active profile selected. Use "Zeus: Select Profile".');
     }
-    const cli = resolveCliInvocation(ctx.root, ctx.settings);
-    runtimeState.lastDoctorChecks = [];
 
-    if (cli.exists) {
-      await vscode.window.withProgress({
-        location: vscode.ProgressLocation.Notification,
-        title: `Zeus doctor (${ctx.activeProfile})`,
-      }, async () => {
-        await runCliCommand({
-          output,
-          rootDir: ctx.root,
-          env: ctx.env,
-          settings: ctx.settings,
-          cliArgs: [...buildCliBaseArgs(ctx.settings), 'doctor', '--profile', ctx.activeProfile],
-        });
-      });
-      runtimeState.lastDoctorChecks = [
-        {
-          name: 'CLI Doctor',
-          status: 'PASS',
-          details: 'Doctor command completed successfully.',
-        },
-      ];
-      refreshViews();
-      vscode.window.showInformationMessage('Zeus doctor checks passed.');
-      return;
-    }
+    const result = await vscode.window.withProgress({
+      location: vscode.ProgressLocation.Notification,
+      title: `Zeus doctor (${ctx.activeProfile})`,
+    }, async () => gateway.runDoctor({ profile: ctx.activeProfile }));
 
-    appendOutput(output, '[doctor] CLI not reachable; running fallback checks.');
-    runtimeState.lastDoctorChecks = runFallbackDoctorChecks(ctx);
-    for (const check of runtimeState.lastDoctorChecks) {
-      appendOutput(output, `[${check.status}] ${check.name}: ${check.details}`);
-    }
+    runtimeState.lastDoctorChecks = Array.isArray(result.checks) ? result.checks : [];
     refreshViews();
-    if (runtimeState.lastDoctorChecks.some((entry) => entry.status === 'FAIL')) {
-      throw new Error('Doctor fallback checks reported failures. See "Zeus RPG Toolkit" output.');
+
+    if (result.status === 'FAIL') {
+      throw new Error(result.summary || 'Doctor failed.');
     }
-    vscode.window.showInformationMessage('Zeus fallback doctor checks passed.');
+
+    vscode.window.showInformationMessage(result.summary || 'Doctor checks passed.');
+    return result;
   }
 
   async function fetchSourcesCommand() {
-    const ctx = getCurrentContext();
+    const ctx = gateway.resolveContext();
     if (!ctx.activeProfile) {
       throw new Error('No active profile selected. Use "Zeus: Select Profile".');
     }
 
-    const cli = resolveCliInvocation(ctx.root, ctx.settings);
-    if (cli.exists) {
-      await vscode.window.withProgress({
-        location: vscode.ProgressLocation.Notification,
-        title: `Zeus fetch (${ctx.activeProfile})`,
-      }, async () => {
-        await runCliCommand({
-          output,
-          rootDir: ctx.root,
-          env: ctx.env,
-          settings: ctx.settings,
-          cliArgs: [...buildCliBaseArgs(ctx.settings), 'fetch', '--profile', ctx.activeProfile],
-        });
-        appendOutput(output, '[fetch] completed via CLI');
-      });
-    } else {
-      appendOutput(output, '[fetch] CLI not reachable, using core API fallback.');
-      await vscode.window.withProgress({
-        location: vscode.ProgressLocation.Notification,
-        title: `Zeus fetch (${ctx.activeProfile})`,
-      }, async () => {
-        const result = await fetch(ctx.activeProfile, {
-          runtime: {
-            cwd: ctx.root,
-            env: ctx.env,
-          },
-        });
-        appendOutput(output, '[fetch] completed via fallback');
-        appendOutput(output, result.summary);
-      });
+    const result = await vscode.window.withProgress({
+      location: vscode.ProgressLocation.Notification,
+      title: `Zeus fetch (${ctx.activeProfile})`,
+    }, async () => gateway.fetchSources({ profile: ctx.activeProfile }));
+
+    if (result.status === 'BLOCKED') {
+      throw new Error(result.reason);
     }
 
     refreshViews();
     vscode.window.showInformationMessage('Fetch completed.');
+    return result;
   }
 
   async function analyzeCurrentFileCommand() {
-    const ctx = getCurrentContext();
-    if (!ctx.activeProfile) {
-      throw new Error('No active profile selected. Use "Zeus: Select Profile".');
-    }
     const editor = vscode.window.activeTextEditor;
     if (!editor || !editor.document || editor.document.uri.scheme !== 'file') {
       throw new Error('Open a local source file first.');
@@ -541,117 +341,84 @@ async function activate(context) {
     const currentPath = editor.document.uri.fsPath;
     const member = path.basename(currentPath, path.extname(currentPath)).toUpperCase();
     const sourceRoot = path.dirname(currentPath);
-    const outputRoot = resolveOutputRoot(ctx.root, ctx.settings);
-
-    await vscode.window.withProgress({
-      location: vscode.ProgressLocation.Notification,
-      title: `Zeus analyze ${member}`,
-    }, async () => {
-      const result = analyze(ctx.activeProfile, {
-        runtime: {
-          cwd: ctx.root,
-          env: ctx.env,
-        },
-        source: sourceRoot,
-        member,
-        mode: 'documentation',
-        out: outputRoot,
-      });
-      appendOutput(output, '[analyze-current-file] completed');
-      appendOutput(output, {
-        member,
-        outputProgramDir: result.outputProgramDir,
-      });
+    const result = await gateway.analyzeWorkspace({
+      members: [member],
+      mode: 'documentation',
+      targetPath: sourceRoot,
     });
 
+    if (result.status === 'BLOCKED') {
+      throw new Error(result.reason);
+    }
+
+    output.appendLine(`[analyze-current-file] ${result.summary}`);
     refreshViews();
+    return result;
   }
 
   async function analyzeWorkspaceCommand() {
-    const ctx = getCurrentContext();
+    const ctx = gateway.resolveContext();
     if (!ctx.activeProfile) {
       throw new Error('No active profile selected. Use "Zeus: Select Profile".');
     }
 
-    const resolvedProfile = resolveProfile(ctx.profiles, ctx.activeProfile, { env: ctx.env });
-    const defaultSourceRoot = resolvedProfile && resolvedProfile.sourceRoot
-      ? path.resolve(ctx.root, resolvedProfile.sourceRoot)
-      : ctx.root;
-    const sourceRoot = fs.existsSync(defaultSourceRoot) ? defaultSourceRoot : ctx.root;
-    const members = collectMembers(sourceRoot);
-    if (members.length === 0) {
-      throw new Error(`No source members found in ${sourceRoot}`);
+    const memberCandidates = gateway.getMemberCandidates();
+    if (memberCandidates.members.length === 0) {
+      throw new Error(`No source members found in ${memberCandidates.sourceRoot}`);
     }
 
     const selectedMembers = await vscode.window.showQuickPick(
-      members.map((member) => ({ label: member })),
+      memberCandidates.members.map((member) => ({ label: member })),
       {
         canPickMany: true,
         placeHolder: 'Select one or more members to analyze',
       },
     );
     if (!selectedMembers || selectedMembers.length === 0) {
-      return;
+      return null;
     }
 
-    const workflowConfig = readWorkflowConfig(ctx.profiles, resolvedProfile, ctx.env);
     const modePick = await vscode.window.showQuickPick(
-      (workflowConfig.analyzeModes || ['documentation', 'defect-analysis']).map((mode) => ({
-        label: mode,
-      })),
+      gateway.getAnalyzeModeChoices().map((mode) => ({ label: mode })),
       {
         placeHolder: 'Select analyze mode',
       },
     );
     if (!modePick) {
-      return;
+      return null;
     }
 
-    const outputRoot = resolveOutputRoot(ctx.root, ctx.settings);
-    await vscode.window.withProgress({
+    const result = await vscode.window.withProgress({
       location: vscode.ProgressLocation.Notification,
       title: 'Zeus analyze workspace',
     }, async (progress) => {
-      for (let index = 0; index < selectedMembers.length; index += 1) {
-        const member = selectedMembers[index].label;
-        progress.report({
-          message: `${member} (${index + 1}/${selectedMembers.length})`,
-          increment: Math.floor(100 / selectedMembers.length),
-        });
-        const result = analyze(ctx.activeProfile, {
-          runtime: {
-            cwd: ctx.root,
-            env: ctx.env,
-          },
-          source: sourceRoot,
-          member,
-          mode: modePick.label,
-          out: outputRoot,
-        });
-        appendOutput(output, {
-          type: 'analyze-workspace',
-          member,
-          outputProgramDir: result.outputProgramDir,
-        });
-      }
+      progress.report({ message: `Analyzing ${selectedMembers.length} member(s)` });
+      return gateway.analyzeWorkspace({
+        profile: ctx.activeProfile,
+        mode: modePick.label,
+        members: selectedMembers.map((entry) => entry.label),
+        targetPath: memberCandidates.sourceRoot,
+      });
     });
 
+    if (result.status === 'BLOCKED') {
+      throw new Error(result.reason);
+    }
+
+    output.appendLine(`[analyze-workspace] ${result.summary}`);
     refreshViews();
+    return result;
   }
 
   async function queryTableCommand() {
-    const ctx = getCurrentContext();
-    if (!ctx.activeProfile) {
-      throw new Error('No active profile selected. Use "Zeus: Select Profile".');
-    }
-
     const table = await vscode.window.showInputBox({
       prompt: 'DB table name (required)',
       placeHolder: 'CUSTOMERS',
     });
     if (!table) {
-      return;
+      return null;
     }
+
     const schema = await vscode.window.showInputBox({
       prompt: 'Schema (optional)',
       placeHolder: 'MYLIB',
@@ -661,160 +428,124 @@ async function activate(context) {
       placeHolder: 'CUST%',
     });
 
-    const result = queryTable(ctx.activeProfile, table, {
-      runtime: {
-        cwd: ctx.root,
-        env: ctx.env,
-      },
-      schema: schema || undefined,
-      filter: filter || undefined,
+    const result = await gateway.queryTableMetadata({
+      table,
+      schema: schema || '',
+      filter: filter || '',
     });
 
-    appendOutput(output, '[query-table] completed');
-    appendOutput(output, {
-      table: result.table,
-      schema: result.schema,
-      tableRows: Array.isArray(result.tableInfo.rows) ? result.tableInfo.rows.length : 0,
-      columnRows: Array.isArray(result.columns.rows) ? result.columns.rows.length : 0,
-    });
+    if (result.status === 'BLOCKED') {
+      throw new Error(result.reason);
+    }
 
-    const outputRoot = resolveOutputRoot(ctx.root, ctx.settings);
-    const queryRoot = path.join(outputRoot, 'queries');
-    ensureDir(queryRoot);
-    const targetPath = path.join(queryRoot, `${new Date().toISOString().replace(/[:.]/g, '-')}-${String(result.table).toUpperCase()}.json`);
-    fs.writeFileSync(targetPath, `${JSON.stringify(sanitizeValue({
-      table: result.table,
-      schema: result.schema,
-      filter: result.filter,
-      tableInfo: result.tableInfo.rows || [],
-      columns: result.columns.rows || [],
-    }), null, 2)}\n`, 'utf8');
-    const document = await vscode.workspace.openTextDocument(targetPath);
-    await vscode.window.showTextDocument(document, { preview: false });
+    if (result.reportPath) {
+      const ctx = gateway.resolveContext();
+      const absolutePath = path.resolve(ctx.rootDir, result.reportPath);
+      const document = await vscode.workspace.openTextDocument(absolutePath);
+      await vscode.window.showTextDocument(document, { preview: false });
+    }
 
     refreshViews();
+    return result;
   }
 
   async function runWorkflowCommand() {
-    const ctx = getCurrentContext();
+    const ctx = gateway.resolveContext();
     if (!ctx.activeProfile) {
       throw new Error('No active profile selected. Use "Zeus: Select Profile".');
     }
 
-    const readOnlyMode = Boolean(ctx.settings.get('readOnlyMode'));
-    if (!readOnlyMode) {
+    if (!ctx.readOnlyMode) {
       const confirmation = await vscode.window.showWarningMessage(
         'Read-only mode is disabled. Continue with workflow execution?',
         { modal: true },
         'Continue',
       );
       if (confirmation !== 'Continue') {
-        return;
+        return null;
       }
     }
 
     const resolvedProfile = resolveProfile(ctx.profiles, ctx.activeProfile, { env: ctx.env });
     const workflowConfig = readWorkflowConfig(ctx.profiles, resolvedProfile, ctx.env);
     const presetNames = Object.keys(workflowConfig.presets || {}).sort((left, right) => left.localeCompare(right));
-    const quickPickItems = [
-      { label: '(Use Default Preset)', preset: '' },
-      ...presetNames.map((name) => ({ label: name, preset: name })),
-    ];
-    const presetPick = await vscode.window.showQuickPick(quickPickItems, {
-      placeHolder: 'Select workflow preset',
-    });
+    const presetPick = await vscode.window.showQuickPick(
+      [
+        { label: '(Use Default Preset)', preset: '' },
+        ...presetNames.map((name) => ({ label: name, preset: name })),
+      ],
+      { placeHolder: 'Select workflow preset' },
+    );
     if (!presetPick) {
-      return;
+      return null;
     }
 
-    const outputRoot = resolveOutputRoot(ctx.root, ctx.settings);
-    const cli = resolveCliInvocation(ctx.root, ctx.settings);
-    if (cli.exists) {
-      const cliArgs = [...buildCliBaseArgs(ctx.settings), 'workflow', 'run', '--profile', ctx.activeProfile, '--out', outputRoot];
-      if (presetPick.preset) {
-        cliArgs.push('--preset', presetPick.preset);
-      }
-      await vscode.window.withProgress({
-        location: vscode.ProgressLocation.Notification,
-        title: `Zeus workflow (${ctx.activeProfile})`,
-      }, async () => {
-        await runCliCommand({
-          output,
-          rootDir: ctx.root,
-          env: ctx.env,
-          settings: ctx.settings,
-          cliArgs,
-        });
-        appendOutput(output, '[workflow] completed via CLI');
-      });
-    } else {
-      appendOutput(output, '[workflow] CLI not reachable, using core API fallback.');
-      const workflowState = await vscode.window.withProgress({
-        location: vscode.ProgressLocation.Notification,
-        title: `Zeus workflow (${ctx.activeProfile})`,
-      }, async () => runWorkflow(ctx.activeProfile, presetPick.preset, {
-        runtime: {
-          cwd: ctx.root,
-          env: ctx.env,
-        },
-        out: outputRoot,
-      }));
+    const workflowState = await vscode.window.withProgress({
+      location: vscode.ProgressLocation.Notification,
+      title: `Zeus workflow (${ctx.activeProfile})`,
+    }, async () => runWorkflow(ctx.activeProfile, presetPick.preset, {
+      runtime: {
+        cwd: ctx.rootDir,
+        env: ctx.env,
+      },
+      out: ctx.outputRoot,
+    }));
 
-      appendOutput(output, '[workflow] completed via fallback');
-      appendOutput(output, {
-        status: workflowState.status,
-        runId: workflowState.runId,
-        runRoot: workflowState.paths.runRoot,
-        reportPath: workflowState.paths.reportPath,
-      });
-    }
+    output.appendLine('[workflow] completed via core API fallback path');
+    output.appendLine(JSON.stringify(sanitizeValue({
+      status: workflowState.status,
+      runId: workflowState.runId,
+      runRoot: workflowState.paths.runRoot,
+      reportPath: workflowState.paths.reportPath,
+    }), null, 2));
 
-    const latestReports = findLatestFiles(outputRoot, (entry) => path.basename(entry).toLowerCase() === 'report.md', 1);
-    if (latestReports.length > 0) {
-      const document = await vscode.workspace.openTextDocument(latestReports[0].absolutePath);
+    const latest = await gateway.getLatestReport();
+    if (latest && latest.absolutePath) {
+      const document = await vscode.workspace.openTextDocument(latest.absolutePath);
       await vscode.window.showTextDocument(document, { preview: false });
     }
 
     refreshViews();
+    return workflowState;
   }
 
   async function openLatestReportCommand() {
-    const ctx = getCurrentContext();
-    const outputRoot = resolveOutputRoot(ctx.root, ctx.settings);
-    const reports = findLatestFiles(outputRoot, (entry) => path.basename(entry).toLowerCase() === 'report.md', 1);
-    if (reports.length === 0) {
-      throw new Error(`No report.md found under ${outputRoot}`);
+    const latest = await gateway.getLatestReport();
+    if (!latest || latest.status !== 'PASS' || !latest.absolutePath) {
+      throw new Error('No report.md found under current output root.');
     }
-    const document = await vscode.workspace.openTextDocument(reports[0].absolutePath);
+
+    const document = await vscode.workspace.openTextDocument(latest.absolutePath);
     await vscode.window.showTextDocument(document, { preview: false });
+    return latest;
   }
 
   async function openDashboardCommand() {
-    const ctx = getCurrentContext();
-    const outputRoot = resolveOutputRoot(ctx.root, ctx.settings);
-    const reportEntries = findLatestFiles(outputRoot, (entry) => path.basename(entry).toLowerCase() === 'report.md', 5);
-    const aiEntries = findLatestFiles(outputRoot, (entry) => path.basename(entry).toLowerCase() === 'ai_prompt.md', 5);
-    const dashboardPath = path.join(ctx.root, '.local', 'zeus-dashboard.md');
+    const ctx = gateway.resolveContext();
+    const reportEntries = findLatestFiles(ctx.outputRoot, (entry) => path.basename(entry).toLowerCase() === 'report.md', 5);
+    const aiEntries = findLatestFiles(ctx.outputRoot, (entry) => path.basename(entry).toLowerCase() === 'ai_prompt.md', 5);
+    const dashboardPath = path.join(ctx.rootDir, '.local', 'zeus-dashboard.md');
     ensureDir(path.dirname(dashboardPath));
 
     const content = [
       '# Zeus RPG Toolkit Dashboard',
       '',
       `- Active profile: ${ctx.activeProfile || '<none>'}`,
-      `- Config: ${resolveSettingPath(ctx.root, ctx.settings.get('configPath'), 'config/profiles.json')}`,
-      `- Output root: ${outputRoot}`,
-      `- Read-only mode: ${Boolean(ctx.settings.get('readOnlyMode'))}`,
+      `- Config: ${toPosix(path.relative(ctx.rootDir, ctx.configPath) || path.basename(ctx.configPath))}`,
+      `- Output root: ${toPosix(path.relative(ctx.rootDir, ctx.outputRoot) || '.')}`,
+      `- Read-only mode: ${ctx.readOnlyMode}`,
       '',
       '## Latest Reports',
-      ...(reportEntries.length > 0 ? reportEntries.map((entry) => `- ${toPosix(path.relative(ctx.root, entry.absolutePath))}`) : ['- none']),
+      ...(reportEntries.length > 0 ? reportEntries.map((entry) => `- ${toPosix(path.relative(ctx.rootDir, entry.absolutePath))}`) : ['- none']),
       '',
       '## Latest AI Prompts',
-      ...(aiEntries.length > 0 ? aiEntries.map((entry) => `- ${toPosix(path.relative(ctx.root, entry.absolutePath))}`) : ['- none']),
+      ...(aiEntries.length > 0 ? aiEntries.map((entry) => `- ${toPosix(path.relative(ctx.rootDir, entry.absolutePath))}`) : ['- none']),
       '',
       '## Commands',
       '- Zeus: Select Profile',
+      '- Zeus: Show Active Environment',
+      '- Zeus: Create Agent Terminal',
       '- Zeus: Run Doctor',
-      '- Zeus: Run Workflow',
       '- Zeus: Generate AI Context',
       '- Zeus: Open Latest Report',
     ].join('\n');
@@ -825,7 +556,7 @@ async function activate(context) {
   }
 
   async function generateAiContextCommand() {
-    const ctx = getCurrentContext();
+    const ctx = gateway.resolveContext();
     if (!Boolean(ctx.settings.get('enableAgentMode'))) {
       throw new Error('Agent mode is disabled in settings.');
     }
@@ -834,36 +565,41 @@ async function activate(context) {
       prompt: 'Optional ticket/task context for AI prompt',
       placeHolder: 'Ticket-123: add XYZ validation',
     }) || '';
-    const outputRoot = resolveOutputRoot(ctx.root, ctx.settings);
 
-    const result = generateAiContextBundle({
-      workspaceRoot: ctx.root,
-      outputRoot,
-      activeProfile: ctx.activeProfile,
-      taskContext,
-      selectedPaths: Array.from(selectionState.values()),
-      timestamp: new Date(),
-    });
-    await context.workspaceState.update(LAST_AI_PROMPT_KEY, result.files.aiPrompt);
+    const result = await gateway.generateAiContext(
+      {
+        profile: ctx.activeProfile,
+        ticket: taskContext,
+        selectedFiles: Array.from(selectionState.values()),
+        includeLatestReport: true,
+      },
+      Array.from(selectionState.values()),
+    );
 
-    appendOutput(output, '[ai-context] generated');
-    appendOutput(output, result);
+    if (result.status === 'BLOCKED') {
+      throw new Error(result.reason);
+    }
 
-    const document = await vscode.workspace.openTextDocument(result.files.aiPrompt);
-    await vscode.window.showTextDocument(document, { preview: false });
+    if (result.files && result.files.ai_prompt_md) {
+      const document = await vscode.workspace.openTextDocument(path.resolve(ctx.rootDir, result.files.ai_prompt_md));
+      await vscode.window.showTextDocument(document, { preview: false });
+    }
+
+    output.appendLine('[ai-context] generated');
+    output.appendLine(JSON.stringify(sanitizeValue(result), null, 2));
     refreshViews();
+    return result;
   }
 
   async function copyAiPromptToClipboardCommand() {
-    const ctx = getCurrentContext();
-    const outputRoot = resolveOutputRoot(ctx.root, ctx.settings);
+    const ctx = gateway.resolveContext();
     const lastPrompt = context.workspaceState.get(LAST_AI_PROMPT_KEY, '');
     let promptPath = '';
 
     if (lastPrompt && fs.existsSync(lastPrompt)) {
       promptPath = lastPrompt;
     } else {
-      const latest = findLatestFiles(outputRoot, (entry) => path.basename(entry).toLowerCase() === 'ai_prompt.md', 1);
+      const latest = findLatestFiles(ctx.outputRoot, (entry) => path.basename(entry).toLowerCase() === 'ai_prompt.md', 1);
       promptPath = latest.length > 0 ? latest[0].absolutePath : '';
     }
     if (!promptPath) {
@@ -876,7 +612,7 @@ async function activate(context) {
   }
 
   async function addPathSelectionCommand(uri, expectedFolder) {
-    const root = ensureWorkspace();
+    const ctx = gateway.resolveContext();
     let targetPath = '';
     if (uri && uri.fsPath) {
       targetPath = uri.fsPath;
@@ -897,30 +633,44 @@ async function activate(context) {
       }
     }
 
-    const relative = resolveSafeRelativePath(root, targetPath);
+    const relative = resolveSafeRelativePath(ctx.rootDir, targetPath);
     if (!relative) {
       throw new Error('Only paths inside the current workspace can be added.');
     }
+
     selectionState.add(relative);
     await persistSelectionState();
-    appendOutput(output, `[ai-context] added ${relative}`);
+    output.appendLine(`[ai-context] added ${relative}`);
     refreshViews();
   }
 
   async function clearAiContextSelectionCommand() {
     selectionState.clear();
     await persistSelectionState();
-    appendOutput(output, '[ai-context] selection cleared');
+    output.appendLine('[ai-context] selection cleared');
     refreshViews();
   }
 
+  async function invokeAgentToolCommand(toolName, input) {
+    const result = await gateway.runAgentTool(
+      toolName,
+      input || {},
+      Array.from(selectionState.values()),
+    );
+    output.appendLine(`[agent-tool] ${toolName || '<unknown>'} -> ${result.status}`);
+    output.appendLine(JSON.stringify(sanitizeValue(result), null, 2));
+    return result;
+  }
+
   const profilesProvider = new SimpleTreeProvider(async () => {
-    const ctx = getCurrentContext();
+    const ctx = gateway.resolveContext();
     const items = [];
+
     if (!ctx.activeProfile) {
       items.push(new vscode.TreeItem('No active profile', vscode.TreeItemCollapsibleState.None));
       return items;
     }
+
     items.push(new vscode.TreeItem(`Active: ${ctx.activeProfile}`, vscode.TreeItemCollapsibleState.None));
     for (const profile of ctx.profileNames) {
       const item = new vscode.TreeItem(profile, vscode.TreeItemCollapsibleState.None);
@@ -935,16 +685,18 @@ async function activate(context) {
   });
 
   const workflowsProvider = new SimpleTreeProvider(async () => {
-    const ctx = getCurrentContext();
+    const ctx = gateway.resolveContext();
     if (!ctx.activeProfile) {
       return [new vscode.TreeItem('No active profile', vscode.TreeItemCollapsibleState.None)];
     }
+
     const profile = resolveProfile(ctx.profiles, ctx.activeProfile, { env: ctx.env });
     const workflowConfig = readWorkflowConfig(ctx.profiles, profile, ctx.env);
     const presetNames = Object.keys(workflowConfig.presets || {}).sort((left, right) => left.localeCompare(right));
     if (presetNames.length === 0) {
       return [new vscode.TreeItem('No workflow presets configured', vscode.TreeItemCollapsibleState.None)];
     }
+
     return presetNames.map((presetName) => {
       const item = new vscode.TreeItem(presetName, vscode.TreeItemCollapsibleState.None);
       item.description = (workflowConfig.presets[presetName].steps || []).join(', ');
@@ -957,36 +709,39 @@ async function activate(context) {
   });
 
   const fetchedSourcesProvider = new SimpleTreeProvider(async () => {
-    const root = ensureWorkspace();
+    const ctx = gateway.resolveContext();
     const candidates = [];
-    const defaultFetchRoot = path.join(root, 'rpg_sources');
+    const defaultFetchRoot = path.join(ctx.rootDir, 'rpg_sources');
     if (fs.existsSync(defaultFetchRoot)) {
-      const item = new vscode.TreeItem(toPosix(path.relative(root, defaultFetchRoot)), vscode.TreeItemCollapsibleState.None);
+      const item = new vscode.TreeItem(toPosix(path.relative(ctx.rootDir, defaultFetchRoot)), vscode.TreeItemCollapsibleState.None);
       item.resourceUri = vscode.Uri.file(defaultFetchRoot);
       candidates.push(item);
     }
-    const runFetchRoots = findLatestFiles(path.join(root, 'analysis'), (entry) => entry.toLowerCase().endsWith(`${path.sep}fetch${path.sep}zeus-import-manifest.json`), 10)
+
+    const runFetchRoots = findLatestFiles(path.join(ctx.rootDir, 'analysis'), (entry) => entry.toLowerCase().endsWith(`${path.sep}fetch${path.sep}zeus-import-manifest.json`), 10)
       .map((entry) => path.dirname(entry.absolutePath));
     for (const fetchRoot of runFetchRoots) {
-      const item = new vscode.TreeItem(toPosix(path.relative(root, fetchRoot)), vscode.TreeItemCollapsibleState.None);
+      const item = new vscode.TreeItem(toPosix(path.relative(ctx.rootDir, fetchRoot)), vscode.TreeItemCollapsibleState.None);
       item.resourceUri = vscode.Uri.file(fetchRoot);
       candidates.push(item);
     }
+
     if (candidates.length === 0) {
       return [new vscode.TreeItem('No fetched sources found', vscode.TreeItemCollapsibleState.None)];
     }
+
     return candidates;
   });
 
   const reportsProvider = new SimpleTreeProvider(async () => {
-    const ctx = getCurrentContext();
-    const outputRoot = resolveOutputRoot(ctx.root, ctx.settings);
-    const reports = findLatestFiles(outputRoot, (entry) => path.basename(entry).toLowerCase() === 'report.md', 15);
+    const ctx = gateway.resolveContext();
+    const reports = findLatestFiles(ctx.outputRoot, (entry) => path.basename(entry).toLowerCase() === 'report.md', 15);
     if (reports.length === 0) {
       return [new vscode.TreeItem('No reports found', vscode.TreeItemCollapsibleState.None)];
     }
+
     return reports.map((entry) => {
-      const item = new vscode.TreeItem(toPosix(path.relative(ctx.root, entry.absolutePath)), vscode.TreeItemCollapsibleState.None);
+      const item = new vscode.TreeItem(toPosix(path.relative(ctx.rootDir, entry.absolutePath)), vscode.TreeItemCollapsibleState.None);
       item.command = {
         command: 'vscode.open',
         title: 'Open Report',
@@ -997,16 +752,16 @@ async function activate(context) {
   });
 
   const aiContextProvider = new SimpleTreeProvider(async () => {
-    const ctx = getCurrentContext();
-    const outputRoot = resolveOutputRoot(ctx.root, ctx.settings);
-    const items = [];
-    items.push(new vscode.TreeItem(`Selected Paths: ${selectionState.size}`, vscode.TreeItemCollapsibleState.None));
+    const ctx = gateway.resolveContext();
+    const prompts = findLatestFiles(ctx.outputRoot, (entry) => path.basename(entry).toLowerCase() === 'ai_prompt.md', 10);
+    const items = [new vscode.TreeItem(`Selected Paths: ${selectionState.size}`, vscode.TreeItemCollapsibleState.None)];
+
     for (const selected of Array.from(selectionState.values()).sort((left, right) => left.localeCompare(right))) {
       items.push(new vscode.TreeItem(`- ${selected}`, vscode.TreeItemCollapsibleState.None));
     }
-    const prompts = findLatestFiles(outputRoot, (entry) => path.basename(entry).toLowerCase() === 'ai_prompt.md', 10);
+
     for (const prompt of prompts) {
-      const item = new vscode.TreeItem(toPosix(path.relative(ctx.root, prompt.absolutePath)), vscode.TreeItemCollapsibleState.None);
+      const item = new vscode.TreeItem(toPosix(path.relative(ctx.rootDir, prompt.absolutePath)), vscode.TreeItemCollapsibleState.None);
       item.command = {
         command: 'vscode.open',
         title: 'Open AI Prompt',
@@ -1014,6 +769,7 @@ async function activate(context) {
       };
       items.push(item);
     }
+
     return items;
   });
 
@@ -1023,7 +779,7 @@ async function activate(context) {
     }
     return runtimeState.lastDoctorChecks.map((check) => {
       const item = new vscode.TreeItem(`[${check.status}] ${check.name}`, vscode.TreeItemCollapsibleState.None);
-      item.description = maskSecretsInText(check.details);
+      item.description = maskSecretsInText(check.details || '');
       return item;
     });
   });
@@ -1047,121 +803,40 @@ async function activate(context) {
     vscode.window.registerTreeDataProvider('zeusAiContextView', aiContextProvider),
     vscode.window.registerTreeDataProvider('zeusDiagnosticsView', diagnosticsProvider),
     vscode.commands.registerCommand('zeusRpgToolkit.refreshViews', refreshViews),
-    vscode.commands.registerCommand('zeusRpgToolkit.openConfig', async () => {
-      try {
-        await openConfig();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.selectProfile', async (profile) => {
-      try {
-        await selectProfile(profile);
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.runDoctor', async () => {
-      try {
-        await runDoctorCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.fetchSources', async () => {
-      try {
-        await fetchSourcesCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.analyzeWorkspace', async () => {
-      try {
-        await analyzeWorkspaceCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.analyzeCurrentFile', async () => {
-      try {
-        await analyzeCurrentFileCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.queryTable', async () => {
-      try {
-        await queryTableCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.runWorkflow', async () => {
-      try {
-        await runWorkflowCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.openLatestReport', async () => {
-      try {
-        await openLatestReportCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.openDashboard', async () => {
-      try {
-        await openDashboardCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.generateAiContext', async () => {
-      try {
-        await generateAiContextCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.copyAiPromptToClipboard', async () => {
-      try {
-        await copyAiPromptToClipboardCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.addFileToAiContext', async (uri) => {
-      try {
-        await addPathSelectionCommand(uri, false);
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.addFolderToAiContext', async (uri) => {
-      try {
-        await addPathSelectionCommand(uri, true);
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
-    vscode.commands.registerCommand('zeusRpgToolkit.clearAiContextSelection', async () => {
-      try {
-        await clearAiContextSelectionCommand();
-      } catch (error) {
-        vscode.window.showErrorMessage(maskSecretsInText(error.message));
-      }
-    }),
+    vscode.commands.registerCommand('zeusRpgToolkit.openConfig', createGuardedCommand(output, openConfigCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.selectProfile', createGuardedCommand(output, async (profile) => selectProfile(profile))),
+    vscode.commands.registerCommand('zeusRpgToolkit.showActiveEnvironment', createGuardedCommand(output, showActiveEnvironmentCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.createAgentTerminal', createGuardedCommand(output, createAgentTerminalCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.runDoctor', createGuardedCommand(output, runDoctorCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.fetchSources', createGuardedCommand(output, fetchSourcesCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.analyzeWorkspace', createGuardedCommand(output, analyzeWorkspaceCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.analyzeCurrentFile', createGuardedCommand(output, analyzeCurrentFileCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.queryTable', createGuardedCommand(output, queryTableCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.runWorkflow', createGuardedCommand(output, runWorkflowCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.openLatestReport', createGuardedCommand(output, openLatestReportCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.openDashboard', createGuardedCommand(output, openDashboardCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.generateAiContext', createGuardedCommand(output, generateAiContextCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.copyAiPromptToClipboard', createGuardedCommand(output, copyAiPromptToClipboardCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.addFileToAiContext', createGuardedCommand(output, async (uri) => addPathSelectionCommand(uri, false))),
+    vscode.commands.registerCommand('zeusRpgToolkit.addFolderToAiContext', createGuardedCommand(output, async (uri) => addPathSelectionCommand(uri, true))),
+    vscode.commands.registerCommand('zeusRpgToolkit.clearAiContextSelection', createGuardedCommand(output, clearAiContextSelectionCommand)),
+    vscode.commands.registerCommand('zeusRpgToolkit.invokeAgentTool', createGuardedCommand(output, async (toolName, input) => invokeAgentToolCommand(toolName, input))),
+    vscode.commands.registerCommand('zeusRpgToolkit.listAgentTools', createGuardedCommand(output, async () => gateway.getAgentTools())),
   );
 
-  try {
-    const ctx = getCurrentContext();
-    if (ctx.activeProfile) {
-      runtimeState.statusBar.text = `Zeus: ${ctx.activeProfile}`;
-    }
-  } catch (_) {
-    runtimeState.statusBar.text = 'Zeus: <no workspace>';
+  for (const toolName of AGENT_TOOL_COMMANDS) {
+    const commandId = `zeusRpgToolkit.tool.${toolName}`;
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        commandId,
+        createGuardedCommand(output, async (input) => invokeAgentToolCommand(toolName, input)),
+      ),
+    );
   }
+
+  updateStatusBar();
+  applyTerminalEnvironmentCollection();
+  refreshViews();
 }
 
 function deactivate() {}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,210 +1,252 @@
 {
-  "name": "zeus-rpg-toolkit-vscode",
-  "displayName": "Zeus RPG Toolkit",
-  "description": "VS Code integration for IBM i / RPG analysis and AI agent coding workflows",
-  "version": "0.1.0",
-  "publisher": "zeus-rpg-toolkit",
-  "engines": {
-    "vscode": "^1.90.0"
-  },
-  "categories": [
-    "Other"
-  ],
-  "main": "./extension.js",
-  "activationEvents": [
-    "onStartupFinished"
-  ],
-  "contributes": {
-    "commands": [
-      {
-        "command": "zeusRpgToolkit.openDashboard",
-        "title": "Zeus: Open Dashboard"
-      },
-      {
-        "command": "zeusRpgToolkit.selectProfile",
-        "title": "Zeus: Select Profile"
-      },
-      {
-        "command": "zeusRpgToolkit.runDoctor",
-        "title": "Zeus: Run Doctor"
-      },
-      {
-        "command": "zeusRpgToolkit.fetchSources",
-        "title": "Zeus: Fetch Sources"
-      },
-      {
-        "command": "zeusRpgToolkit.analyzeWorkspace",
-        "title": "Zeus: Analyze Workspace"
-      },
-      {
-        "command": "zeusRpgToolkit.analyzeCurrentFile",
-        "title": "Zeus: Analyze Current File"
-      },
-      {
-        "command": "zeusRpgToolkit.queryTable",
-        "title": "Zeus: Query Table"
-      },
-      {
-        "command": "zeusRpgToolkit.generateAiContext",
-        "title": "Zeus: Generate AI Context"
-      },
-      {
-        "command": "zeusRpgToolkit.copyAiPromptToClipboard",
-        "title": "Zeus: Copy AI Prompt to Clipboard"
-      },
-      {
-        "command": "zeusRpgToolkit.runWorkflow",
-        "title": "Zeus: Run Workflow"
-      },
-      {
-        "command": "zeusRpgToolkit.openLatestReport",
-        "title": "Zeus: Open Latest Report"
-      },
-      {
-        "command": "zeusRpgToolkit.openConfig",
-        "title": "Zeus: Open Config"
-      },
-      {
-        "command": "zeusRpgToolkit.addFileToAiContext",
-        "title": "Zeus: Add File to AI Context"
-      },
-      {
-        "command": "zeusRpgToolkit.addFolderToAiContext",
-        "title": "Zeus: Add Folder to AI Context"
-      },
-      {
-        "command": "zeusRpgToolkit.clearAiContextSelection",
-        "title": "Zeus: Clear AI Context Selection"
-      },
-      {
-        "command": "zeusRpgToolkit.refreshViews",
-        "title": "Refresh",
-        "icon": "$(refresh)"
-      }
-    ],
-    "configuration": {
-      "title": "Zeus RPG Toolkit",
-      "properties": {
-        "zeusRpgToolkit.configPath": {
-          "type": "string",
-          "default": "config/profiles.json",
-          "markdownDescription": "Relative or absolute path to `profiles.json`."
-        },
-        "zeusRpgToolkit.defaultProfile": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Active Zeus profile name from `profiles.json`."
-        },
-        "zeusRpgToolkit.outputRoot": {
-          "type": "string",
-          "default": "analysis",
-          "markdownDescription": "Root output folder used by workflow and AI context commands."
-        },
-        "zeusRpgToolkit.readOnlyMode": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Read-only safety mode. Enabled by default."
-        },
-        "zeusRpgToolkit.enableAgentMode": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable AI context generation and agent-oriented commands."
-        },
-        "zeusRpgToolkit.javaPath": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Optional Java runtime path. Can point to a directory or executable."
-        },
-        "zeusRpgToolkit.cliPath": {
-          "type": "string",
-          "default": "cli/zeus.js",
-          "markdownDescription": "Relative or absolute path to the Zeus CLI entry file."
-        }
-      }
-    },
-    "viewContainers": {
-      "activitybar": [
-        {
-          "id": "zeusRpgToolkit",
-          "title": "Zeus RPG Toolkit",
-          "icon": "resources/zeus.svg"
-        }
-      ]
-    },
-    "views": {
-      "zeusRpgToolkit": [
-        {
-          "id": "zeusProfilesView",
-          "name": "Profiles"
-        },
-        {
-          "id": "zeusWorkflowsView",
-          "name": "Workflows"
-        },
-        {
-          "id": "zeusFetchedSourcesView",
-          "name": "Fetched Sources"
-        },
-        {
-          "id": "zeusReportsView",
-          "name": "Reports"
-        },
-        {
-          "id": "zeusAiContextView",
-          "name": "AI Context Bundles"
-        },
-        {
-          "id": "zeusDiagnosticsView",
-          "name": "Diagnostics"
-        }
-      ]
-    },
-    "menus": {
-      "explorer/context": [
-        {
-          "command": "zeusRpgToolkit.addFileToAiContext",
-          "when": "resourceScheme == file && !explorerResourceIsFolder",
-          "group": "navigation@20"
-        },
-        {
-          "command": "zeusRpgToolkit.addFolderToAiContext",
-          "when": "resourceScheme == file && explorerResourceIsFolder",
-          "group": "navigation@21"
-        }
-      ],
-      "view/title": [
-        {
-          "command": "zeusRpgToolkit.refreshViews",
-          "when": "view == zeusProfilesView",
-          "group": "navigation"
-        },
-        {
-          "command": "zeusRpgToolkit.refreshViews",
-          "when": "view == zeusWorkflowsView",
-          "group": "navigation"
-        },
-        {
-          "command": "zeusRpgToolkit.refreshViews",
-          "when": "view == zeusFetchedSourcesView",
-          "group": "navigation"
-        },
-        {
-          "command": "zeusRpgToolkit.refreshViews",
-          "when": "view == zeusReportsView",
-          "group": "navigation"
-        },
-        {
-          "command": "zeusRpgToolkit.refreshViews",
-          "when": "view == zeusAiContextView",
-          "group": "navigation"
-        },
-        {
-          "command": "zeusRpgToolkit.refreshViews",
-          "when": "view == zeusDiagnosticsView",
-          "group": "navigation"
-        }
-      ]
-    }
-  }
+    "name":  "zeus-rpg-toolkit-vscode",
+    "displayName":  "Zeus RPG Toolkit",
+    "description":  "VS Code integration for IBM i / RPG analysis and AI agent coding workflows",
+    "version":  "0.1.0",
+    "publisher":  "zeus-rpg-toolkit",
+    "engines":  {
+                    "vscode":  "^1.90.0"
+                },
+    "categories":  [
+                       "Other"
+                   ],
+    "main":  "./extension.js",
+    "activationEvents":  [
+                             "onStartupFinished"
+                         ],
+    "contributes":  {
+                        "commands":  [
+                                         {
+                                             "command":  "zeusRpgToolkit.openDashboard",
+                                             "title":  "Zeus: Open Dashboard"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.selectProfile",
+                                             "title":  "Zeus: Select Profile"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.runDoctor",
+                                             "title":  "Zeus: Run Doctor"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.fetchSources",
+                                             "title":  "Zeus: Fetch Sources"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.analyzeWorkspace",
+                                             "title":  "Zeus: Analyze Workspace"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.analyzeCurrentFile",
+                                             "title":  "Zeus: Analyze Current File"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.queryTable",
+                                             "title":  "Zeus: Query Table"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.generateAiContext",
+                                             "title":  "Zeus: Generate AI Context"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.copyAiPromptToClipboard",
+                                             "title":  "Zeus: Copy AI Prompt to Clipboard"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.runWorkflow",
+                                             "title":  "Zeus: Run Workflow"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.openLatestReport",
+                                             "title":  "Zeus: Open Latest Report"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.openConfig",
+                                             "title":  "Zeus: Open Config"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.addFileToAiContext",
+                                             "title":  "Zeus: Add File to AI Context"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.addFolderToAiContext",
+                                             "title":  "Zeus: Add Folder to AI Context"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.clearAiContextSelection",
+                                             "title":  "Zeus: Clear AI Context Selection"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.refreshViews",
+                                             "title":  "Refresh",
+                                             "icon":  "$(refresh)"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.showActiveEnvironment",
+                                             "title":  "Zeus: Show Active Environment"
+                                         },
+                                         {
+                                             "command":  "zeusRpgToolkit.createAgentTerminal",
+                                             "title":  "Zeus: Create Agent Terminal"
+                                         }
+                                     ],
+                        "configuration":  {
+                                              "title":  "Zeus RPG Toolkit",
+                                              "properties":  {
+                                                                 "zeusRpgToolkit.configPath":  {
+                                                                                                   "type":  "string",
+                                                                                                   "default":  "config/profiles.json",
+                                                                                                   "markdownDescription":  "Relative or absolute path to `profiles.json`."
+                                                                                               },
+                                                                 "zeusRpgToolkit.defaultProfile":  {
+                                                                                                       "type":  "string",
+                                                                                                       "default":  "",
+                                                                                                       "markdownDescription":  "Active Zeus profile name from `profiles.json`."
+                                                                                                   },
+                                                                 "zeusRpgToolkit.outputRoot":  {
+                                                                                                   "type":  "string",
+                                                                                                   "default":  "analysis",
+                                                                                                   "markdownDescription":  "Root output folder used by workflow and AI context commands."
+                                                                                               },
+                                                                 "zeusRpgToolkit.readOnlyMode":  {
+                                                                                                     "type":  "boolean",
+                                                                                                     "default":  true,
+                                                                                                     "markdownDescription":  "Read-only safety mode. Enabled by default."
+                                                                                                 },
+                                                                 "zeusRpgToolkit.enableAgentMode":  {
+                                                                                                        "type":  "boolean",
+                                                                                                        "default":  true,
+                                                                                                        "markdownDescription":  "Enable AI context generation and agent-oriented commands."
+                                                                                                    },
+                                                                 "zeusRpgToolkit.javaPath":  {
+                                                                                                 "type":  "string",
+                                                                                                 "default":  "",
+                                                                                                 "markdownDescription":  "Optional Java runtime path. Can point to a directory or executable."
+                                                                                             },
+                                                                 "zeusRpgToolkit.cliPath":  {
+                                                                                                "type":  "string",
+                                                                                                "default":  "cli/zeus.js",
+                                                                                                "markdownDescription":  "Relative or absolute path to the Zeus CLI entry file."
+                                                                                            },
+                                                                 "zeusRpgToolkit.env.ZEUS_CONFIG_DIR":  {
+                                                                                                            "markdownDescription":  "Optional ZEUS_CONFIG_DIR override for Zeus subprocesses (directory or profiles.json path).",
+                                                                                                            "default":  "",
+                                                                                                            "type":  "string"
+                                                                                                        },
+                                                                 "zeusRpgToolkit.env.ZEUS_OUTPUT_ROOT":  {
+                                                                                                             "markdownDescription":  "Optional ZEUS_OUTPUT_ROOT override for Zeus subprocesses and agent terminals.",
+                                                                                                             "default":  "",
+                                                                                                             "type":  "string"
+                                                                                                         },
+                                                                 "zeusRpgToolkit.env.ZEUS_PROFILE":  {
+                                                                                                         "markdownDescription":  "Optional ZEUS_PROFILE override for Zeus subprocesses and agent terminals.",
+                                                                                                         "default":  "",
+                                                                                                         "type":  "string"
+                                                                                                     },
+                                                                 "zeusRpgToolkit.env.ZEUS_CLI_PATH":  {
+                                                                                                          "markdownDescription":  "Optional ZEUS_CLI_PATH override for Zeus subprocesses and agent terminals.",
+                                                                                                          "default":  "",
+                                                                                                          "type":  "string"
+                                                                                                      },
+                                                                 "zeusRpgToolkit.env.ZEUS_JAVA_PATH":  {
+                                                                                                           "markdownDescription":  "Optional ZEUS_JAVA_PATH override used to extend PATH for Zeus subprocesses and terminals.",
+                                                                                                           "default":  "",
+                                                                                                           "type":  "string"
+                                                                                                       },
+                                                                 "zeusRpgToolkit.env.ZEUS_READ_ONLY":  {
+                                                                                                           "markdownDescription":  "Optional ZEUS_READ_ONLY override. Empty value falls back to zeusRpgToolkit.readOnlyMode.",
+                                                                                                           "enum":  [
+                                                                                                                        "true",
+                                                                                                                        "false",
+                                                                                                                        ""
+                                                                                                                    ],
+                                                                                                           "default":  "",
+                                                                                                           "type":  "string"
+                                                                                                       }
+                                                             }
+                                          },
+                        "viewContainers":  {
+                                               "activitybar":  [
+                                                                   {
+                                                                       "id":  "zeusRpgToolkit",
+                                                                       "title":  "Zeus RPG Toolkit",
+                                                                       "icon":  "resources/zeus.svg"
+                                                                   }
+                                                               ]
+                                           },
+                        "views":  {
+                                      "zeusRpgToolkit":  [
+                                                             {
+                                                                 "id":  "zeusProfilesView",
+                                                                 "name":  "Profiles"
+                                                             },
+                                                             {
+                                                                 "id":  "zeusWorkflowsView",
+                                                                 "name":  "Workflows"
+                                                             },
+                                                             {
+                                                                 "id":  "zeusFetchedSourcesView",
+                                                                 "name":  "Fetched Sources"
+                                                             },
+                                                             {
+                                                                 "id":  "zeusReportsView",
+                                                                 "name":  "Reports"
+                                                             },
+                                                             {
+                                                                 "id":  "zeusAiContextView",
+                                                                 "name":  "AI Context Bundles"
+                                                             },
+                                                             {
+                                                                 "id":  "zeusDiagnosticsView",
+                                                                 "name":  "Diagnostics"
+                                                             }
+                                                         ]
+                                  },
+                        "menus":  {
+                                      "explorer/context":  [
+                                                               {
+                                                                   "command":  "zeusRpgToolkit.addFileToAiContext",
+                                                                   "when":  "resourceScheme == file \u0026\u0026 !explorerResourceIsFolder",
+                                                                   "group":  "navigation@20"
+                                                               },
+                                                               {
+                                                                   "command":  "zeusRpgToolkit.addFolderToAiContext",
+                                                                   "when":  "resourceScheme == file \u0026\u0026 explorerResourceIsFolder",
+                                                                   "group":  "navigation@21"
+                                                               }
+                                                           ],
+                                      "view/title":  [
+                                                         {
+                                                             "command":  "zeusRpgToolkit.refreshViews",
+                                                             "when":  "view == zeusProfilesView",
+                                                             "group":  "navigation"
+                                                         },
+                                                         {
+                                                             "command":  "zeusRpgToolkit.refreshViews",
+                                                             "when":  "view == zeusWorkflowsView",
+                                                             "group":  "navigation"
+                                                         },
+                                                         {
+                                                             "command":  "zeusRpgToolkit.refreshViews",
+                                                             "when":  "view == zeusFetchedSourcesView",
+                                                             "group":  "navigation"
+                                                         },
+                                                         {
+                                                             "command":  "zeusRpgToolkit.refreshViews",
+                                                             "when":  "view == zeusReportsView",
+                                                             "group":  "navigation"
+                                                         },
+                                                         {
+                                                             "command":  "zeusRpgToolkit.refreshViews",
+                                                             "when":  "view == zeusAiContextView",
+                                                             "group":  "navigation"
+                                                         },
+                                                         {
+                                                             "command":  "zeusRpgToolkit.refreshViews",
+                                                             "when":  "view == zeusDiagnosticsView",
+                                                             "group":  "navigation"
+                                                         }
+                                                     ]
+                                  }
+                    }
 }
-

--- a/vscode-extension/prompts/zeus-agent.prompt.md
+++ b/vscode-extension/prompts/zeus-agent.prompt.md
@@ -1,0 +1,31 @@
+# Zeus Agent Workflow Prompt
+
+You are operating inside Zeus RPG Toolkit VS Code integration.
+
+## Mandatory startup checks
+
+1. Run `zeus_doctor` first when environment status is unknown.
+2. Confirm active profile and read-only mode.
+3. If profile is missing, ask to run `Zeus: Select Profile`.
+
+## Safe operation policy
+
+- Prefer read-only analysis and reporting flows.
+- Never run deployment actions.
+- Never run IBM i write operations.
+- Never expose secrets in output, context, logs, or prompts.
+- Use `zeus_generate_ai_context` before proposing code-level RPG changes.
+- Use latest report/context files as grounded evidence.
+
+## Tool preference order
+
+1. `zeus_doctor`
+2. `zeus_generate_ai_context`
+3. `zeus_analyze_workspace`
+4. `zeus_query_table`
+5. `zeus_get_latest_report`
+6. `zeus_fetch_sources` (only when read-only policy allows)
+
+## Risk handling
+
+If an action is not clearly read-only or a tool returns `BLOCKED`, require user confirmation and stop autonomous execution.

--- a/vscode-extension/src/zeusCommandGateway.js
+++ b/vscode-extension/src/zeusCommandGateway.js
@@ -1,0 +1,882 @@
+const fs = require('fs');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+const {
+  analyze,
+  fetch,
+  queryTable,
+} = require('../../src/api/zeusApi');
+const {
+  DEFAULT_EXTENSIONS,
+  loadProfiles,
+  readWorkflowConfig,
+  resolveProfile,
+} = require('../../src/config/runtimeConfig');
+const { generateAiContextBundle } = require('../../src/agent/aiContextService');
+const {
+  maskSecretsInText,
+  sanitizeValue,
+} = require('../../src/security/secretMasking');
+const { listSelectableProfiles, resolveActiveProfile } = require('../../src/vscode/profileSelection');
+const {
+  validateSqlIdentifier,
+} = require('../../src/db2/readOnlyQueryService');
+const { validateFilterPattern } = require('../../src/core/queryService');
+
+const READ_ONLY_SAFE_ACTIONS = new Set([
+  'zeus_doctor',
+  'zeus_analyze_workspace',
+  'zeus_query_table',
+  'zeus_generate_ai_context',
+  'zeus_get_latest_report',
+]);
+const FILTER_SAFE_PATTERN = /^[A-Z0-9_%$#@-]*$/i;
+const AGENT_TOOL_DEFINITIONS = Object.freeze([
+  {
+    name: 'zeus_doctor',
+    description: 'Run Zeus diagnostics for the active profile and return sanitized PASS/FAIL/SKIP checks.',
+  },
+  {
+    name: 'zeus_fetch_sources',
+    description: 'Fetch configured source members through safe read-only compatible pathways.',
+  },
+  {
+    name: 'zeus_analyze_workspace',
+    description: 'Analyze workspace members and return report paths, summary, and warnings.',
+  },
+  {
+    name: 'zeus_query_table',
+    description: 'Run read-only DB2 table metadata query with validated schema/table/filter inputs.',
+  },
+  {
+    name: 'zeus_generate_ai_context',
+    description: 'Generate sanitized AI context bundle paths and summary for agent workflows.',
+  },
+  {
+    name: 'zeus_get_latest_report',
+    description: 'Return the latest report path, type, timestamp, and summary.',
+  },
+]);
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function toPosix(filePath) {
+  return String(filePath || '').split(path.sep).join('/');
+}
+
+function normalizeBooleanString(value, fallback = true) {
+  if (value === undefined || value === null || value === '') {
+    return fallback ? 'true' : 'false';
+  }
+  const normalized = String(value).trim().toLowerCase();
+  return normalized === 'false' ? 'false' : 'true';
+}
+
+function resolvePathFromSetting(rootDir, rawValue, fallbackValue) {
+  const fallback = String(fallbackValue || '').trim();
+  const raw = String(rawValue || '').trim() || fallback;
+  return path.resolve(rootDir, raw);
+}
+
+function maskEnvForLogs(env) {
+  const safe = {};
+  const keys = [
+    'ZEUS_CONFIG_DIR',
+    'ZEUS_PROFILE',
+    'ZEUS_OUTPUT_ROOT',
+    'ZEUS_READ_ONLY',
+    'ZEUS_CLI_PATH',
+    'ZEUS_JAVA_PATH',
+  ];
+  for (const key of keys) {
+    if (env[key] === undefined) {
+      continue;
+    }
+    safe[key] = sanitizeValue(env[key], key);
+  }
+  return safe;
+}
+
+function buildSafeTableIdentifier(value, label) {
+  if (!value || !String(value).trim()) {
+    throw new Error(`Missing required option: ${label}`);
+  }
+  return validateSqlIdentifier(value, label);
+}
+
+function safeFilterPattern(value) {
+  const normalized = String(value || '').trim().toUpperCase();
+  if (!normalized) {
+    return '';
+  }
+  if (!FILTER_SAFE_PATTERN.test(normalized)) {
+    throw new Error(`Invalid --filter pattern: ${value}`);
+  }
+  return validateFilterPattern(normalized);
+}
+
+function createZeusCommandGateway({ vscode, outputChannel, workspaceState, lastAiPromptKey }) {
+  function appendOutput(message) {
+    if (!outputChannel) {
+      return;
+    }
+    const rendered = typeof message === 'string'
+      ? message
+      : JSON.stringify(sanitizeValue(message), null, 2);
+    outputChannel.appendLine(maskSecretsInText(rendered));
+  }
+
+  function ensureWorkspaceRoot() {
+    const folder = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders[0];
+    const root = folder ? folder.uri.fsPath : '';
+    if (!root) {
+      throw new Error('Open a workspace folder before running Zeus commands.');
+    }
+    return root;
+  }
+
+  function getSettings(rootDir) {
+    return vscode.workspace.getConfiguration('zeusRpgToolkit', vscode.Uri.file(rootDir));
+  }
+
+  function resolveZeusEnv(settings, activeProfile) {
+    const envSetting = (key) => String(settings.get(`env.${key}`) || '').trim();
+    const topConfigPath = String(settings.get('configPath') || 'config/profiles.json').trim();
+    const topProfile = String(settings.get('defaultProfile') || '').trim();
+    const topOutput = String(settings.get('outputRoot') || 'analysis').trim();
+    const topReadOnly = Boolean(settings.get('readOnlyMode'));
+    const topCliPath = String(settings.get('cliPath') || 'cli/zeus.js').trim();
+    const topJavaPath = String(settings.get('javaPath') || '').trim();
+
+    const zeus = {
+      ZEUS_CONFIG_DIR: envSetting('ZEUS_CONFIG_DIR') || topConfigPath,
+      ZEUS_PROFILE: activeProfile || envSetting('ZEUS_PROFILE') || topProfile,
+      ZEUS_OUTPUT_ROOT: envSetting('ZEUS_OUTPUT_ROOT') || topOutput,
+      ZEUS_READ_ONLY: normalizeBooleanString(envSetting('ZEUS_READ_ONLY'), topReadOnly),
+      ZEUS_CLI_PATH: envSetting('ZEUS_CLI_PATH') || topCliPath,
+      ZEUS_JAVA_PATH: envSetting('ZEUS_JAVA_PATH') || topJavaPath,
+    };
+
+    return zeus;
+  }
+
+  function createProcessEnv(rootDir, settings, activeProfile) {
+    const merged = { ...process.env };
+    const zeus = resolveZeusEnv(settings, activeProfile);
+
+    for (const [key, value] of Object.entries(zeus)) {
+      if (!String(value || '').trim()) {
+        continue;
+      }
+      merged[key] = String(value);
+    }
+
+    const javaPathRaw = String(zeus.ZEUS_JAVA_PATH || settings.get('javaPath') || '').trim();
+    if (javaPathRaw) {
+      const resolved = path.resolve(rootDir, javaPathRaw);
+      const javaBinDir = fs.existsSync(resolved) && fs.statSync(resolved).isDirectory()
+        ? resolved
+        : path.dirname(resolved);
+      merged.PATH = `${javaBinDir}${path.delimiter}${merged.PATH || ''}`;
+    }
+
+    return {
+      env: merged,
+      zeus,
+    };
+  }
+
+  function resolveConfigArg(settings) {
+    return String(settings.get('configPath') || 'config/profiles.json').trim();
+  }
+
+  function resolveCliInvocation(rootDir, settings, zeusEnv) {
+    const cliSetting = String(zeusEnv.ZEUS_CLI_PATH || settings.get('cliPath') || 'cli/zeus.js').trim();
+    const cliPath = path.resolve(rootDir, cliSetting);
+    return {
+      cliPath,
+      exists: fs.existsSync(cliPath),
+    };
+  }
+
+  function loadProfilesForWorkspace(rootDir, settings, env) {
+    const configPath = resolveConfigArg(settings);
+    const profileLoadArgs = configPath ? { config: configPath } : {};
+    const profiles = loadProfiles({
+      cwd: rootDir,
+      env,
+      args: profileLoadArgs,
+    });
+
+    return {
+      profiles,
+      profileNames: listSelectableProfiles(profiles),
+    };
+  }
+
+  function resolveActiveProfileName(settings, profileNames) {
+    const preferred = String(settings.get('defaultProfile') || settings.get('env.ZEUS_PROFILE') || '').trim();
+    return resolveActiveProfile(preferred, profileNames);
+  }
+
+  function resolveOutputRoot(rootDir, settings, zeusEnv) {
+    const raw = String(zeusEnv.ZEUS_OUTPUT_ROOT || settings.get('outputRoot') || 'analysis').trim();
+    return path.resolve(rootDir, raw || 'analysis');
+  }
+
+  function resolveContext() {
+    const rootDir = ensureWorkspaceRoot();
+    const settings = getSettings(rootDir);
+
+    const provisionalEnv = createProcessEnv(rootDir, settings, String(settings.get('defaultProfile') || '').trim());
+    const loaded = loadProfilesForWorkspace(rootDir, settings, provisionalEnv.env);
+    const activeProfile = resolveActiveProfileName(settings, loaded.profileNames);
+    const resolvedEnv = createProcessEnv(rootDir, settings, activeProfile);
+    const outputRoot = resolveOutputRoot(rootDir, settings, resolvedEnv.zeus);
+    const configPath = resolvePathFromSetting(rootDir, resolveConfigArg(settings), 'config/profiles.json');
+    const readOnlyMode = String(resolvedEnv.zeus.ZEUS_READ_ONLY || '').toLowerCase() !== 'false';
+
+    return {
+      rootDir,
+      settings,
+      env: resolvedEnv.env,
+      zeusEnv: resolvedEnv.zeus,
+      profiles: loaded.profiles,
+      profileNames: loaded.profileNames,
+      activeProfile,
+      outputRoot,
+      configPath,
+      readOnlyMode,
+    };
+  }
+
+  async function setActiveProfile(profileName) {
+    const ctx = resolveContext();
+    const selected = String(profileName || '').trim();
+    if (!selected) {
+      throw new Error('Profile name is required.');
+    }
+    if (!ctx.profileNames.includes(selected)) {
+      throw new Error(`Profile "${selected}" not found in config.`);
+    }
+    await ctx.settings.update('defaultProfile', selected, vscode.ConfigurationTarget.Workspace);
+    await ctx.settings.update('env.ZEUS_PROFILE', selected, vscode.ConfigurationTarget.Workspace);
+    return {
+      status: 'PASS',
+      profile: selected,
+    };
+  }
+
+  function buildCliBaseArgs(settings) {
+    const args = [];
+    const configPath = resolveConfigArg(settings);
+    if (configPath) {
+      args.push('--config', configPath);
+    }
+    return args;
+  }
+
+  async function runCliCommand(ctx, cliArgs) {
+    const cli = resolveCliInvocation(ctx.rootDir, ctx.settings, ctx.zeusEnv);
+    if (!cli.exists) {
+      throw new Error(`CLI path not found: ${cli.cliPath}. Update zeusRpgToolkit.cliPath or zeusRpgToolkit.env.ZEUS_CLI_PATH.`);
+    }
+
+    const nodeArgs = [cli.cliPath, ...cliArgs];
+    appendOutput(`[cli] node ${nodeArgs.join(' ')}`);
+
+    const outputLines = [];
+    await new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, nodeArgs, {
+        cwd: ctx.rootDir,
+        env: ctx.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      const onData = (chunk) => {
+        const text = String(chunk || '');
+        const lines = text.split(/\r?\n/).filter(Boolean);
+        for (const line of lines) {
+          const masked = maskSecretsInText(line);
+          outputLines.push(masked);
+          appendOutput(masked);
+        }
+      };
+
+      child.stdout.on('data', onData);
+      child.stderr.on('data', onData);
+      child.on('error', reject);
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`CLI command failed with exit code ${code}.`));
+        }
+      });
+    });
+
+    return {
+      status: 'PASS',
+      outputLines,
+    };
+  }
+
+  function runFallbackDoctorChecks(ctx) {
+    const checks = [];
+    const cli = resolveCliInvocation(ctx.rootDir, ctx.settings, ctx.zeusEnv);
+    const nodeVersion = spawnSync(process.execPath, ['--version'], { encoding: 'utf8' });
+    const javaVersion = spawnSync('java', ['-version'], {
+      cwd: ctx.rootDir,
+      env: ctx.env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const javaLibDir = path.join(ctx.rootDir, 'java', 'lib');
+    const jarCount = fs.existsSync(javaLibDir)
+      ? fs.readdirSync(javaLibDir, { withFileTypes: true }).filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.jar')).length
+      : 0;
+
+    checks.push({
+      name: 'CLI',
+      status: cli.exists ? 'PASS' : 'FAIL',
+      details: cli.exists ? `Found ${cli.cliPath}` : `CLI path not found: ${cli.cliPath}`,
+    });
+    checks.push({
+      name: 'Config',
+      status: fs.existsSync(ctx.configPath) ? 'PASS' : 'FAIL',
+      details: fs.existsSync(ctx.configPath)
+        ? `Found ${toPosix(path.relative(ctx.rootDir, ctx.configPath) || path.basename(ctx.configPath))}`
+        : `Missing config at ${ctx.configPath}.`,
+    });
+    checks.push({
+      name: 'Profile',
+      status: ctx.profileNames.includes(ctx.activeProfile) ? 'PASS' : 'FAIL',
+      details: ctx.profileNames.includes(ctx.activeProfile)
+        ? `Selected profile "${ctx.activeProfile}" is available.`
+        : `Selected profile "${ctx.activeProfile}" not found in config.`,
+    });
+    checks.push({
+      name: 'Node Runtime',
+      status: nodeVersion.status === 0 ? 'PASS' : 'FAIL',
+      details: nodeVersion.status === 0
+        ? String(nodeVersion.stdout || '').trim()
+        : (nodeVersion.error ? nodeVersion.error.message : String(nodeVersion.stderr || '').trim()),
+    });
+    checks.push({
+      name: 'Java Runtime',
+      status: javaVersion.status === 0 ? 'PASS' : 'FAIL',
+      details: javaVersion.status === 0
+        ? String(javaVersion.stderr || javaVersion.stdout || '').split(/\r?\n/).find(Boolean) || 'java -version'
+        : (javaVersion.error ? javaVersion.error.message : String(javaVersion.stderr || javaVersion.stdout || '').trim()),
+    });
+    checks.push({
+      name: 'Classpath Hints',
+      status: jarCount > 0 ? 'PASS' : 'SKIP',
+      details: `java/lib jars=${jarCount}${fs.existsSync(path.join(javaLibDir, 'jt400.jar')) ? ', jt400.jar detected' : ', jt400.jar not detected'}`,
+    });
+
+    return checks.map((entry) => sanitizeValue(entry));
+  }
+
+  function requireProfile(ctx, requestedProfile) {
+    const effective = String(requestedProfile || '').trim() || ctx.activeProfile;
+    if (!effective) {
+      throw new Error('No active profile selected. Use "Zeus: Select Profile".');
+    }
+    return effective;
+  }
+
+  function ensureReadOnlyAllowed(ctx, actionName) {
+    const isSafe = READ_ONLY_SAFE_ACTIONS.has(actionName);
+    if (ctx.readOnlyMode || isSafe) {
+      return null;
+    }
+    return {
+      tool: actionName,
+      status: 'BLOCKED',
+      requiresUserConfirmation: true,
+      reason: 'Action is blocked because read-only mode is disabled. Explicit user confirmation is required.',
+    };
+  }
+
+  async function runDoctor(input = {}) {
+    const ctx = resolveContext();
+    const profile = requireProfile(ctx, input.profile);
+    const readOnlyBlock = ensureReadOnlyAllowed(ctx, 'zeus_doctor');
+    if (readOnlyBlock) {
+      return readOnlyBlock;
+    }
+
+    const cli = resolveCliInvocation(ctx.rootDir, ctx.settings, ctx.zeusEnv);
+    if (cli.exists) {
+      await runCliCommand(ctx, [...buildCliBaseArgs(ctx.settings), 'doctor', '--profile', profile]);
+      return {
+        tool: 'zeus_doctor',
+        status: 'PASS',
+        profile,
+        checks: [
+          {
+            name: 'CLI Doctor',
+            status: 'PASS',
+            details: 'Doctor command completed successfully.',
+          },
+        ],
+        summary: 'Doctor command completed successfully.',
+      };
+    }
+
+    const checks = runFallbackDoctorChecks(ctx);
+    const hasFail = checks.some((check) => check.status === 'FAIL');
+    for (const check of checks) {
+      appendOutput(`[${check.status}] ${check.name}: ${check.details}`);
+    }
+
+    return {
+      tool: 'zeus_doctor',
+      status: hasFail ? 'FAIL' : 'PASS',
+      profile,
+      checks,
+      summary: hasFail
+        ? 'Doctor fallback checks reported failures.'
+        : 'Doctor fallback checks passed.',
+    };
+  }
+
+  async function fetchSources(input = {}) {
+    const ctx = resolveContext();
+    const profile = requireProfile(ctx, input.profile);
+    const readOnlyBlock = ensureReadOnlyAllowed(ctx, 'zeus_fetch_sources');
+    if (readOnlyBlock) {
+      return readOnlyBlock;
+    }
+
+    let summary;
+    const cli = resolveCliInvocation(ctx.rootDir, ctx.settings, ctx.zeusEnv);
+    if (cli.exists) {
+      const cliResult = await runCliCommand(ctx, [...buildCliBaseArgs(ctx.settings), 'fetch', '--profile', profile]);
+      summary = {
+        mode: 'cli',
+        lines: cliResult.outputLines.length,
+      };
+    } else {
+      const fallback = await fetch(profile, {
+        runtime: {
+          cwd: ctx.rootDir,
+          env: ctx.env,
+        },
+      });
+      summary = {
+        mode: 'api',
+        downloadedCount: Number(fallback.summary.downloadedCount || 0),
+      };
+      appendOutput('[fetch] completed via fallback API');
+      appendOutput(fallback.summary);
+    }
+
+    const resolvedProfile = resolveProfile(ctx.profiles, profile, { env: ctx.env });
+    const profileFetchOut = resolvedProfile && resolvedProfile.fetch && resolvedProfile.fetch.out
+      ? path.resolve(ctx.rootDir, resolvedProfile.fetch.out)
+      : path.resolve(ctx.rootDir, 'rpg_sources');
+
+    return {
+      tool: 'zeus_fetch_sources',
+      status: 'PASS',
+      profile,
+      outputFolder: toPosix(path.relative(ctx.rootDir, profileFetchOut) || '.'),
+      fetchedFileCount: Number(summary.downloadedCount || 0) || null,
+      summary: sanitizeValue(summary),
+    };
+  }
+
+  function collectMembers(sourceRoot) {
+    if (!sourceRoot || !fs.existsSync(sourceRoot)) {
+      return [];
+    }
+    const extensionSet = new Set(DEFAULT_EXTENSIONS.map((entry) => entry.toLowerCase()));
+    const members = new Set();
+    const pending = [sourceRoot];
+
+    while (pending.length > 0) {
+      const current = pending.pop();
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        const absolutePath = path.join(current, entry.name);
+        if (entry.isDirectory()) {
+          pending.push(absolutePath);
+          continue;
+        }
+        if (!entry.isFile()) {
+          continue;
+        }
+        const ext = path.extname(entry.name).toLowerCase();
+        if (!extensionSet.has(ext)) {
+          continue;
+        }
+        members.add(path.basename(entry.name, ext).toUpperCase());
+      }
+    }
+
+    return Array.from(members).sort((left, right) => left.localeCompare(right));
+  }
+
+  function resolveAnalyzeSourceRoot(ctx, profile) {
+    const resolvedProfile = resolveProfile(ctx.profiles, profile, { env: ctx.env });
+    const defaultSourceRoot = resolvedProfile && resolvedProfile.sourceRoot
+      ? path.resolve(ctx.rootDir, resolvedProfile.sourceRoot)
+      : ctx.rootDir;
+    return fs.existsSync(defaultSourceRoot) ? defaultSourceRoot : ctx.rootDir;
+  }
+
+  async function analyzeWorkspace(input = {}) {
+    const ctx = resolveContext();
+    const profile = requireProfile(ctx, input.profile);
+    const readOnlyBlock = ensureReadOnlyAllowed(ctx, 'zeus_analyze_workspace');
+    if (readOnlyBlock) {
+      return readOnlyBlock;
+    }
+
+    const targetPath = String(input.targetPath || '').trim();
+    let sourceRoot = resolveAnalyzeSourceRoot(ctx, profile);
+    if (targetPath) {
+      const candidate = path.resolve(ctx.rootDir, targetPath);
+      const prefix = `${path.resolve(ctx.rootDir)}${path.sep}`;
+      if (candidate !== path.resolve(ctx.rootDir) && !candidate.startsWith(prefix)) {
+        throw new Error('targetPath must stay inside the workspace.');
+      }
+      if (!fs.existsSync(candidate) || !fs.statSync(candidate).isDirectory()) {
+        throw new Error(`targetPath does not exist or is not a directory: ${targetPath}`);
+      }
+      sourceRoot = candidate;
+    }
+
+    const mode = String(input.mode || 'documentation').trim() || 'documentation';
+    const members = Array.isArray(input.members) && input.members.length > 0
+      ? input.members.map((member) => String(member || '').trim().toUpperCase()).filter(Boolean)
+      : collectMembers(sourceRoot);
+    if (members.length === 0) {
+      throw new Error(`No source members found in ${sourceRoot}`);
+    }
+
+    const analyzed = [];
+    for (const member of members) {
+      const result = analyze(profile, {
+        runtime: {
+          cwd: ctx.rootDir,
+          env: ctx.env,
+        },
+        source: sourceRoot,
+        member,
+        mode,
+        out: ctx.outputRoot,
+      });
+      analyzed.push({
+        member,
+        outputProgramDir: result.outputProgramDir,
+        reportPath: path.join(result.outputProgramDir, 'report.md'),
+      });
+    }
+
+    return {
+      tool: 'zeus_analyze_workspace',
+      status: 'PASS',
+      profile,
+      mode,
+      targetPath: toPosix(path.relative(ctx.rootDir, sourceRoot) || '.'),
+      analyzedCount: analyzed.length,
+      reportPaths: analyzed.map((entry) => toPosix(path.relative(ctx.rootDir, entry.reportPath))),
+      warnings: [],
+      summary: `${analyzed.length} member(s) analyzed.`,
+    };
+  }
+
+  async function queryTableMetadata(input = {}) {
+    const ctx = resolveContext();
+    const profile = requireProfile(ctx, input.profile);
+    const readOnlyBlock = ensureReadOnlyAllowed(ctx, 'zeus_query_table');
+    if (readOnlyBlock) {
+      return readOnlyBlock;
+    }
+
+    const table = buildSafeTableIdentifier(input.table, '--table');
+    const schema = input.schema ? buildSafeTableIdentifier(input.schema, '--schema') : '';
+    const filter = safeFilterPattern(input.filter);
+
+    const result = queryTable(profile, table, {
+      runtime: {
+        cwd: ctx.rootDir,
+        env: ctx.env,
+      },
+      schema: schema || undefined,
+      filter: filter || undefined,
+    });
+
+    const queryRoot = path.join(ctx.outputRoot, 'queries');
+    ensureDir(queryRoot);
+    const outputPath = path.join(
+      queryRoot,
+      `${new Date().toISOString().replace(/[:.]/g, '-')}-${table}.json`,
+    );
+    fs.writeFileSync(outputPath, `${JSON.stringify(sanitizeValue({
+      table: result.table,
+      schema: result.schema,
+      filter: result.filter,
+      tableInfo: result.tableInfo.rows || [],
+      columns: result.columns.rows || [],
+    }), null, 2)}\n`, 'utf8');
+
+    return {
+      tool: 'zeus_query_table',
+      status: 'PASS',
+      profile,
+      table,
+      schema: result.schema || schema || '',
+      filter,
+      columnCount: Array.isArray(result.columns.rows) ? result.columns.rows.length : 0,
+      tableMatches: Array.isArray(result.tableInfo.rows) ? result.tableInfo.rows.length : 0,
+      reportPath: toPosix(path.relative(ctx.rootDir, outputPath)),
+      summary: 'Read-only table metadata query completed.',
+    };
+  }
+
+  async function generateAiContext(input = {}, selectedPaths = []) {
+    const ctx = resolveContext();
+    const profile = requireProfile(ctx, input.profile);
+    const readOnlyBlock = ensureReadOnlyAllowed(ctx, 'zeus_generate_ai_context');
+    if (readOnlyBlock) {
+      return readOnlyBlock;
+    }
+
+    const taskContext = String(input.ticket || input.taskContext || '').trim();
+    const includeLatestReport = input.includeLatestReport !== false;
+    const bundle = generateAiContextBundle({
+      workspaceRoot: ctx.rootDir,
+      outputRoot: ctx.outputRoot,
+      activeProfile: profile,
+      taskContext,
+      selectedPaths: Array.isArray(input.selectedFiles) && input.selectedFiles.length > 0
+        ? input.selectedFiles
+        : selectedPaths,
+      timestamp: new Date(),
+    });
+
+    if (!includeLatestReport && bundle.files && bundle.files.report && fs.existsSync(bundle.files.report)) {
+      fs.unlinkSync(bundle.files.report);
+      bundle.files.report = null;
+    }
+
+    if (workspaceState && lastAiPromptKey) {
+      await workspaceState.update(lastAiPromptKey, bundle.files.aiPrompt);
+    }
+
+    return {
+      tool: 'zeus_generate_ai_context',
+      status: 'PASS',
+      profile,
+      outputDir: toPosix(path.relative(ctx.rootDir, bundle.outputDir)),
+      files: {
+        ai_prompt_md: bundle.files.aiPrompt ? toPosix(path.relative(ctx.rootDir, bundle.files.aiPrompt)) : null,
+        context_json: bundle.files.context ? toPosix(path.relative(ctx.rootDir, bundle.files.context)) : null,
+        safety_rules_md: bundle.files.safetyRules ? toPosix(path.relative(ctx.rootDir, bundle.files.safetyRules)) : null,
+      },
+      summary: 'AI context bundle generated.',
+    };
+  }
+
+  function findLatestFiles(rootDir, matcher, maxEntries = 20) {
+    if (!fs.existsSync(rootDir)) {
+      return [];
+    }
+
+    const results = [];
+    const pending = [rootDir];
+    while (pending.length > 0) {
+      const current = pending.pop();
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        const absolutePath = path.join(current, entry.name);
+        if (entry.isDirectory()) {
+          pending.push(absolutePath);
+          continue;
+        }
+        if (!entry.isFile()) {
+          continue;
+        }
+        if (!matcher(absolutePath)) {
+          continue;
+        }
+        results.push({
+          absolutePath,
+          modifiedAt: fs.statSync(absolutePath).mtimeMs,
+        });
+      }
+    }
+
+    return results
+      .sort((left, right) => right.modifiedAt - left.modifiedAt)
+      .slice(0, maxEntries);
+  }
+
+  async function getLatestReport() {
+    const ctx = resolveContext();
+    const readOnlyBlock = ensureReadOnlyAllowed(ctx, 'zeus_get_latest_report');
+    if (readOnlyBlock) {
+      return readOnlyBlock;
+    }
+
+    const reports = findLatestFiles(
+      ctx.outputRoot,
+      (entry) => path.basename(entry).toLowerCase() === 'report.md',
+      1,
+    );
+    if (reports.length === 0) {
+      return {
+        tool: 'zeus_get_latest_report',
+        status: 'SKIP',
+        reportPath: null,
+        reportType: null,
+        timestamp: null,
+        summary: 'No report found.',
+      };
+    }
+
+    const latest = reports[0];
+    return {
+      tool: 'zeus_get_latest_report',
+      status: 'PASS',
+      reportPath: toPosix(path.relative(ctx.rootDir, latest.absolutePath)),
+      reportType: 'report.md',
+      timestamp: new Date(latest.modifiedAt).toISOString(),
+      summary: 'Latest report resolved.',
+      absolutePath: latest.absolutePath,
+    };
+  }
+
+  function buildEnvironmentSummary() {
+    const ctx = resolveContext();
+    const relativeConfig = toPosix(path.relative(ctx.rootDir, ctx.configPath));
+    const relativeOutput = toPosix(path.relative(ctx.rootDir, ctx.outputRoot));
+
+    return sanitizeValue({
+      activeProfile: ctx.activeProfile || '',
+      readOnlyMode: ctx.readOnlyMode,
+      workspaceRoot: ctx.rootDir,
+      configPath: relativeConfig || path.basename(ctx.configPath),
+      outputRoot: relativeOutput || '.',
+      cliPath: toPosix(path.relative(ctx.rootDir, resolveCliInvocation(ctx.rootDir, ctx.settings, ctx.zeusEnv).cliPath)),
+      zeusEnv: maskEnvForLogs(ctx.zeusEnv),
+    });
+  }
+
+  function createAgentTerminal() {
+    const ctx = resolveContext();
+    const terminalEnv = {
+      ...ctx.env,
+      ZEUS_PROFILE: ctx.activeProfile || '',
+      ZEUS_READ_ONLY: ctx.readOnlyMode ? 'true' : 'false',
+      ZEUS_CONFIG_DIR: ctx.zeusEnv.ZEUS_CONFIG_DIR || toPosix(path.relative(ctx.rootDir, ctx.configPath)),
+      ZEUS_OUTPUT_ROOT: ctx.zeusEnv.ZEUS_OUTPUT_ROOT || toPosix(path.relative(ctx.rootDir, ctx.outputRoot)),
+      ZEUS_CLI_PATH: ctx.zeusEnv.ZEUS_CLI_PATH || 'cli/zeus.js',
+    };
+
+    const terminal = vscode.window.createTerminal({
+      name: 'Zeus Agent Terminal',
+      cwd: ctx.rootDir,
+      env: terminalEnv,
+    });
+
+    const configForBanner = toPosix(path.relative(ctx.rootDir, ctx.configPath) || path.basename(ctx.configPath));
+    terminal.show();
+    terminal.sendText('echo Zeus RPG Toolkit environment loaded.');
+    terminal.sendText(`echo Active profile: ${maskSecretsInText(ctx.activeProfile || '<none>')}`);
+    terminal.sendText(`echo Read-only mode: ${ctx.readOnlyMode ? 'true' : 'false'}`);
+    terminal.sendText(`echo Config: ${maskSecretsInText(configForBanner)}`);
+
+    return {
+      status: 'PASS',
+      terminalName: 'Zeus Agent Terminal',
+      activeProfile: ctx.activeProfile,
+      readOnlyMode: ctx.readOnlyMode,
+      configPath: configForBanner,
+    };
+  }
+
+  function getAnalyzeModeChoices() {
+    const ctx = resolveContext();
+    const profile = resolveProfile(ctx.profiles, requireProfile(ctx), { env: ctx.env });
+    const workflowConfig = readWorkflowConfig(ctx.profiles, profile, ctx.env);
+    return workflowConfig.analyzeModes || ['documentation', 'defect-analysis'];
+  }
+
+  function getMemberCandidates() {
+    const ctx = resolveContext();
+    const profile = requireProfile(ctx);
+    const sourceRoot = resolveAnalyzeSourceRoot(ctx, profile);
+    return {
+      sourceRoot,
+      members: collectMembers(sourceRoot),
+    };
+  }
+
+  async function runAgentTool(toolName, input = {}, selectedPaths = []) {
+    const name = String(toolName || '').trim();
+    if (!name) {
+      throw new Error('Tool name is required.');
+    }
+
+    if (name === 'zeus_doctor') {
+      return runDoctor(input);
+    }
+    if (name === 'zeus_fetch_sources') {
+      return fetchSources(input);
+    }
+    if (name === 'zeus_analyze_workspace') {
+      return analyzeWorkspace(input);
+    }
+    if (name === 'zeus_query_table') {
+      return queryTableMetadata(input);
+    }
+    if (name === 'zeus_generate_ai_context') {
+      return generateAiContext(input, selectedPaths);
+    }
+    if (name === 'zeus_get_latest_report' || name === 'zeus_open_latest_report') {
+      return getLatestReport();
+    }
+
+    return {
+      tool: name,
+      status: 'BLOCKED',
+      requiresUserConfirmation: true,
+      reason: 'Unsupported Zeus agent tool. Allowed tools are read-only safe operations only.',
+      availableTools: AGENT_TOOL_DEFINITIONS.map((entry) => ({
+        name: entry.name,
+        description: entry.description,
+      })),
+    };
+  }
+
+  function getAgentTools() {
+    return AGENT_TOOL_DEFINITIONS.map((entry) => ({ ...entry }));
+  }
+
+  return {
+    appendOutput,
+    buildEnvironmentSummary,
+    createAgentTerminal,
+    getAnalyzeModeChoices,
+    getMemberCandidates,
+    getLatestReport,
+    resolveContext,
+    runAgentTool,
+    getAgentTools,
+    runDoctor,
+    fetchSources,
+    analyzeWorkspace,
+    queryTableMetadata,
+    generateAiContext,
+    setActiveProfile,
+  };
+}
+
+module.exports = {
+  createZeusCommandGateway,
+};


### PR DESCRIPTION
This PR adds a minimal, safe VS Code agent bridge for zeus-rpg-toolkit.

Summary:

Adds centralized VS Code Zeus command gateway
Adds agent-friendly Zeus command bridge
Adds Zeus Agent Terminal with ZEUS_* environment injection
Adds active environment display command
Adds internal agent tools:
zeus_doctor
zeus_fetch_sources
zeus_analyze_workspace
zeus_query_table
zeus_generate_ai_context
zeus_get_latest_report
zeus_open_latest_report alias
Adds Agent Mode documentation and Copilot instructions
Improves secret masking and test coverage

Safety:

Default remains read-only
Agent tools are allowlisted
Risky operations return BLOCKED with requiresUserConfirmation
Secrets are masked in logs, tool results, and generated context
No deployment or IBM i write operations added

Validation:

npm test: PASS
npm run test:benchmark: PASS
node --check vscode-extension/extension.js: PASS
node --check vscode-extension/src/zeusCommandGateway.js: PASS
VS Code command coverage verified manually
No separate VS Code extension host tests exist yet

Notes:
VS Code LM Tool API wiring and optional @zeus chat participant were intentionally deferred because the extension target is currently ^1.90.0 and this PR keeps the implementation minimal and low-risk.