### PR TITLE
Set generic identifiers across docs and CLI examples

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -266,11 +266,11 @@ Standard env load for project development sessions:
 ```powershell
 cd C:\Users\Developer.User\Tools\zeus-rpg-promptkit
 . .\config\load-env.ps1 -Environment project   # loads .env.local + .env.project.local
-node cli/zeus.js doctor --profile sample-ase --show-resolved
+node cli/zeus.js doctor --profile sample-dev --show-resolved
 ```
 
 Systems:
-- **SYS_TEST** — test system, active development, profile `sample-ase`
+- **SYS_TEST** — test system, active development, profile `sample-dev`
 - **SYS_PROD** — production system, metadata read-only, NEVER write
 
 Session prompt template: `docs/ai-session-prompt.md`

--- a/docs/ai-session-prompt.md
+++ b/docs/ai-session-prompt.md
@@ -52,7 +52,7 @@ cd C:\Users\Developer.User\Tools\zeus-rpg-promptkit
 
 Danach Verbindung prüfen:
 ```powershell
-node cli/zeus.js doctor --profile sample-ase --show-resolved
+node cli/zeus.js doctor --profile sample-dev --show-resolved
 ```
 
 Erwartetes Ergebnis: Alle kritischen Checks [PASS], CURRENT_SERVER = SYS_TEST.
@@ -62,15 +62,15 @@ Erwartetes Ergebnis: Alle kritischen Checks [PASS], CURRENT_SERVER = SYS_TEST.
 **SQL-Abfragen (read-only):**
 ```powershell
 # Inline SQL
-node cli/zeus.js query-sql --profile sample-ase --sql "SELECT ..." --output table
+node cli/zeus.js query-sql --profile sample-dev --sql "SELECT ..." --output table
 
 # SQL aus Datei (Kommentar-Header erlaubt)
-node cli/zeus.js query-sql --profile sample-ase --file ./test-scripts/sql/meine-abfrage.sql --output table
+node cli/zeus.js query-sql --profile sample-dev --file ./test-scripts/sql/meine-abfrage.sql --output table
 ```
 
 **Tabellen-Metadaten:**
 ```powershell
-node cli/zeus.js query-table --profile sample-ase --table APP_TABLE_00 --schema APPDATA
+node cli/zeus.js query-table --profile sample-dev --table APP_TABLE_00 --schema APPDATA
 ```
 
 **IBM i CL-Kommandos (via Java IbmiCommandRunner — read-only bevorzugen):**
@@ -102,33 +102,33 @@ SELECT JOB_NAME, JOB_STATUS, JOB_TYPE FROM QSYS2.ACTIVE_JOB_INFO WHERE CURRENT_U
 **Feld- und Tabellenquerverweise suchen (`field-search`):**
 ```powershell
 # Lokal — in bereits gefetchten Quellen (sehr schnell, kein IBM i-Zugriff)
-node cli/zeus.js field-search --profile sample-ase --field FIELD_ALPHA --table APP_TABLE --source ./analysis/zeus-fetch --mode local
+node cli/zeus.js field-search --profile sample-dev --field FIELD_ALPHA --table APP_TABLE --source ./analysis/zeus-fetch --mode local
 
 # Remote — alle Member direkt auf IBM i durchsuchen (langsamer, vollständig)
-node cli/zeus.js field-search --profile sample-ase --field FIELD_ALPHA --table APP_TABLE --source-lib ASE --source-file QRPGLESRC --mode remote
+node cli/zeus.js field-search --profile sample-dev --field FIELD_ALPHA --table APP_TABLE --source-lib LIBDEV --source-file QRPGLESRC --mode remote
 
 # Alles kombiniert
-node cli/zeus.js field-search --profile sample-ase --field FIELD_ALPHA --table APP_TABLE --source ./analysis/zeus-fetch --source-lib ASE --mode all
+node cli/zeus.js field-search --profile sample-dev --field FIELD_ALPHA --table APP_TABLE --source ./analysis/zeus-fetch --source-lib LIBDEV --mode all
 ```
 > Ausschließlich lesend — lokal via `fs.readFileSync`, remote via JT400 `IFSFileInputStream`.
 > Ausgabe zeigt automatisch `[READS:TABELLE]` / `[WRITES:TABELLE]` Kontext.
 
 **RPG-Quellcode analysieren:**
 ```powershell
-node cli/zeus.js analyze --source ./analysis/zeus-fetch/QRPGLESRC --program APPPGM --profile sample-ase --out ./output
-node cli/zeus.js analyze --source ./analysis/zeus-fetch/QRPGLESRC --program APPPGM --profile sample-ase --out ./output --optimize-context
+node cli/zeus.js analyze --source ./analysis/zeus-fetch/QRPGLESRC --program APPPGM --profile sample-dev --out ./output
+node cli/zeus.js analyze --source ./analysis/zeus-fetch/QRPGLESRC --program APPPGM --profile sample-dev --out ./output --optimize-context
 ```
 
 **Fetch von IBM i (nur mit expliziter User-Freigabe):**
 ```powershell
 # ⚠ Fragt User vorher, ob Quellen neu geholt werden sollen
-node cli/zeus.js fetch --profile sample-ase
+node cli/zeus.js fetch --profile sample-dev
 ```
 
 ### Systemlandschaft (wichtig!)
 - **SYS_TEST** = IBM i Testsystem → Abfragen und Diagnose erlaubt, schreibende Aktionen nur mit Freigabe
 - **SYS_PROD** = IBM i Produktionssystem → ausschließlich READ-ONLY, NIEMALS schreibend anfassen
