### PR TITLE
Fix broken GitHub doc links by using relative markdown paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 
 ## Documentation Map
 
-- Canonical documentation index: [`docs/index.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/index.md)
-- Authoritative tool reference for all AI assistants: [`docs/tool-catalog.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/tool-catalog.md)
+- Canonical documentation index: [`docs/index.md`](docs/index.md)
+- Authoritative tool reference for all AI assistants: [`docs/tool-catalog.md`](docs/tool-catalog.md)
 
 The documentation is now organized by domains (`ai/`, `cli/`, `quickstart/`, `workflows/`, `safety/`, `internal/`, `viewer/`).
 `docs/tool-catalog.md` is the binding command reference and safety baseline for GPT, Claude, Grok, Copilot, and other assistants.

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -2,7 +2,6 @@
 
 The authoritative CLI command reference is maintained in:
 
-- [`../tool-catalog.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/tool-catalog.md)
+- [`../tool-catalog.md`](../tool-catalog.md)
 
 This file intentionally acts as a stable alias so humans and AI assistants have a predictable entry point under `docs/cli/`.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,59 +4,59 @@ Central navigation for humans and AI assistants.
 
 ## Start Here
 
-- [`tool-catalog.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/tool-catalog.md): authoritative command catalog, safety levels, and workflow presets.
-- [`ai/session-prompt.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/ai/session-prompt.md): session bootstrap prompt for AI-assisted work.
-- [`cli/reference.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/cli/reference.md): stable CLI reference alias to the tool catalog.
+- [`tool-catalog.md`](tool-catalog.md): authoritative command catalog, safety levels, and workflow presets.
+- [`ai/session-prompt.md`](ai/session-prompt.md): session bootstrap prompt for AI-assisted work.
+- [`cli/reference.md`](cli/reference.md): stable CLI reference alias to the tool catalog.
 
 ## AI
 
-- [`ai/session-prompt.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/ai/session-prompt.md)
-- [`ai/prompt-contracts.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/ai/prompt-contracts.md)
-- [`ai/ai-knowledge-projection.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/ai/ai-knowledge-projection.md)
-- [`ai/agent-validation-checklist.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/ai/agent-validation-checklist.md)
+- [`ai/session-prompt.md`](ai/session-prompt.md)
+- [`ai/prompt-contracts.md`](ai/prompt-contracts.md)
+- [`ai/ai-knowledge-projection.md`](ai/ai-knowledge-projection.md)
+- [`ai/agent-validation-checklist.md`](ai/agent-validation-checklist.md)
 
 ## CLI
 
-- [`cli/reference.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/cli/reference.md)
-- [`cli/examples.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/cli/examples.md)
+- [`cli/reference.md`](cli/reference.md)
+- [`cli/examples.md`](cli/examples.md)
 
 ## Quickstart
 
-- [`quickstart/5-minutes.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/quickstart/5-minutes.md)
-- [`quickstart/multiroot-workspace.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/quickstart/multiroot-workspace.md)
-- [`quickstart/qa-quickstart.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/quickstart/qa-quickstart.md)
+- [`quickstart/5-minutes.md`](quickstart/5-minutes.md)
+- [`quickstart/multiroot-workspace.md`](quickstart/multiroot-workspace.md)
+- [`quickstart/qa-quickstart.md`](quickstart/qa-quickstart.md)
 
 ## Workflows
 
-- [`workflows/investigation-workflows.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/workflows/investigation-workflows.md)
-- [`workflows/agent-mode.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/workflows/agent-mode.md)
-- [`workflows/agentic-coding.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/workflows/agentic-coding.md)
+- [`workflows/investigation-workflows.md`](workflows/investigation-workflows.md)
+- [`workflows/agent-mode.md`](workflows/agent-mode.md)
+- [`workflows/agentic-coding.md`](workflows/agentic-coding.md)
 
 ## Safety
 
-- [`safety/safe-sharing.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/safety/safe-sharing.md)
-- [`safety/best-practice-guide.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/safety/best-practice-guide.md)
-- [`safety/advanced-features-risk-testing-deployment.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/safety/advanced-features-risk-testing-deployment.md)
+- [`safety/safe-sharing.md`](safety/safe-sharing.md)
+- [`safety/best-practice-guide.md`](safety/best-practice-guide.md)
+- [`safety/advanced-features-risk-testing-deployment.md`](safety/advanced-features-risk-testing-deployment.md)
 
 ## Internal Technical Docs
 
-- [`internal/canonical-analysis-model.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/canonical-analysis-model.md)
-- [`internal/analyzer-stage-pipeline.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/analyzer-stage-pipeline.md)
-- [`internal/metadata-extraction-challenges.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/metadata-extraction-challenges.md)
-- [`internal/fetch-encoding-contract.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/fetch-encoding-contract.md)
-- [`internal/fixture-sanitization.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/fixture-sanitization.md)
-- [`internal/import-manifest-contract.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/import-manifest-contract.md)
-- [`internal/pui-edit.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/pui-edit.md)
-- [`internal/qa-validation-layer.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/qa-validation-layer.md)
-- [`internal/reproducible-output-mode.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/reproducible-output-mode.md)
-- [`internal/scanner-corpus.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/scanner-corpus.md)
-- [`internal/secure-env-setup.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/secure-env-setup.md)
-- [`internal/source-ingest-normalization.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/source-ingest-normalization.md)
-- [`internal/system-environment-setup.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/system-environment-setup.md)
-- [`internal/sql/system-environment-discovery.sql`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/sql/system-environment-discovery.sql)
-- [`internal/generate-tool-catalog-proposal.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/internal/generate-tool-catalog-proposal.md)
+- [`internal/canonical-analysis-model.md`](internal/canonical-analysis-model.md)
+- [`internal/analyzer-stage-pipeline.md`](internal/analyzer-stage-pipeline.md)
+- [`internal/metadata-extraction-challenges.md`](internal/metadata-extraction-challenges.md)
+- [`internal/fetch-encoding-contract.md`](internal/fetch-encoding-contract.md)
+- [`internal/fixture-sanitization.md`](internal/fixture-sanitization.md)
+- [`internal/import-manifest-contract.md`](internal/import-manifest-contract.md)
+- [`internal/pui-edit.md`](internal/pui-edit.md)
+- [`internal/qa-validation-layer.md`](internal/qa-validation-layer.md)
+- [`internal/reproducible-output-mode.md`](internal/reproducible-output-mode.md)
+- [`internal/scanner-corpus.md`](internal/scanner-corpus.md)
+- [`internal/secure-env-setup.md`](internal/secure-env-setup.md)
+- [`internal/source-ingest-normalization.md`](internal/source-ingest-normalization.md)
+- [`internal/system-environment-setup.md`](internal/system-environment-setup.md)
+- [`internal/sql/system-environment-discovery.sql`](internal/sql/system-environment-discovery.sql)
+- [`internal/generate-tool-catalog-proposal.md`](internal/generate-tool-catalog-proposal.md)
 
 ## Viewer
 
-- [`viewer/local-ui-shell.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/viewer/local-ui-shell.md)
-- [`viewer/viewer-asset-strategy.md`](/home/zeus/dev/zeus-rpg-promptkit/docs/viewer/viewer-asset-strategy.md)
+- [`viewer/local-ui-shell.md`](viewer/local-ui-shell.md)
+- [`viewer/viewer-asset-strategy.md`](viewer/viewer-asset-strategy.md)


### PR DESCRIPTION
Replaces local absolute filesystem links with repository-relative markdown links in README and docs index/reference so links open correctly on GitHub.