### PR TITLE
test(runtime-config): add boundary and facade api guards

### DIFF
--- a/runtime-config/refactoring-plan.md
+++ b/runtime-config/refactoring-plan.md
@@ -1,4 +1,4 @@
-# Runtime Config Refactoring Plan (Konsolidiert, Stand: 2026-05-15)
+# Runtime Config Refactoring Plan (Konsolidiert, Stand: 2026-05-16)
 
 ## Kontext
 
@@ -197,6 +197,55 @@ bleibt zentrale stabile Export-Fassade.
 
 Schritt A bis C wurden verhaltensgleich als interne Extraktionen umgesetzt.
 Die nachfolgenden Schrittbeschreibungen bleiben als Referenz des umgesetzten Zuschnitts erhalten.
+
+---
+
+## Phase 3 – Boundary-Guard gegen Direktimporte (abgeschlossen)
+
+Zusätzlich abgesichert in:
+
+`tests/runtime-config.test.js`
+
+Abgedeckt:
+
+- keine Direktimporte von internen Runtime-Config-Modulen außerhalb `src/config/`
+- Scan über `src/`, `cli/`, `tests/` auf:
+  - `runtimeConfigCore`
+  - `runtimeConfigDefaults`
+  - `runtimeConfigEnv`
+  - `runtimeConfigProfiles`
+  - `runtimeConfigResolver`
+  - `runtimeConfigValidation`
+  - `runtimeConfigWorkflow`
+- harte Test-Fehlerausgabe mit Datei/Zeile bei Boundary-Verletzungen
+
+Verifikation:
+
+- `node --test tests/runtime-config.test.js`
+- `npm test`
+
+Beide vollständig grün.
+
+---
+
+## Phase 4 – Facade-API-Guard (abgeschlossen)
+
+Zusätzlich abgesichert in:
+
+`tests/runtime-config.test.js`
+
+Abgedeckt:
+
+- stabile öffentliche Exportfläche von `src/config/runtimeConfig.js`
+- expliziter Test der exportierten Schlüssel gegen erwarteten öffentlichen Vertrag
+- verhindert versehentliches Entfernen/Umbenennen von Public Exports
+
+Verifikation:
+
+- `node --test tests/runtime-config.test.js`
+- `npm test`
+
+Beide vollständig grün.
 
 ---
 

--- a/tests/runtime-config.test.js
+++ b/tests/runtime-config.test.js
@@ -34,6 +34,113 @@ function createTempProject(profiles) {
   return tempRoot;
 }
 