-- **Profil** `sample-ase` → Standard für aktive Entwicklung (Libraries: ASE, APPLIB, APPDATA)
+- **Profil** `sample-dev` → Standard für aktive Entwicklung (Libraries: LIBDEV, APPLIB, APPDATA)
 - **Profil** `sample-source` → Produktionsnahe Quelldaten (Library SOURCEN)
 
 **Grundregel:** Code wird lokal im Workspace bearbeitet, nie direkt auf IBM i.
@@ -212,7 +212,7 @@ $env:ZEUS_DB_HOST    # sollte: SYS_TEST
 $env:ZEUS_DB_USER       # sollte: Dein IBM i User
 
 # Verbindung validieren
-node cli/zeus.js doctor --profile sample-ase --show-resolved
+node cli/zeus.js doctor --profile sample-dev --show-resolved
 ```
 
 Geladen werden:
@@ -225,8 +225,8 @@ Geladen werden:
 
 | Profil | Source-Library | Zweck |
 |---|---|---|
-| `sample-ase` | ASE, APPLIB, APPDATA | Aktive Entwicklung, laufende Tickets |
-| `sample-objecttest` | APPLIB, APPDATA | Neu entwickelte/geänderte Quellen |
+| `sample-dev` | LIBDEV, APPLIB, APPDATA | Aktive Entwicklung, laufende Tickets |
+| `sample-preprod` | APPLIB, APPDATA | Neu entwickelte/geänderte Quellen |
 | `sample-source` | SOURCEN, APPDATA | Produktionsnahe Quellbasis |
 
 Alle drei Profile nutzen SYS_TEST als Fetch- und DB-Host.

--- a/docs/investigation-workflows.md
+++ b/docs/investigation-workflows.md
@@ -110,10 +110,10 @@ Kompilierungszeit, Besitzer, Quellmember, Compiler-Version und Journal-Status.
 
 ```bash
 # Vollstaendige Objektinfo (*PGM, *FILE, *SRVPGM, *MODULE ...)
-zeus inspect-object --profile sample-ase --lib APPLIB --name APP_TABLE_00 --type *FILE
+zeus inspect-object --profile sample-dev --lib APPLIB --name APP_TABLE_00 --type *FILE
 
 # Nur Journal-Status (schnell, relevant fuer SQLSTATE 55019 Diagnose)
-zeus inspect-object --profile sample-ase --lib APPLIB --name APP_TABLE_00 --type *FILE --journal
+zeus inspect-object --profile sample-dev --lib APPLIB --name APP_TABLE_00 --type *FILE --journal
 ```
 
 Schluessel-Output-Felder:
@@ -130,7 +130,7 @@ nie automatisch ausgefuehrt.
 
 ```bash
 # 1. Before-Snapshot aufnehmen (vor dem Test)
-zeus test-run start --profile sample-ase \
+zeus test-run start --profile sample-dev \
     --program APPPGM \
     --table APPLIB.APP_TABLE_00 \
     --key ID=88656 \
@@ -140,7 +140,7 @@ zeus test-run start --profile sample-ase \
 # 2. Test manuell durchfuehren
 
 # 3. After-Snapshot + Diff
