### PR TITLE
Refactor search-source command into core service

### DIFF
--- a/src/cli/commands/searchSourceCommand.js
+++ b/src/cli/commands/searchSourceCommand.js
@@ -13,114 +13,30 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { glob } = require('glob');
-
-/**
- * search-source command
- *
- * Searches locally fetched IBM i source members for keywords or patterns.
- * Useful after `zeus fetch` to find member references, table names, program calls, etc.
- *
- * Usage:
- *   zeus search-source --search-term "SELECT * FROM" --source-root ./analysis/zeus-fetch
- *   zeus search-source --member PROGRAM_001 --source-root ./analysis/zeus-fetch
- *   zeus search-source --table "TABLE_A" --source-root ./analysis/zeus-fetch --case-sensitive
- */
-
-function escapeRegex(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
+const {
+  executeSearchSource,
+  groupResultsByFile,
+} = require('../../core/searchSourceService');
 
 async function runSearchSource(args) {
-  if (!args['source-root']) {
-    console.error('Missing required option: --source-root <path>');
-    process.exit(2);
-  }
-
-  const sourceRoot = path.resolve(String(args['source-root']).trim());
-  if (!fs.existsSync(sourceRoot)) {
-    console.error(`Source root not found: ${sourceRoot}`);
-    process.exit(2);
-  }
-
-  // Collect search criteria
-  const searchTerm = args['search-term'];
-  const member = args.member;
-  const table = args.table;
-  const caseSensitive = args['case-sensitive'] === true || args['case-sensitive'] === 'true';
-  const maxResults = parseInt(args['max-results'] || '100', 10);
-  const filePattern = args['file-pattern'] || '*.{rpgle,rpg,clle,sql,dds,bnd}';
-
-  if (!searchTerm && !member && !table) {
-    console.error('Provide at least one search criterion: --search-term, --member, or --table');
-    process.exit(2);
-  }
-
-  // Build regex from criteria
-  let regex;
-  if (member) {
-    // Search for exact member name (anywhere in file or as member name in metadata)
-    const escapedMember = escapeRegex(member.toUpperCase());
-    regex = caseSensitive
-      ? new RegExp(`(^|[^A-Z0-9_])${escapedMember}([^A-Z0-9_]|$)|// Member: ${escapedMember}|Member: ${escapedMember}`)
-      : new RegExp(`(^|[^A-Z0-9_])${escapedMember.toLowerCase()}([^A-Z0-9_]|$)|// Member: ${escapedMember.toLowerCase()}|Member: ${escapedMember.toLowerCase()}`, 'i');
-  } else if (table) {
-    const escapedTable = escapeRegex(table.toUpperCase());
-    regex = caseSensitive
-      ? new RegExp(`(FROM|INTO|UPDATE|DELETE FROM|JOIN)\\s+${escapedTable}`, 'i')
-      : new RegExp(`(FROM|INTO|UPDATE|DELETE FROM|JOIN)\\s+${escapedTable}`, 'i');
-  } else if (searchTerm) {
-    regex = caseSensitive
-      ? new RegExp(searchTerm)
-      : new RegExp(searchTerm, 'i');
-  }
-
-  // Find all source files
-  let files;
+  let execution;
   try {
-    files = await glob(filePattern, {
-      cwd: sourceRoot,
-      absolute: false,
-      nodir: true,
-      maxDepth: 10,
+    execution = await executeSearchSource(args, {
+      onWarning: (message) => {
+        console.warn(`Warning: ${message}`);
+      },
     });
-  } catch (err) {
-    console.error(`Glob search failed: ${err.message}`);
+  } catch (error) {
+    console.error(error.message);
     process.exit(2);
   }
 
-  if (files.length === 0) {
-    console.log(`No source files found matching pattern: ${filePattern}`);
+  if (execution.noSourceFiles) {
+    console.log(`No source files found matching pattern: ${execution.filePattern}`);
     return;
   }
 
-  // Search each file
-  const results = [];
-  for (const file of files) {
-    const filePath = path.join(sourceRoot, file);
-    try {
-      const content = fs.readFileSync(filePath, 'utf8');
-      const lines = content.split('\n');
-
-      lines.forEach((line, lineNum) => {
-        if (regex.test(line) && results.length < maxResults) {
-          results.push({
-            file,
-            lineNumber: lineNum + 1,
-            line: line.substring(0, 100), // truncate for display
-          });
-        }
-      });
-    } catch (err) {
-      if (args.verbose) {
-        console.warn(`Warning: Cannot read ${file}: ${err.message}`);
-      }
-    }
-  }
-
-  // Output
+  const { maxResults, results } = execution;
   if (results.length === 0) {
     console.log('No matches found.');
     return;
@@ -129,13 +45,7 @@ async function runSearchSource(args) {
   console.log(`Found ${results.length} matches (max ${maxResults}):`);
   console.log('');
 
-  const grouped = {};
-  results.forEach(r => {
-    if (!grouped[r.file]) {
-      grouped[r.file] = [];
-    }
-    grouped[r.file].push(r);
-  });
+  const grouped = groupResultsByFile(results);
 
   Object.keys(grouped).sort().forEach(file => {
     console.log(`  ${file}`);

--- a/src/core/searchSourceService.js
+++ b/src/core/searchSourceService.js
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 Zeus PromptKit Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { glob } = require('glob');
+
+function escapeRegex(str) {
+  return String(str).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function toBoolean(value) {
+  return value === true || value === 'true';
+}
+
+function parseMaxResults(value) {
+  const parsed = Number.parseInt(String(value || '100'), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error('Invalid option: --max-results must be a positive integer');
+  }
+  return parsed;
+}
+
+function buildSearchRegex({ searchTerm, member, table, caseSensitive }) {
+  if (member) {
+    const escapedMember = escapeRegex(String(member).toUpperCase());
+    return caseSensitive
+      ? new RegExp(`(^|[^A-Z0-9_])${escapedMember}([^A-Z0-9_]|$)|// Member: ${escapedMember}|Member: ${escapedMember}`)
+      : new RegExp(`(^|[^A-Z0-9_])${escapedMember.toLowerCase()}([^A-Z0-9_]|$)|// Member: ${escapedMember.toLowerCase()}|Member: ${escapedMember.toLowerCase()}`, 'i');
+  }
+
+  if (table) {
+    const escapedTable = escapeRegex(String(table).toUpperCase());
+    return new RegExp(`(FROM|INTO|UPDATE|DELETE FROM|JOIN)\\s+${escapedTable}`, 'i');
+  }
+
+  if (searchTerm) {
+    return caseSensitive
+      ? new RegExp(String(searchTerm))
+      : new RegExp(String(searchTerm), 'i');
+  }
+
+  return null;
+}
+
+function groupResultsByFile(results) {
+  const grouped = {};
+  for (const result of results || []) {
+    if (!grouped[result.file]) {
+      grouped[result.file] = [];
+    }
+    grouped[result.file].push(result);
+  }
+  return grouped;
+}
+
+async function executeSearchSource(
+  args,
+  {
+    cwd = process.cwd(),
+    existsSync = fs.existsSync,
+    readFileSync = fs.readFileSync,
+    globFn = glob,
+    onWarning = null,
+  } = {},
+) {
+  if (!args['source-root']) {
+    throw new Error('Missing required option: --source-root <path>');
+  }
+
+  const sourceRoot = path.resolve(cwd, String(args['source-root']).trim());
+  if (!existsSync(sourceRoot)) {
+    throw new Error(`Source root not found: ${sourceRoot}`);
+  }
+
+  const searchTerm = args['search-term'];
+  const member = args.member;
+  const table = args.table;
+  const caseSensitive = toBoolean(args['case-sensitive']);
+  const maxResults = parseMaxResults(args['max-results']);
+  const filePattern = args['file-pattern'] || '*.{rpgle,rpg,clle,sql,dds,bnd}';
+
+  if (!searchTerm && !member && !table) {
+    throw new Error('Provide at least one search criterion: --search-term, --member, or --table');
+  }
+
+  const regex = buildSearchRegex({ searchTerm, member, table, caseSensitive });
+
+  let files = [];
+  try {
+    files = await globFn(filePattern, {
+      cwd: sourceRoot,
+      absolute: false,
+      nodir: true,
+      maxDepth: 10,
+    });
+  } catch (err) {
+    throw new Error(`Glob search failed: ${err.message}`);
+  }
+
+  if (files.length === 0) {
+    return {
+      filePattern,
+      maxResults,
+      noSourceFiles: true,
+      results: [],
+    };
+  }
+
+  const results = [];
+  for (const file of files) {
+    const filePath = path.join(sourceRoot, file);
+    try {
+      const content = readFileSync(filePath, 'utf8');
+      const lines = content.split('\n');
+      lines.forEach((line, lineNum) => {
+        if (regex.test(line) && results.length < maxResults) {
+          results.push({
+            file,
+            lineNumber: lineNum + 1,
+            line: line.substring(0, 100),
+          });
+        }
+      });
+    } catch (err) {
+      if (toBoolean(args.verbose) && typeof onWarning === 'function') {
+        onWarning(`Cannot read ${file}: ${err.message}`);
+      }
+    }
+  }
+
+  return {
+    filePattern,
+    maxResults,
+    noSourceFiles: false,
+    results,
+  };
+}
+
+module.exports = {
+  buildSearchRegex,
+  escapeRegex,
+  executeSearchSource,
+  groupResultsByFile,
+  parseMaxResults,
+};

--- a/tests/search-source-command.test.js
+++ b/tests/search-source-command.test.js
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 
 const { runSearchSource } = require('../src/cli/commands/searchSourceCommand');
+const { executeSearchSource } = require('../src/core/searchSourceService');
 
 function captureConsoleLogs(fn) {
   const logs = [];
@@ -46,6 +47,54 @@ test('search-source finds matches in synthetic source files', async () => {
     assert.match(output, /PROGRAM_001\.rpgle/);
     assert.match(output, /SELECT \* FROM TABLE_A/);
   } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('search-source service reports no source files for unmatched pattern', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-search-source-empty-'));
+  try {
+    const execution = await executeSearchSource({
+      'source-root': tempDir,
+      'search-term': 'SELECT',
+      'file-pattern': '*.rpgle',
+    });
+
+    assert.equal(execution.noSourceFiles, true);
+    assert.deepEqual(execution.results, []);
+    assert.equal(execution.filePattern, '*.rpgle');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('search-source exits with code 2 when no criteria are provided', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-search-source-args-'));
+  const originalExit = process.exit;
+  const originalError = console.error;
+  let exitCode = null;
+  const errors = [];
+
+  process.exit = (code) => {
+    exitCode = code;
+    throw new Error(`__EXIT__${code}`);
+  };
+  console.error = (...args) => {
+    errors.push(args.join(' '));
+  };
+
+  try {
+    await assert.rejects(
+      () => runSearchSource({
+        'source-root': tempDir,
+      }),
+      /__EXIT__2/,
+    );
+    assert.equal(exitCode, 2);
+    assert.match(errors.join('\n'), /Provide at least one search criterion/);
+  } finally {
+    process.exit = originalExit;
+    console.error = originalError;
     fs.rmSync(tempDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
- Extracts search-source logic into `src/core/searchSourceService.js`
- Keeps CLI command as thin adapter for output and exit handling
- Preserves existing validation, regex behavior, grouping, and max-results output
- Adds focused tests for service and command error behavior