+test('runtime-config facade exports remain stable', () => {
+  const runtimeConfigFacade = require('../src/config/runtimeConfig');
+  const exportedKeys = Object.keys(runtimeConfigFacade).sort();
+
+  assert.deepEqual(exportedKeys, [
+    'ALLOWED_FETCH_TRANSPORTS',
+    'ALLOWED_WORKFLOW_STEPS',
+    'ALLOWED_WORK_COPY_EXTENSIONS',
+    'DEFAULT_ANALYSIS_LIMITS',
+    'DEFAULT_EXTENSIONS',
+    'DEFAULT_TOKEN_BUDGET',
+    'DEFAULT_WORKFLOW_ANALYZE_MODES',
+    'DEFAULT_WORKFLOW_STEPS',
+    'DEFAULT_WORK_COPY',
+    'describeProfilesLocation',
+    'getProfilesMetadata',
+    'loadProfiles',
+    'normalizeTokenBudgetKey',
+    'readTokenBudgetConfig',
+    'readWorkCopyConfig',
+    'readWorkflowConfig',
+    'resolveAnalyzeConfig',
+    'resolveAnalyzeDbConfig',
+    'resolveBundleConfig',
+    'resolveFetchConfig',
+    'resolveProfile',
+    'resolveProfilesConfigPaths',
+    'resolveWorkflowPresetConfig',
+    'validateProfiles',
+  ]);
+});
+
+const IMPORT_SPECIFIER_PATTERNS = [
+  /require\(\s*['"]([^'"]+)['"]\s*\)/g,
+  /\bfrom\s+['"]([^'"]+)['"]/g,
+  /\bimport\(\s*['"]([^'"]+)['"]\s*\)/g,
+];
+
+function listJavaScriptFiles(rootDir) {
+  const collected = [];
+
+  function walk(currentDir) {
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+
+      const extension = path.extname(entry.name).toLowerCase();
+      if (extension === '.js' || extension === '.cjs' || extension === '.mjs') {
+        collected.push(fullPath);
+      }
+    }
+  }
+
+  if (fs.existsSync(rootDir)) {
+    walk(rootDir);
+  }
+
+  return collected;
+}
+
+function readInternalRuntimeConfigModuleNames(repoRoot) {
+  const configDir = path.join(repoRoot, 'src', 'config');
+  if (!fs.existsSync(configDir)) {
+    return [];
+  }
+
+  return fs.readdirSync(configDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /^runtimeConfig.+\.js$/i.test(entry.name))
+    .map((entry) => entry.name)
+    .filter((name) => name.toLowerCase() !== 'runtimeconfig.js')
+    .map((name) => name.slice(0, -3))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function collectForbiddenRuntimeConfigImports(relativePath, sourceText, internalModuleNames) {
+  const violations = [];
+  const internalModuleNameSet = new Set(internalModuleNames.map((name) => name.toLowerCase()));
+  if (internalModuleNameSet.size === 0) {
+    return violations;
+  }
+
+  for (const pattern of IMPORT_SPECIFIER_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match = pattern.exec(sourceText);
+    while (match) {
+      const specifier = String(match[1] || '').trim();
+      const moduleName = path.basename(specifier).replace(/\.js$/i, '');
+      if (internalModuleNameSet.has(moduleName.toLowerCase())) {
+        const uptoMatch = sourceText.slice(0, match.index);
+        const line = uptoMatch.split('\n').length;
+        violations.push({
+          relativePath,
+          line,
+          specifier,
+        });
+      }
+      match = pattern.exec(sourceText);
+    }
+  }
+
+  return violations;
+}
+
 test('loadProfiles falls back to profiles.example.json', () => {
   const tempRoot = createTempProject({
     default: {
@@ -873,4 +980,38 @@ test('resolveProfile distinguishes null overrides from undefined inherit-through
   const resolved = resolveProfile(profiles, 'child', { env: {} });
   assert.equal(resolved.db.host, null);
   assert.equal(resolved.db.user, 'base-user');
+});
+
+test('runtime-config boundary: no direct imports of internal runtime-config modules outside src/config', () => {
+  const repoRoot = path.resolve(__dirname, '..');
+  const rootsToScan = ['src', 'cli', 'tests'];
+  const violations = [];
+  const internalModuleNames = readInternalRuntimeConfigModuleNames(repoRoot);
+  assert.ok(
+    internalModuleNames.length > 0,
+    'Expected at least one internal runtime-config module under src/config for boundary protection.',
+  );
+
+  for (const root of rootsToScan) {
+    const absoluteRoot = path.join(repoRoot, root);
+    const files = listJavaScriptFiles(absoluteRoot);
+    for (const filePath of files) {
+      const relativePath = path.relative(repoRoot, filePath).replace(/\\/g, '/');
+      if (relativePath.startsWith('src/config/')) {
+        continue;
+      }
+
+      const sourceText = fs.readFileSync(filePath, 'utf8');
+      violations.push(...collectForbiddenRuntimeConfigImports(relativePath, sourceText, internalModuleNames));
+    }
+  }
+
+  const formattedViolations = violations
+    .map((entry) => `${entry.relativePath}:${entry.line} imports "${entry.specifier}"`)
+    .join('\n');
+  assert.equal(
+    violations.length,
+    0,
+    `Found forbidden direct imports of internal runtime-config modules:\n${formattedViolations}`,
+  );
 });


### PR DESCRIPTION
## Summary
- add a runtime-config boundary guard test to block direct imports of internal runtime-config modules outside `src/config`
- make boundary guard discovery dynamic for future `runtimeConfig*.js` internal modules
- add a facade API export stability test for `src/config/runtimeConfig.js`
- update `runtime-config/refactoring-plan.md` with completed phases for boundary and facade guards

## Validation
- node --test tests/runtime-config.test.js
- npm test