-zeus test-run capture --profile sample-ase --manifest test-run-manifest.json
+zeus test-run capture --profile sample-dev --manifest test-run-manifest.json
 
 # 4. Rollback-SQL anzeigen (fuer manuelle Ausfuehrung in ACS)
 zeus test-run rollback --manifest test-run-manifest.json

--- a/docs/metadata-extraction-challenges.md
+++ b/docs/metadata-extraction-challenges.md
@@ -68,18 +68,18 @@ function extractSqlState(error) {
 
 **Problem:**
 ```
-Error: SQLSTATE 42704 (Object not found: ASE/APP_STAGING_00)
+Error: SQLSTATE 42704 (Object not found: LIBDEV/APP_STAGING_00)
 ```
 
 **Root Cause:**
 - Table **exists** but in a **different schema** than queried
 - `resolveDefaultSchema()` doesn't check alternative schemas
-- Query fails because it queries `ASE.APP_STAGING_00` but table is in `APPDATA.APP_STAGING_00`
+- Query fails because it queries `LIBDEV.APP_STAGING_00` but table is in `APPDATA.APP_STAGING_00`
 
 **Current Workaround:**
 ```javascript
 // Hardcoded to one schema — no fallback
-const schema = resolveDefaultSchema(dbConfig); // → 'ASE'
+const schema = resolveDefaultSchema(dbConfig); // → 'LIBDEV'
 ```
 
 **Impact**: 
@@ -131,7 +131,7 @@ const resolveColumn = (logicalName, catalogName) => {
 -- Query ambiguous: which APP_STAGING_00?
 SELECT * FROM APP_STAGING_00;
 -- Result: SQL0205 (Ambiguous reference)
--- Because APP_STAGING_00 exists in both ASE and APPDATA libraries
+-- Because APP_STAGING_00 exists in both LIBDEV and APPDATA libraries
 ```
 
 **Root Cause:**
@@ -142,7 +142,7 @@ SELECT * FROM APP_STAGING_00;
 **Current Workaround:**
 ```javascript
 // Must always qualify
-SELECT * FROM ASE.APP_STAGING_00;  // explicit
+SELECT * FROM LIBDEV.APP_STAGING_00;  // explicit
 ```
 
 **Impact**: 

--- a/docs/sql/system-environment-discovery.sql
+++ b/docs/sql/system-environment-discovery.sql
@@ -1,7 +1,7 @@
 -- PROJECT environment discovery queries
 -- Purpose:
---   1. Confirm source-file presence in BIB, APPLIB, ASE
---   2. Inspect application files in APPDATA, APPLIB, ASE
+--   1. Confirm source-file presence in BIB, APPLIB, LIBDEV
+--   2. Inspect application files in APPDATA, APPLIB, LIBDEV
 --   3. Discover schema, columns, and likely ticket-relevant fields
 -- Usage:
 --   Replace the placeholder literals before execution.
@@ -13,7 +13,7 @@ SELECT TABLE_SCHEMA,
        SYSTEM_TABLE_SCHEMA,
        SYSTEM_TABLE_NAME
 FROM QSYS2.SYSTABLES
-WHERE TABLE_SCHEMA IN ('BIB', 'APPLIB', 'ASE')
+WHERE TABLE_SCHEMA IN ('BIB', 'APPLIB', 'LIBDEV')
   AND TABLE_NAME IN (
     'QRPGLESRC',
     'QCPYSRC',
@@ -33,7 +33,7 @@ SELECT TABLE_SCHEMA,
        SYSTEM_TABLE_SCHEMA,
        SYSTEM_TABLE_NAME
 FROM QSYS2.SYSTABLES
-WHERE TABLE_SCHEMA IN ('APPDATA', 'APPLIB', 'ASE')
+WHERE TABLE_SCHEMA IN ('APPDATA', 'APPLIB', 'LIBDEV')
   AND TABLE_NAME NOT IN (
     'QRPGLESRC',
     'QCPYSRC',
@@ -45,7 +45,7 @@ WHERE TABLE_SCHEMA IN ('APPDATA', 'APPLIB', 'ASE')
   )
 ORDER BY TABLE_SCHEMA, TABLE_NAME;
 
--- 3) Locate a concrete file or table across APPDATA, APPLIB, ASE.
+-- 3) Locate a concrete file or table across APPDATA, APPLIB, LIBDEV.
 --    Replace 'MEINTABLE' with the object you are investigating.
 SELECT TABLE_SCHEMA,
        TABLE_NAME,
@@ -54,7 +54,7 @@ SELECT TABLE_SCHEMA,
        SYSTEM_TABLE_NAME
 FROM QSYS2.SYSTABLES
 WHERE TABLE_NAME = 'MEINTABLE'
-  AND TABLE_SCHEMA IN ('APPDATA', 'APPLIB', 'ASE')
+  AND TABLE_SCHEMA IN ('APPDATA', 'APPLIB', 'LIBDEV')
 ORDER BY TABLE_SCHEMA, TABLE_NAME;
 
 -- 4) Column shape for one concrete table or file.
@@ -82,7 +82,7 @@ SELECT TABLE_SCHEMA,
        LENGTH,
        COLUMN_TEXT
 FROM QSYS2.SYSCOLUMNS
-WHERE TABLE_SCHEMA IN ('APPDATA', 'APPLIB', 'ASE')
+WHERE TABLE_SCHEMA IN ('APPDATA', 'APPLIB', 'LIBDEV')
   AND (
     COLUMN_NAME LIKE '%STATUS%'
     OR COLUMN_NAME LIKE '%NR%'
@@ -108,7 +108,7 @@ FROM TABLE(
     OBJECT_TYPE_LIST => '*FILE'
   )
 )
-WHERE OBJLIB IN ('BIB', 'APPLIB', 'ASE')
+WHERE OBJLIB IN ('BIB', 'APPLIB', 'LIBDEV')
 ORDER BY OBJLIB, OBJNAME;
 
 -- 7) Program object lookup across the known libraries.
@@ -127,7 +127,7 @@ FROM TABLE(
     OBJECT_TYPE_LIST => '*PGM'
   )
 )
-WHERE OBJLIB IN ('BIB', 'APPLIB', 'ASE')
+WHERE OBJLIB IN ('BIB', 'APPLIB', 'LIBDEV')
 ORDER BY OBJLIB, OBJNAME;
 
 -- 8) Quick schema discovery when only the table name is known.

--- a/docs/system-environment-setup.md
+++ b/docs/system-environment-setup.md
@@ -4,7 +4,7 @@ Die System-Profile trennen drei Rollen:
 
 - SYS_TEST als primaeres Arbeits- und Fetch-System
 - SYS_PROD als Quelle fuer produktive Metadaten und bei Bedarf Testdaten
-- BIB, APPLIB und ASE als getrennte Source-Libraries auf SYS_TEST
+- BIB, APPLIB und LIBDEV als getrennte Source-Libraries auf SYS_TEST
 
 **Env-Vars haben immer Vorrang vor Profilwerten.** Das erlaubt Multi-Maschinen-Setups
 ohne Profile anzufassen — z.B. Sourcen von SYS_TEST fetchen, Metadaten aber gegen
@@ -58,10 +58,10 @@ Wenn nicht gesetzt, faellt zeus auf `ZEUS_METADATA_DB_*` zurueck.
 
 - `sample-source`
   Zweck: Produktivnahe Source-Basis aus Library `SOURCEN`
-- `sample-objecttest`
+- `sample-preprod`
   Zweck: neu entwickelte oder geaenderte Quellen aus `APPLIB`
-- `sample-ase`
-  Zweck: laufende Entwicklung aus `ASE`
+- `sample-dev`
+  Zweck: laufende Entwicklung aus `LIBDEV`
 
 Alle drei Profile:
 
@@ -118,7 +118,7 @@ cd C:\Users\Developer.User\Tools\zeus-rpg-promptkit
 . .\config\load-env.ps1 -Environment project
 
 # Pruefen ob alles korrekt geladen wurde:
-node cli/zeus.js doctor --profile sample-ase --show-resolved
+node cli/zeus.js doctor --profile sample-dev --show-resolved
 ```
 
 ## Neue Befehle dieser Session
@@ -127,10 +127,10 @@ node cli/zeus.js doctor --profile sample-ase --show-resolved
 
 ```powershell
 # Zeigt kompiliertes Objekt inkl. Journal-Status
-node cli/zeus.js inspect-object --profile sample-ase --lib APPLIB --name APP_TABLE_00 --type *FILE
+node cli/zeus.js inspect-object --profile sample-dev --lib APPLIB --name APP_TABLE_00 --type *FILE
 
 # Nur Journal-Status
-node cli/zeus.js inspect-object --profile sample-ase --lib APPLIB --name APP_TABLE_00 --type *FILE --journal
+node cli/zeus.js inspect-object --profile sample-dev --lib APPLIB --name APP_TABLE_00 --type *FILE --journal
 ```
 
 ### test-run — Before/After-Snapshot + Rollback-SQL
@@ -140,7 +140,7 @@ Diff ermitteln und bei Bedarf Rollback-SQL anzeigen (wird NICHT automatisch ausg
 
 ```powershell
 # 1. Vor dem Test: Before-Snapshot
-node cli/zeus.js test-run start --profile sample-ase `
+node cli/zeus.js test-run start --profile sample-dev `
     --program APPPGM `
     --table APPLIB.APP_TABLE_00 `
     --key ID=88656 `
@@ -149,7 +149,7 @@ node cli/zeus.js test-run start --profile sample-ase `
 # 2. Test durchfuehren (manuell)
 
 # 3. After-Snapshot + Diff
-node cli/zeus.js test-run capture --profile sample-ase --manifest test-run-manifest.json
+node cli/zeus.js test-run capture --profile sample-dev --manifest test-run-manifest.json
 
 # 4. Rollback-SQL anzeigen (nur lesen, nicht ausfuehren!)
 node cli/zeus.js test-run rollback --manifest test-run-manifest.json
@@ -158,6 +158,6 @@ node cli/zeus.js test-run rollback --manifest test-run-manifest.json
 ## Empfohlene Reihenfolge
 
 1. `sample-source` fuer die produktionsnahe Ausgangslage verwenden.
-2. `sample-objecttest` gegenpruefen, wenn ein Change oder ein Hotfix kurz vor Produktivnahme steht.
-3. `sample-ase` nur dann dazunehmen, wenn die Ursache vermutlich noch in aktiver Entwicklung liegt.
+2. `sample-preprod` gegenpruefen, wenn ein Change oder ein Hotfix kurz vor Produktivnahme steht.
+3. `sample-dev` nur dann dazunehmen, wenn die Ursache vermutlich noch in aktiver Entwicklung liegt.
 4. Fuer Support-Tickets zuerst Metadaten via SYS_PROD lesen und nur bei Bedarf read-only Testdaten ziehen.

--- a/src/cli/commands/testRunCommand.js
+++ b/src/cli/commands/testRunCommand.js
@@ -22,9 +22,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *   zeus test-run rollback --manifest <path>   (zeigt Rollback-SQL — führt es NICHT aus)
  *
  * Beispiel (aus Session CHANGE-1234):
- *   zeus test-run start --profile sample-ase --program APPPGM --table APPLIB.APP_TABLE_00 --key ID=88656 --label "CHANGE-1234 Test DAN=127002"
+ *   zeus test-run start --profile sample-dev --program APPPGM --table APPLIB.APP_TABLE_00 --key ID=88656 --label "CHANGE-1234 Test DAN=127002"
  *   # ... Test durchführen ...
- *   zeus test-run capture --profile sample-ase --manifest test-run-manifest.json
+ *   zeus test-run capture --profile sample-dev --manifest test-run-manifest.json
  *   zeus test-run rollback --manifest test-run-manifest.json
  */
 
@@ -85,9 +85,9 @@ async function run(args) {
     console.log('  rollback — Rollback-SQL aus Manifest anzeigen (nicht ausführen!)');
     console.log('');
     console.log('Beispiel:');
-    console.log('  zeus test-run start --profile sample-ase --program APPPGM \\');
+    console.log('  zeus test-run start --profile sample-dev --program APPPGM \\');
     console.log('       --table APPLIB.APP_TABLE_00 --key ID=88656 --label "Test DAN=127002"');
-    console.log('  zeus test-run capture --profile sample-ase --manifest test-run-manifest.json');
+    console.log('  zeus test-run capture --profile sample-dev --manifest test-run-manifest.json');
     console.log('  zeus test-run rollback --manifest test-run-manifest.json');
     console.log('');
     return;


### PR DESCRIPTION
Replaces environment/profile/library placeholders with generic identifiers to avoid project-specific naming in documentation and examples.