### PR TITLE
feat(ui): add Zeus Prompt Workbench MVP (API + canvas + quality gates)

### DIFF
--- a/docs/viewer/prompt-workbench-architecture.md
+++ b/docs/viewer/prompt-workbench-architecture.md
@@ -1,0 +1,75 @@
+---
+Title: Prompt Workbench Architecture
+Description: Zielarchitektur und Integrationspfad fuer die GUI Prompt Workbench im bestehenden Node.js-Toolset.
+Last Updated: 2026-05-17
+---
+
+# Prompt Workbench Architecture
+
+## Zielarchitektur
+Die Prompt Workbench wird als additive Erweiterung des bestehenden `zeus serve` Stacks umgesetzt.
+
+- Bestehender Entry Point bleibt: `src/ui/localUiServer.js`
+- Bestehende Run-Explorer-Routen bleiben unveraendert
+- Neue Builder-Routen laufen unter `/api/prompt-builder/*`
+- Prompt-Composition und Template-Persistenz sind als getrennte UI-Services kapsuliert
+
+## Neue und angepasste Module
+
+Neue Module:
+- `src/ui/promptWorkbenchRegistry.js`
+- `src/ui/promptWorkbenchTemplateStore.js`
+- `src/ui/promptWorkbenchService.js`
+
+Angepasst:
+- `src/ui/localUiServer.js`
+
+### Verantwortlichkeiten
+
+`promptWorkbenchRegistry.js`
+- Use-Case Registry
+- Modul-Registry fuer Prompt-Bausteine
+- deterministische Prompt-Vorschau-Komposition
+
+`promptWorkbenchTemplateStore.js`
+- lokale Template-CRUD-Funktionen
+- Dateipfad-Normalisierung
+- JSON-Store (`config/local-only/prompt-workbench/templates.json` per Default)
+
+`promptWorkbenchService.js`
+- API-nahe Validierung
+- Contract-Metadaten
+- Orchestrierung von Registry + Store + Token-Schaetzung
+
+`localUiServer.js`
+- Route-Dispatch fuer Prompt-Builder-Endpunkte
+- JSON-Body Parsing
+- Method-Guards mit `Allow` Headern
+
+## API Contract (v1)
+- `GET /api/prompt-builder/contracts`
+- `GET /api/prompt-builder/use-cases`
+- `GET /api/prompt-builder/modules`
+- `POST /api/prompt-builder/preview`
+- `GET /api/prompt-builder/templates`
+- `POST /api/prompt-builder/templates`
+- `GET /api/prompt-builder/templates/:templateId`
+- `PUT /api/prompt-builder/templates/:templateId`
+- `DELETE /api/prompt-builder/templates/:templateId`
+
+## Migrationspfad ohne Bruch
+1. Prompt-Builder API parallel zu bestehenden Run-Explorer-Routen bereitstellen.
+2. Bestehende UI-Flaechen und CLI-Verhalten unveraendert lassen.
+3. Frontend-Workbench schrittweise auf neue Endpunkte aufsetzen.
+4. Regression-Tests fuer bestehende API-Routen beibehalten und erweitern.
+
+## Technische Risiken und Gegenmassnahmen
+
+Risiko: Unsauberes Input-Handling bei JSON-Payloads.
+- Gegenmassnahme: zentrale Body-Validierung, Groessenlimit, konsistente Fehlerantworten.
+
+Risiko: Template-Store kollidiert mit Team-Workflows.
+- Gegenmassnahme: lokaler, gitignorierter Standardpfad unter `config/local-only/`.
+
+Risiko: Regression in bestehenden Local-UI-Routen.
+- Gegenmassnahme: additive Route-Struktur und bestehende Testabdeckung weiter nutzen.

--- a/docs/viewer/prompt-workbench-quality-gates.md
+++ b/docs/viewer/prompt-workbench-quality-gates.md
@@ -1,0 +1,50 @@
+---
+Title: Prompt Workbench Quality Gates
+Description: Testmatrix, Regression-Schutz und negative Validierungsfaelle fuer Prompt Workbench.
+Last Updated: 2026-05-17
+---
+
+# Prompt Workbench Quality Gates
+
+## Testmatrix
+
+### API Contract und Routing
+- Prompt Builder route discovery (`/api/prompt-builder/contracts`)
+- Method guards (`405`) inkl. `Allow` Header
+- Bestehende Run-Explorer-Routen weiterhin stabil (`/api/runs`, `/api/runs/:program`, artifacts)
+
+### Prompt Rendering und Validation
+- Preview success path
+- Invalid JSON payload handling
+- Missing required fields (`useCaseId`) -> `400`
+- Invalid types (`moduleIds` not array) -> `400`
+
+### Template Persistence
+- Create/Read/Update/Delete success path
+- Missing template errors (`404` via server mapping)
+- Payload validation (`name`, `moduleIds`) boundaries
+
+### Output Context Integration
+- Context source list from `output/<PROGRAM>`
+- Prompt artifact list for selected run
+- Import existing `ai_prompt_*.md` as seed
+- Invalid import path rejection (`report.md` etc.)
+- Unknown run rejection (`404`)
+
+## Regression-Schutz
+
+- Existing Local UI run endpoints stay read-only and compatible.
+- Prompt Builder routes are additive under `/api/prompt-builder/*`.
+- No changes to analyze/workflow artifact contracts were introduced.
+
+## Aktuelle Testdateien
+
+- `tests/local-ui-server.test.js`
+- `tests/prompt-workbench-service.test.js`
+- `tests/prompt-workbench-template-store.test.js`
+
+## Empfohlene naechste Gates
+
+- UI-E2E smoke test for Prompt Canvas interactions.
+- Snapshot-style rendering check for preview composition.
+- Load test for large local template catalogs.

--- a/src/cli/commands/serveCommand.js
+++ b/src/cli/commands/serveCommand.js
@@ -43,7 +43,7 @@ async function runServe(args) {
 
   if (verbose) {
     console.log(`[verbose] Output root: ${result.outputRoot}`);
-    console.log('[verbose] API routes: /api/health, /api/runs, /api/runs/:program, /api/runs/:program/artifacts/content');
+    console.log('[verbose] API routes: /api/health, /api/runs, /api/runs/:program, /api/runs/:program/artifacts/content, /api/prompt-builder/*');
   }
 
   console.log(`Zeus local UI available at: ${result.url}`);

--- a/src/ui/localUiServer.js
+++ b/src/ui/localUiServer.js
@@ -21,9 +21,11 @@ const {
   executeReadRunViews,
 } = require('../core/runExplorerService');
 const { renderLocalUiShell } = require('./localUiShell');
+const { createPromptWorkbenchService } = require('./promptWorkbenchService');
 
 const DEFAULT_UI_HOST = '127.0.0.1';
 const DEFAULT_UI_PORT = 4782;
+const MAX_JSON_BODY_BYTES = 512 * 1024;
 
 function normalizeHost(host) {
   const normalized = String(host || DEFAULT_UI_HOST).trim();
@@ -55,6 +57,15 @@ function sendJson(response, statusCode, payload) {
   response.end(`${JSON.stringify(payload, null, 2)}\n`);
 }
 
+function sendMethodNotAllowed(response, methods) {
+  response.writeHead(405, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    Allow: (Array.isArray(methods) ? methods : []).join(', '),
+  });
+  response.end(`${JSON.stringify({ error: 'Method not allowed' }, null, 2)}\n`);
+}
+
 function sendText(response, statusCode, content, contentType = 'text/plain; charset=utf-8') {
   response.writeHead(statusCode, {
     'Content-Type': contentType,
@@ -70,20 +81,181 @@ function splitPathname(pathname) {
     .map((entry) => decodeURIComponent(entry));
 }
 
-function createLocalUiRequestHandler({ outputRoot }) {
-  const resolvedOutputRoot = path.resolve(outputRoot);
+function readJsonBody(request, options = {}) {
+  const maxBytes = Number.isInteger(options.maxBytes) && options.maxBytes > 0
+    ? options.maxBytes
+    : MAX_JSON_BODY_BYTES;
 
-  return function handleRequest(request, response) {
+  return new Promise((resolve, reject) => {
+    let bytes = 0;
+    let body = '';
+
+    request.on('data', (chunk) => {
+      bytes += chunk.length;
+      if (bytes > maxBytes) {
+        reject(new Error(`Request body exceeds ${maxBytes} bytes.`));
+        return;
+      }
+      body += chunk.toString('utf8');
+    });
+
+    request.on('end', () => {
+      const trimmed = body.trim();
+      if (!trimmed) {
+        resolve({});
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(trimmed));
+      } catch (error) {
+        reject(new Error(`Invalid JSON body: ${error.message}`));
+      }
+    });
+
+    request.on('error', reject);
+  });
+}
+
+async function handlePromptBuilderRequest({
+  request,
+  response,
+  pathname,
+  segments,
+  promptWorkbenchService,
+}) {
+  if (!pathname.startsWith('/api/prompt-builder')) {
+    return false;
+  }
+
+  if (pathname === '/api/prompt-builder/contracts') {
+    if (request.method !== 'GET') {
+      sendMethodNotAllowed(response, ['GET']);
+      return true;
+    }
+    sendJson(response, 200, promptWorkbenchService.getContract());
+    return true;
+  }
+
+  if (pathname === '/api/prompt-builder/use-cases') {
+    if (request.method !== 'GET') {
+      sendMethodNotAllowed(response, ['GET']);
+      return true;
+    }
+    sendJson(response, 200, promptWorkbenchService.listUseCases());
+    return true;
+  }
+
+  if (pathname === '/api/prompt-builder/modules') {
+    if (request.method !== 'GET') {
+      sendMethodNotAllowed(response, ['GET']);
+      return true;
+    }
+    sendJson(response, 200, promptWorkbenchService.listModules());
+    return true;
+  }
+
+  if (pathname === '/api/prompt-builder/preview') {
+    if (request.method !== 'POST') {
+      sendMethodNotAllowed(response, ['POST']);
+      return true;
+    }
+    const payload = await readJsonBody(request);
+    sendJson(response, 200, promptWorkbenchService.previewPrompt(payload));
+    return true;
+  }
+
+  if (pathname === '/api/prompt-builder/templates') {
+    if (request.method === 'GET') {
+      sendJson(response, 200, promptWorkbenchService.listTemplates());
+      return true;
+    }
+    if (request.method === 'POST') {
+      const payload = await readJsonBody(request);
+      sendJson(response, 201, promptWorkbenchService.createTemplate(payload));
+      return true;
+    }
+    sendMethodNotAllowed(response, ['GET', 'POST']);
+    return true;
+  }
+
+  if (segments[0] === 'api' && segments[1] === 'prompt-builder' && segments[2] === 'templates' && segments.length === 4) {
+    const templateId = segments[3];
+    if (request.method === 'GET') {
+      sendJson(response, 200, promptWorkbenchService.readTemplate(templateId));
+      return true;
+    }
+    if (request.method === 'PUT') {
+      const payload = await readJsonBody(request);
+      sendJson(response, 200, promptWorkbenchService.updateTemplate(templateId, payload));
+      return true;
+    }
+    if (request.method === 'DELETE') {
+      sendJson(response, 200, promptWorkbenchService.deleteTemplate(templateId));
+      return true;
+    }
+    sendMethodNotAllowed(response, ['GET', 'PUT', 'DELETE']);
+    return true;
+  }
+
+  if (pathname === '/api/prompt-builder/context-sources') {
+    if (request.method !== 'GET') {
+      sendMethodNotAllowed(response, ['GET']);
+      return true;
+    }
+    sendJson(response, 200, promptWorkbenchService.listContextSources());
+    return true;
+  }
+
+  if (segments[0] === 'api' && segments[1] === 'prompt-builder' && segments[2] === 'context-sources' && segments[4] === 'prompts' && segments.length === 5) {
+    if (request.method !== 'GET') {
+      sendMethodNotAllowed(response, ['GET']);
+      return true;
+    }
+    sendJson(response, 200, promptWorkbenchService.listContextSourcePrompts(segments[3]));
+    return true;
+  }
+
+  if (pathname === '/api/prompt-builder/context-sources/import') {
+    if (request.method !== 'POST') {
+      sendMethodNotAllowed(response, ['POST']);
+      return true;
+    }
+    const payload = await readJsonBody(request);
+    sendJson(response, 200, promptWorkbenchService.importContextPrompt(payload));
+    return true;
+  }
+
+  sendJson(response, 404, { error: `Route not found: ${pathname}` });
+  return true;
+}
+
+function createLocalUiRequestHandler({ outputRoot, promptWorkbenchService }) {
+  const resolvedOutputRoot = path.resolve(outputRoot);
+  const service = promptWorkbenchService || createPromptWorkbenchService();
+
+  return async function handleRequest(request, response) {
     const url = new URL(request.url, 'http://127.0.0.1');
     const pathname = url.pathname;
     const segments = splitPathname(pathname);
 
-    if (request.method !== 'GET') {
-      sendJson(response, 405, { error: 'Method not allowed' });
-      return;
-    }
-
     try {
+      const promptBuilderHandled = await handlePromptBuilderRequest({
+        request,
+        response,
+        pathname,
+        segments,
+        promptWorkbenchService: service,
+      });
+      if (promptBuilderHandled) {
+        return;
+      }
+
+      if (request.method !== 'GET') {
+        sendMethodNotAllowed(response, ['GET']);
+        return;
+      }
+
       if (pathname === '/' || pathname === '/index.html') {
         sendText(response, 200, renderLocalUiShell(), 'text/html; charset=utf-8');
         return;
@@ -148,12 +320,22 @@ function createLocalUiRequestHandler({ outputRoot }) {
   };
 }
 
-async function startLocalUiServer({ outputRoot, host = DEFAULT_UI_HOST, port = DEFAULT_UI_PORT } = {}) {
+async function startLocalUiServer({
+  outputRoot,
+  host = DEFAULT_UI_HOST,
+  port = DEFAULT_UI_PORT,
+  templateStorePath,
+} = {}) {
   const resolvedHost = normalizeHost(host);
   const resolvedPort = parsePositiveInteger(port, DEFAULT_UI_PORT);
   const resolvedOutputRoot = path.resolve(outputRoot || 'output');
+  const promptWorkbenchService = createPromptWorkbenchService({
+    templateStorePath,
+    outputRoot: resolvedOutputRoot,
+  });
   const server = http.createServer(createLocalUiRequestHandler({
     outputRoot: resolvedOutputRoot,
+    promptWorkbenchService,
   }));
 
   await new Promise((resolve, reject) => {

--- a/src/ui/localUiShell.js
+++ b/src/ui/localUiShell.js
@@ -13,63 +13,1165 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 function renderLocalUiShell() {
   return `<!doctype html>
-<html lang="en"><head>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Zeus Local UI</title>
 <style>
-body{margin:0;font-family:Georgia,serif;background:#f6f1e6;color:#1f2933}*{box-sizing:border-box}
-.app{display:grid;grid-template-columns:300px 1fr;min-height:100vh}.panel{background:#fffaf0;border:1px solid #d4c3a3;border-radius:14px}
-aside{padding:18px;border-right:1px solid #d4c3a3;background:#fffaf0}.main{padding:18px;display:grid;gap:14px;min-height:100vh}
-.list,.tabs,.chips{display:flex;flex-wrap:wrap;gap:8px}.stack{display:grid;gap:12px}.run-list,.item-list{display:grid;gap:8px;max-height:70vh;overflow:auto}
-button,.chip,a.btn,select,input{font:inherit}.run,.item,.tab,.btn{border:1px solid #d4c3a3;background:#fff;padding:10px 12px;border-radius:12px;cursor:pointer;text-decoration:none;color:#8a4b08}
-.active{background:#fff0cf;border-color:#8a4b08}.hero{padding:18px;display:flex;justify-content:space-between;gap:12px}.metrics{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
-.metric{padding:14px}.metric strong{display:block;font-size:24px;color:#8a4b08}.view{display:none}.view.active{display:grid}.two{grid-template-columns:300px 1fr;gap:14px}.three{grid-template-columns:260px 1fr 1fr;gap:14px}
-.sub{padding:14px;display:grid;gap:10px;align-content:start}.preview{border:1px solid #d4c3a3;border-radius:12px;background:#fffdf7;min-height:340px;overflow:auto}
+body{margin:0;font-family:Georgia,serif;background:#f6f1e6;color:#1f2933}
+*{box-sizing:border-box}
+.app{display:grid;grid-template-columns:300px 1fr;min-height:100vh}
+.panel{background:#fffaf0;border:1px solid #d4c3a3;border-radius:14px}
+aside{padding:18px;border-right:1px solid #d4c3a3;background:#fffaf0}
+.main{padding:18px;display:grid;gap:14px;min-height:100vh}
+.list,.tabs,.chips{display:flex;flex-wrap:wrap;gap:8px}
+.stack{display:grid;gap:12px}
+.run-list,.item-list{display:grid;gap:8px;max-height:70vh;overflow:auto}
+button,.chip,a.btn,select,input,textarea{font:inherit}
+.run,.item,.tab,.btn{border:1px solid #d4c3a3;background:#fff;padding:10px 12px;border-radius:12px;cursor:pointer;text-decoration:none;color:#8a4b08}
+.active{background:#fff0cf;border-color:#8a4b08}
+.hero{padding:18px;display:flex;justify-content:space-between;gap:12px}
+.metrics{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
+.metric{padding:14px}
+.metric strong{display:block;font-size:24px;color:#8a4b08}
+.view{display:none}
+.view.active{display:grid}
+.two{grid-template-columns:300px 1fr;gap:14px}
+.three{grid-template-columns:260px 1fr 1fr;gap:14px}
+.sub{padding:14px;display:grid;gap:10px;align-content:start}
+.preview{border:1px solid #d4c3a3;border-radius:12px;background:#fffdf7;min-height:340px;overflow:auto}
 pre{margin:0;padding:14px;white-space:pre-wrap;word-break:break-word;font-family:Consolas,monospace;font-size:12px;line-height:1.45}
-.empty{padding:18px;color:#5c6b73;border:1px dashed #d4c3a3;border-radius:12px}.tokens{display:flex;flex-wrap:wrap;gap:6px}.token{padding:6px 9px;border:1px solid #d4c3a3;border-radius:999px;background:#fff}
-iframe{width:100%;height:420px;border:0;background:#fff}@media(max-width:1100px){.app{grid-template-columns:1fr}.metrics,.two,.three{grid-template-columns:1fr}}
-</style></head><body>
+.empty{padding:18px;color:#5c6b73;border:1px dashed #d4c3a3;border-radius:12px}
+.tokens{display:flex;flex-wrap:wrap;gap:6px}
+.token{padding:6px 9px;border:1px solid #d4c3a3;border-radius:999px;background:#fff}
+iframe{width:100%;height:420px;border:0;background:#fff}
+textarea{width:100%;min-height:120px;padding:10px;border:1px solid #d4c3a3;border-radius:12px;background:#fff}
+.card-grid{display:grid;gap:10px}
+.card{border:1px solid #d4c3a3;background:#fff;padding:12px;border-radius:12px;display:grid;gap:8px}
+.card h3{margin:0;color:#8a4b08;font-size:17px}
+.card p{margin:0;color:#344854;font-size:14px;line-height:1.35}
+.card .meta{display:flex;gap:8px;flex-wrap:wrap}
+.card .meta .token{font-size:12px}
+.actions{display:flex;gap:8px;flex-wrap:wrap}
+input[type="search"]{width:100%;padding:9px;border:1px solid #d4c3a3;border-radius:10px;background:#fff}
+.field-grid{display:grid;gap:8px}
+.field-grid label{font-size:12px;color:#5b6570;font-weight:bold}
+.field-grid input,.field-grid textarea,.field-grid select{width:100%;padding:9px;border:1px solid #d4c3a3;border-radius:10px;background:#fff}
+.module-row{display:grid;gap:6px;border:1px solid #d4c3a3;border-radius:10px;padding:9px;background:#fff}
+.module-row.active{background:#fff0cf;border-color:#8a4b08}
+.module-row h4{margin:0;color:#8a4b08}
+.small{font-size:12px;color:#5c6b73}
+.status-ok{color:#1f7a3f}
+.status-warn{color:#8a4b08}
+.status-err{color:#a11d2d}
+@media(max-width:1100px){
+  .app{grid-template-columns:1fr}
+  .metrics,.two,.three{grid-template-columns:1fr}
+}
+</style>
+</head>
+<body>
 <div class="app">
-<aside><div class="stack"><div><h1>Zeus Local UI</h1><p>Focused read-only views.</p></div><div class="token">Local-only API</div></div><div id="runs" class="run-list"></div></aside>
-<div class="main">
-<div class="panel hero"><div class="stack"><h2 id="title">Analysis Runs</h2><p id="subtitle">Select a run.</p></div><div id="chips" class="chips"></div></div>
-<div id="metrics" class="metrics"></div>
-<div id="tabs" class="panel tabs" style="padding:10px"></div>
-<div id="graph" class="panel view two"></div>
-<div id="db2" class="panel view two"></div>
-<div id="prompts" class="panel view three"></div>
-<div id="artifacts" class="panel view two"></div>
-</div></div>
+  <aside>
+    <div class="stack">
+      <div>
+        <h1>Zeus Local UI</h1>
+        <p>Focused read-only views.</p>
+      </div>
+      <div class="token">Local-only API</div>
+    </div>
+    <div id="runs" class="run-list"></div>
+  </aside>
+  <div class="main">
+    <div class="panel hero">
+      <div class="stack">
+        <h2 id="title">Analysis Runs</h2>
+        <p id="subtitle">Select a run.</p>
+      </div>
+      <div id="chips" class="chips"></div>
+    </div>
+
+    <div id="metrics" class="metrics"></div>
+    <div id="tabs" class="panel tabs" style="padding:10px"></div>
+
+    <div id="graph" class="panel view two"></div>
+    <div id="db2" class="panel view two"></div>
+    <div id="prompts" class="panel view three"></div>
+    <div id="workbench" class="panel view two"></div>
+    <div id="artifacts" class="panel view two"></div>
+  </div>
+</div>
+
 <script>
-const s={runs:[],detail:null,program:null,tab:'graph',artifact:null,node:null,table:null,left:null,right:null,cache:new Map()};
-const tabs=[['graph','Graph'],['db2','DB2/Test Data'],['prompts','Prompt Compare'],['artifacts','Artifacts']];
+const s={
+  runs:[],detail:null,program:null,tab:'graph',artifact:null,node:null,table:null,left:null,right:null,cache:new Map(),
+  promptBuilder:{
+    loading:false,
+    loaded:false,
+    error:null,
+    useCases:[],
+    modules:[],
+    selectedUseCaseId:null,
+    selectedModuleId:null,
+    moduleOrder:[],
+    fields:{},
+    preview:null,
+    previewEditable:false,
+    previewEditableContent:'',
+    previewDebounceHandle:null,
+    previewLoading:false,
+    previewError:null,
+    additionalRequirements:'',
+    templates:[],
+    selectedTemplateId:null,
+    templateName:'',
+    templateDescription:'',
+    templateTags:'',
+    saveStatus:'',
+    contextSources:[],
+    contextSourceProgram:'',
+    contextSourcePrompts:[],
+    contextSourcePromptPath:'',
+    contextSourceStatus:''
+  }
+};
+
+const tabs=[
+  ['graph','Graph'],
+  ['db2','DB2/Test Data'],
+  ['prompts','Prompt Compare'],
+  ['workbench','Prompt Workbench'],
+  ['artifacts','Artifacts']
+];
+
+const WB_PREVIEW_DEBOUNCE_MS=220;
+
 const pref=['report.md','architecture.html','analysis-index.json','context.json','ai_prompt_documentation.md'];
+
 const q=(id)=>document.getElementById(id);
-const esc=(v)=>String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-const fmt=(v)=>{if(!v)return'n/a';const d=new Date(v);return Number.isNaN(d.getTime())?v:d.toLocaleString();};
-async function getJson(u){const r=await fetch(u);if(!r.ok)throw new Error(await r.text());return r.json();}
-async function getArtifact(p){const k=s.program+':'+p;if(s.cache.has(k))return s.cache.get(k);const v=await getJson('/api/runs/'+encodeURIComponent(s.program)+'/artifacts/content?path='+encodeURIComponent(p));s.cache.set(k,v);return v;}
-function runDefaultArtifact(){const a=s.detail&&s.detail.artifacts||[];for(const p of pref){const m=a.find(x=>x.path===p);if(m)return m.path;}return a[0]&&a[0].path||null;}
-function renderRuns(){const root=q('runs');if(!s.runs.length){root.innerHTML='<div class="empty">No runs.</div>';return;}root.innerHTML=s.runs.map(r=>'<button class="run'+(r.program===s.program?' active':'')+'" data-run="'+esc(r.program)+'"><strong>'+esc(r.program)+'</strong><div>'+esc(r.workflowPreset||r.workflowMode||'standard')+'</div><div>'+esc(fmt(r.completedAt))+'</div></button>').join('');for(const b of root.querySelectorAll('[data-run]'))b.onclick=()=>selectRun(b.dataset.run);}
-function renderHero(){if(!s.detail){q('title').textContent='Analysis Runs';q('subtitle').textContent='Select a run.';q('chips').innerHTML='';return;}const x=s.detail.summary;q('title').textContent=x.program;q('subtitle').textContent='Focused explorer over graph, DB2, prompts, and artifacts.';q('chips').innerHTML=['Status: '+(x.status||'unknown'),'Mode: '+(x.workflowPreset||x.workflowMode||'standard'),'Artifacts: '+x.artifactCount,x.safeSharingEnabled?'Safe sharing':'No safe sharing'].map(v=>'<div class="token">'+esc(v)+'</div>').join('');}
-function renderMetrics(){const root=q('metrics');if(!s.detail){root.innerHTML='';return;}const a=s.detail.analyzeManifest,v=s.detail.views;const m=[['Completed',fmt(s.detail.summary.completedAt)],['Stages',a.summary.stageCount||0],['Graph Nodes',v.summary.graphNodeCount||0],['Prompt Packs',v.summary.promptCount||0]];root.innerHTML=m.map(([k,v])=>'<div class="panel metric"><div>'+esc(k)+'</div><strong>'+esc(String(v))+'</strong></div>').join('');}
-function renderTabs(){q('tabs').innerHTML=tabs.map(([id,label])=>'<button class="tab'+(s.tab===id?' active':'')+'" data-tab="'+id+'">'+label+'</button>').join('');for(const b of q('tabs').querySelectorAll('[data-tab]'))b.onclick=()=>selectTab(b.dataset.tab);}
-function linkArtifacts(paths){return !paths||!paths.length?'<div class="empty">No related artifacts.</div>':'<div class="chips">'+paths.map(p=>'<button class="btn" data-art="'+esc(p)+'">'+esc(p)+'</button>').join('')+'</div>';}
-function linkPrompts(paths){return !paths||!paths.length?'<div class="empty">No related prompts.</div>':'<div class="chips">'+paths.map(p=>'<button class="btn" data-prompt="'+esc(p)+'">'+esc(p)+'</button>').join('')+'</div>';}
-function linkNodes(paths){return !paths||!paths.length?'<div class="empty">No connected nodes.</div>':'<div class="chips">'+paths.map(p=>'<button class="btn" data-node="'+esc(p)+'">'+esc(p)+'</button>').join('')+'</div>';}
-function bindCross(root){for(const b of root.querySelectorAll('[data-art]'))b.onclick=()=>{s.artifact=b.dataset.art;s.tab='artifacts';render();};for(const b of root.querySelectorAll('[data-prompt]'))b.onclick=()=>{s.left=b.dataset.prompt;if(!s.right)s.right=b.dataset.prompt;s.tab='prompts';render();};for(const b of root.querySelectorAll('[data-node]'))b.onclick=()=>{s.node=b.dataset.node;s.tab='graph';render();};}
-function renderGraph(){const root=q('graph');root.classList.toggle('active',s.tab==='graph');if(s.tab!=='graph')return;if(!s.detail||!s.detail.views.graph.available){root.innerHTML='<div class="sub"><div class="empty">No graph available.</div></div>';return;}const g=s.detail.views.graph;const f=(q('graphFilter')&&q('graphFilter').value||'').toLowerCase();const nodes=g.nodes.filter(n=>!f||n.id.toLowerCase().includes(f)||n.type.toLowerCase().includes(f));const sel=g.nodes.find(n=>n.id===s.node)||nodes[0]||null;root.innerHTML='<div class="sub"><h2>Graph Explorer</h2><p>Click nodes to follow related artifacts and prompts.</p><input id="graphFilter" placeholder="Filter nodes"><div class="item-list">'+nodes.map(n=>'<button class="item'+(sel&&sel.id===n.id?' active':'')+'" data-nid="'+esc(n.id)+'"><strong>'+esc(n.id)+'</strong><div>'+esc(n.type)+' • in '+esc(String(n.incomingCount))+' • out '+esc(String(n.outgoingCount))+'</div></button>').join('')+'</div></div><div class="sub">'+(sel?'<h2>'+esc(sel.id)+'</h2><div class="tokens"><div class="token">'+esc(sel.type)+'</div><div class="token">Connected '+esc(String(sel.connectedNodeIds.length))+'</div></div><h3>Connected Nodes</h3>'+linkNodes(sel.connectedNodeIds)+'<h3>Related Artifacts</h3>'+linkArtifacts(sel.relatedArtifactPaths)+'<h3>Related Prompts</h3>'+linkPrompts(sel.relatedPromptPaths)+(g.viewerArtifact?'<a class="btn" target="_blank" rel="noreferrer" href="/runs/'+encodeURIComponent(s.program)+'/artifacts/raw?path='+encodeURIComponent(g.viewerArtifact)+'">Open Architecture Viewer</a>':''):'<div class="empty">No nodes matched.</div>')+'</div>';q('graphFilter').value=f;q('graphFilter').oninput=()=>renderGraph();for(const b of root.querySelectorAll('[data-nid]'))b.onclick=()=>{s.node=b.dataset.nid;renderGraph();};bindCross(root);}
-function renderDb2(){const root=q('db2');root.classList.toggle('active',s.tab==='db2');if(s.tab!=='db2')return;if(!s.detail){root.innerHTML='<div class="sub"><div class="empty">No run selected.</div></div>';return;}const d=s.detail.views.db2;if(!d.metadataAvailable&&!d.testDataAvailable){root.innerHTML='<div class="sub"><div class="empty">No DB2 metadata or test data.</div></div>';return;}const f=(q('db2Filter')&&q('db2Filter').value||'').toLowerCase();const tables=d.tables.filter(t=>!f||t.qualifiedName.toLowerCase().includes(f));const sel=d.tables.find(t=>t.id===s.table)||tables[0]||null;root.innerHTML='<div class="sub"><h2>DB2/Test Data</h2><div class="tokens"><div class="token">Metadata '+esc(String(d.metadataSummary&&d.metadataSummary.tableCount||0))+'</div><div class="token">Samples '+esc(String(d.testDataSummary&&d.testDataSummary.tableCount||0))+'</div><div class="token">Masked '+esc(String(d.testDataSummary&&d.testDataSummary.policySummary&&d.testDataSummary.policySummary.maskedTableCount||0))+'</div></div><input id="db2Filter" placeholder="Filter tables"><div class="item-list">'+tables.map(t=>'<button class="item'+(sel&&sel.id===t.id?' active':'')+'" data-tid="'+esc(t.id)+'"><strong>'+esc(t.qualifiedName||t.table)+'</strong><div>rows '+esc(String(t.sampleRowCount||0))+' • masks '+esc(String(t.maskedColumnCount||0))+'</div></button>').join('')+'</div></div><div class="sub">'+(sel?'<h2>'+esc(sel.qualifiedName||sel.table)+'</h2><div class="tokens"><div class="token">match '+esc(sel.matchStatus||'unknown')+'</div><div class="token">policy '+esc(sel.policyEligibility||'not-exported')+'</div><div class="token">evidence '+esc(String(sel.sourceEvidenceCount||0))+'</div></div><h3>Artifacts</h3>'+linkArtifacts(sel.relatedArtifactPaths)+'<h3>Prompts</h3>'+linkPrompts(sel.relatedPromptPaths):'<div class="empty">No tables matched.</div>')+'</div>';q('db2Filter').value=f;q('db2Filter').oninput=()=>renderDb2();for(const b of root.querySelectorAll('[data-tid]'))b.onclick=()=>{s.table=b.dataset.tid;renderDb2();};bindCross(root);}
-async function renderPromptPreview(id,path){const root=q(id);if(!path){root.innerHTML='<div class="empty">Choose a prompt.</div>';return;}root.innerHTML='<pre>Loading...</pre>';const p=await getArtifact(path);root.innerHTML='<pre>'+esc(p.content)+'</pre>';}
-async function renderPrompts(){const root=q('prompts');root.classList.toggle('active',s.tab==='prompts');if(s.tab!=='prompts')return;if(!s.detail||!s.detail.views.prompts.artifacts.length){root.innerHTML='<div class="sub"><div class="empty">No prompt artifacts.</div></div>';return;}const ps=s.detail.views.prompts.artifacts;if(!s.left)s.left=ps[0].path;if(!s.right)s.right=(ps[1]&&ps[1].path)||ps[0].path;root.innerHTML='<div class="sub"><h2>Prompt Compare</h2><p>Compare prompt packs side by side.</p><div class="item-list">'+ps.map(p=>'<button class="item" data-pick="'+esc(p.path)+'"><strong>'+esc(p.title)+'</strong><div>'+esc(p.path)+'</div></button>').join('')+'</div></div><div class="sub"><h3>Left Prompt</h3><select id="leftSel">'+ps.map(p=>'<option value="'+esc(p.path)+'"'+(p.path===s.left?' selected':'')+'>'+esc(p.title)+'</option>').join('')+'</select><div id="leftPrev" class="preview"></div></div><div class="sub"><h3>Right Prompt</h3><select id="rightSel">'+ps.map(p=>'<option value="'+esc(p.path)+'"'+(p.path===s.right?' selected':'')+'>'+esc(p.title)+'</option>').join('')+'</select><div id="rightPrev" class="preview"></div></div>';for(const b of root.querySelectorAll('[data-pick]'))b.onclick=()=>{s.left=b.dataset.pick;renderPrompts();};q('leftSel').onchange=(e)=>{s.left=e.target.value;renderPrompts();};q('rightSel').onchange=(e)=>{s.right=e.target.value;renderPrompts();};await Promise.all([renderPromptPreview('leftPrev',s.left),renderPromptPreview('rightPrev',s.right)]);}
-function renderArtifacts(){const root=q('artifacts');root.classList.toggle('active',s.tab==='artifacts');if(s.tab!=='artifacts')return;if(!s.detail||!s.detail.artifacts.length){root.innerHTML='<div class="sub"><div class="empty">No artifacts.</div></div>';return;}root.innerHTML='<div class="sub"><h2>Artifact Explorer</h2><p>Artifacts are fetched only when selected.</p><div class="item-list">'+s.detail.artifacts.map(a=>'<button class="item'+(a.path===s.artifact?' active':'')+'" data-aid="'+esc(a.path)+'"><strong>'+esc(a.path)+'</strong><div>'+esc(a.kind)+' • '+esc(String(a.sizeBytes))+' bytes</div></button>').join('')+'</div></div><div class="sub"><div class="stack"><h2 id="aTitle">Artifact Preview</h2><p id="aSub">Choose an artifact.</p></div><a id="aRaw" class="btn" target="_blank" rel="noreferrer" hidden>Open Raw</a><div id="aPrev" class="preview"><div class="empty">No artifact selected.</div></div></div>';for(const b of root.querySelectorAll('[data-aid]'))b.onclick=()=>{s.artifact=b.dataset.aid;renderArtifacts();renderArtifactPreview();};}
-async function renderArtifactPreview(){if(s.tab!=='artifacts')return;const root=q('aPrev'),title=q('aTitle'),sub=q('aSub'),raw=q('aRaw');if(!s.artifact){title.textContent='Artifact Preview';sub.textContent='Choose an artifact.';root.innerHTML='<div class="empty">No artifact selected.</div>';raw.hidden=true;return;}const art=s.detail.artifacts.find(a=>a.path===s.artifact);if(!art){root.innerHTML='<div class="empty">Artifact not found.</div>';raw.hidden=true;return;}title.textContent=art.path;sub.textContent=art.kind+' preview';const rawUrl='/runs/'+encodeURIComponent(s.program)+'/artifacts/raw?path='+encodeURIComponent(art.path);raw.href=rawUrl;raw.hidden=false;if(art.kind==='html'){root.innerHTML='<iframe src="'+rawUrl+'"></iframe>';return;}root.innerHTML='<pre>Loading...</pre>';const p=await getArtifact(art.path);const c=art.kind==='json'?JSON.stringify(JSON.parse(p.content),null,2):p.content;root.innerHTML='<pre>'+esc(c)+'</pre>';}
-async function selectTab(tab){s.tab=tab;await render();}
-async function render(){renderTabs();renderGraph();renderDb2();await renderPrompts();renderArtifacts();await renderArtifactPreview();}
-async function selectRun(program){s.program=program;s.cache.clear();renderRuns();s.detail=await getJson('/api/runs/'+encodeURIComponent(program));s.artifact=runDefaultArtifact();s.node=s.detail.views.graph.nodes[0]&&s.detail.views.graph.nodes[0].id||null;s.table=s.detail.views.db2.tables[0]&&s.detail.views.db2.tables[0].id||null;const ps=s.detail.views.prompts.artifacts;s.left=ps[0]&&ps[0].path||null;s.right=ps[1]&&ps[1].path||s.left;renderHero();renderMetrics();await render();}
-async function boot(){s.runs=await getJson('/api/runs');renderRuns();renderTabs();if(s.runs.length)await selectRun(s.runs[0].program);}
-boot().catch((e)=>{q('artifacts').classList.add('active');q('artifacts').innerHTML='<div class="sub"><div class="empty">'+esc(e.message||String(e))+'</div></div>';});
-</script></body></html>`;
+
+const esc=(v)=>String(v)
+  .replace(/&/g,'&amp;')
+  .replace(/</g,'&lt;')
+  .replace(/>/g,'&gt;');
+
+const escAttr=(v)=>esc(v).replace(/"/g,'&quot;');
+
+const fmt=(v)=>{
+  if(!v) return 'n/a';
+  const d=new Date(v);
+  return Number.isNaN(d.getTime())?v:d.toLocaleString();
+};
+
+async function getJson(u){
+  const r=await fetch(u);
+  if(!r.ok){
+    const txt=await r.text();
+    throw new Error(txt||('Request failed: '+r.status));
+  }
+  return r.json();
+}
+
+async function sendJson(method,u,payload){
+  const r=await fetch(u,{method,headers:{'content-type':'application/json'},body:payload===undefined?undefined:JSON.stringify(payload)});
+  if(!r.ok){
+    const txt=await r.text();
+    throw new Error(txt||('Request failed: '+r.status));
+  }
+  return r.json();
+}
+
+async function getArtifact(p){
+  const k=s.program+':'+p;
+  if(s.cache.has(k)) return s.cache.get(k);
+  const v=await getJson('/api/runs/'+encodeURIComponent(s.program)+'/artifacts/content?path='+encodeURIComponent(p));
+  s.cache.set(k,v);
+  return v;
+}
+
+function runDefaultArtifact(){
+  const a=s.detail&&s.detail.artifacts||[];
+  for(const p of pref){
+    const m=a.find((x)=>x.path===p);
+    if(m) return m.path;
+  }
+  return a[0]&&a[0].path||null;
+}
+
+function renderRuns(){
+  const root=q('runs');
+  if(!s.runs.length){
+    root.innerHTML='<div class="empty">No runs.</div>';
+    return;
+  }
+  root.innerHTML=s.runs.map((r)=>'<button class="run'+(r.program===s.program?' active':'')+'" data-run="'+esc(r.program)+'"><strong>'+esc(r.program)+'</strong><div>'+esc(r.workflowPreset||r.workflowMode||'standard')+'</div><div>'+esc(fmt(r.completedAt))+'</div></button>').join('');
+  for(const b of root.querySelectorAll('[data-run]')) b.onclick=()=>selectRun(b.dataset.run);
+}
+
+function renderHero(){
+  if(!s.detail){
+    q('title').textContent='Analysis Runs';
+    q('subtitle').textContent='Select a run.';
+    q('chips').innerHTML='';
+    return;
+  }
+  const x=s.detail.summary;
+  q('title').textContent=x.program;
+  q('subtitle').textContent='Focused explorer over graph, DB2, prompts, and Prompt Workbench.';
+  q('chips').innerHTML=['Status: '+(x.status||'unknown'),'Mode: '+(x.workflowPreset||x.workflowMode||'standard'),'Artifacts: '+x.artifactCount,x.safeSharingEnabled?'Safe sharing':'No safe sharing'].map((v)=>'<div class="token">'+esc(v)+'</div>').join('');
+}
+
+function renderMetrics(){
+  const root=q('metrics');
+  if(!s.detail){
+    root.innerHTML='';
+    return;
+  }
+  const a=s.detail.analyzeManifest;
+  const v=s.detail.views;
+  const m=[
+    ['Completed',fmt(s.detail.summary.completedAt)],
+    ['Stages',a.summary.stageCount||0],
+    ['Graph Nodes',v.summary.graphNodeCount||0],
+    ['Prompt Packs',v.summary.promptCount||0]
+  ];
+  root.innerHTML=m.map(([k,vv])=>'<div class="panel metric"><div>'+esc(k)+'</div><strong>'+esc(String(vv))+'</strong></div>').join('');
+}
+
+function renderTabs(){
+  q('tabs').innerHTML=tabs.map(([id,label])=>'<button class="tab'+(s.tab===id?' active':'')+'" data-tab="'+id+'">'+label+'</button>').join('');
+  for(const b of q('tabs').querySelectorAll('[data-tab]')) b.onclick=()=>selectTab(b.dataset.tab);
+}
+
+function linkArtifacts(paths){
+  return !paths||!paths.length
+    ? '<div class="empty">No related artifacts.</div>'
+    : '<div class="chips">'+paths.map((p)=>'<button class="btn" data-art="'+esc(p)+'">'+esc(p)+'</button>').join('')+'</div>';
+}
+
+function linkPrompts(paths){
+  return !paths||!paths.length
+    ? '<div class="empty">No related prompts.</div>'
+    : '<div class="chips">'+paths.map((p)=>'<button class="btn" data-prompt="'+esc(p)+'">'+esc(p)+'</button>').join('')+'</div>';
+}
+
+function linkNodes(paths){
+  return !paths||!paths.length
+    ? '<div class="empty">No connected nodes.</div>'
+    : '<div class="chips">'+paths.map((p)=>'<button class="btn" data-node="'+esc(p)+'">'+esc(p)+'</button>').join('')+'</div>';
+}
+
+function bindCross(root){
+  for(const b of root.querySelectorAll('[data-art]')) b.onclick=()=>{s.artifact=b.dataset.art;s.tab='artifacts';render();};
+  for(const b of root.querySelectorAll('[data-prompt]')) b.onclick=()=>{s.left=b.dataset.prompt;if(!s.right)s.right=b.dataset.prompt;s.tab='prompts';render();};
+  for(const b of root.querySelectorAll('[data-node]')) b.onclick=()=>{s.node=b.dataset.node;s.tab='graph';render();};
+}
+
+function renderGraph(){
+  const root=q('graph');
+  root.classList.toggle('active',s.tab==='graph');
+  if(s.tab!=='graph') return;
+
+  if(!s.detail||!s.detail.views.graph.available){
+    root.innerHTML='<div class="sub"><div class="empty">No graph available.</div></div>';
+    return;
+  }
+
+  const g=s.detail.views.graph;
+  const f=((q('graphFilter')&&q('graphFilter').value)||'').toLowerCase();
+  const nodes=g.nodes.filter((n)=>!f||n.id.toLowerCase().includes(f)||n.type.toLowerCase().includes(f));
+  const sel=g.nodes.find((n)=>n.id===s.node)||nodes[0]||null;
+
+  root.innerHTML='<div class="sub"><h2>Graph Explorer</h2><p>Click nodes to follow related artifacts and prompts.</p><input id="graphFilter" placeholder="Filter nodes"><div class="item-list">'+nodes.map((n)=>'<button class="item'+(sel&&sel.id===n.id?' active':'')+'" data-nid="'+esc(n.id)+'"><strong>'+esc(n.id)+'</strong><div>'+esc(n.type)+' • in '+esc(String(n.incomingCount))+' • out '+esc(String(n.outgoingCount))+'</div></button>').join('')+'</div></div><div class="sub">'+(sel?'<h2>'+esc(sel.id)+'</h2><div class="tokens"><div class="token">'+esc(sel.type)+'</div><div class="token">Connected '+esc(String(sel.connectedNodeIds.length))+'</div></div><h3>Connected Nodes</h3>'+linkNodes(sel.connectedNodeIds)+'<h3>Related Artifacts</h3>'+linkArtifacts(sel.relatedArtifactPaths)+'<h3>Related Prompts</h3>'+linkPrompts(sel.relatedPromptPaths)+(g.viewerArtifact?'<a class="btn" target="_blank" rel="noreferrer" href="/runs/'+encodeURIComponent(s.program)+'/artifacts/raw?path='+encodeURIComponent(g.viewerArtifact)+'">Open Architecture Viewer</a>':''):'<div class="empty">No nodes matched.</div>')+'</div>';
+
+  q('graphFilter').value=f;
+  q('graphFilter').oninput=()=>renderGraph();
+  for(const b of root.querySelectorAll('[data-nid]')) b.onclick=()=>{s.node=b.dataset.nid;renderGraph();};
+  bindCross(root);
+}
+
+function renderDb2(){
+  const root=q('db2');
+  root.classList.toggle('active',s.tab==='db2');
+  if(s.tab!=='db2') return;
+
+  if(!s.detail){
+    root.innerHTML='<div class="sub"><div class="empty">No run selected.</div></div>';
+    return;
+  }
+
+  const d=s.detail.views.db2;
+  if(!d.metadataAvailable&&!d.testDataAvailable){
+    root.innerHTML='<div class="sub"><div class="empty">No DB2 metadata or test data.</div></div>';
+    return;
+  }
+
+  const f=((q('db2Filter')&&q('db2Filter').value)||'').toLowerCase();
+  const tables=d.tables.filter((t)=>!f||t.qualifiedName.toLowerCase().includes(f));
+  const sel=d.tables.find((t)=>t.id===s.table)||tables[0]||null;
+
+  root.innerHTML='<div class="sub"><h2>DB2/Test Data</h2><div class="tokens"><div class="token">Metadata '+esc(String(d.metadataSummary&&d.metadataSummary.tableCount||0))+'</div><div class="token">Samples '+esc(String(d.testDataSummary&&d.testDataSummary.tableCount||0))+'</div><div class="token">Masked '+esc(String(d.testDataSummary&&d.testDataSummary.policySummary&&d.testDataSummary.policySummary.maskedTableCount||0))+'</div></div><input id="db2Filter" placeholder="Filter tables"><div class="item-list">'+tables.map((t)=>'<button class="item'+(sel&&sel.id===t.id?' active':'')+'" data-tid="'+esc(t.id)+'"><strong>'+esc(t.qualifiedName||t.table)+'</strong><div>rows '+esc(String(t.sampleRowCount||0))+' • masks '+esc(String(t.maskedColumnCount||0))+'</div></button>').join('')+'</div></div><div class="sub">'+(sel?'<h2>'+esc(sel.qualifiedName||sel.table)+'</h2><div class="tokens"><div class="token">match '+esc(sel.matchStatus||'unknown')+'</div><div class="token">policy '+esc(sel.policyEligibility||'not-exported')+'</div><div class="token">evidence '+esc(String(sel.sourceEvidenceCount||0))+'</div></div><h3>Artifacts</h3>'+linkArtifacts(sel.relatedArtifactPaths)+'<h3>Prompts</h3>'+linkPrompts(sel.relatedPromptPaths):'<div class="empty">No tables matched.</div>')+'</div>';
+
+  q('db2Filter').value=f;
+  q('db2Filter').oninput=()=>renderDb2();
+  for(const b of root.querySelectorAll('[data-tid]')) b.onclick=()=>{s.table=b.dataset.tid;renderDb2();};
+  bindCross(root);
+}
+
+async function renderPromptPreview(id,path){
+  const root=q(id);
+  if(!path){
+    root.innerHTML='<div class="empty">Choose a prompt.</div>';
+    return;
+  }
+  root.innerHTML='<pre>Loading...</pre>';
+  const p=await getArtifact(path);
+  root.innerHTML='<pre>'+esc(p.content)+'</pre>';
+}
+
+async function renderPrompts(){
+  const root=q('prompts');
+  root.classList.toggle('active',s.tab==='prompts');
+  if(s.tab!=='prompts') return;
+
+  if(!s.detail||!s.detail.views.prompts.artifacts.length){
+    root.innerHTML='<div class="sub"><div class="empty">No prompt artifacts.</div></div>';
+    return;
+  }
+
+  const ps=s.detail.views.prompts.artifacts;
+  if(!s.left) s.left=ps[0].path;
+  if(!s.right) s.right=(ps[1]&&ps[1].path)||ps[0].path;
+
+  root.innerHTML='<div class="sub"><h2>Prompt Compare</h2><p>Compare prompt packs side by side.</p><div class="item-list">'+ps.map((p)=>'<button class="item" data-pick="'+esc(p.path)+'"><strong>'+esc(p.title)+'</strong><div>'+esc(p.path)+'</div></button>').join('')+'</div></div><div class="sub"><h3>Left Prompt</h3><select id="leftSel">'+ps.map((p)=>'<option value="'+esc(p.path)+'"'+(p.path===s.left?' selected':'')+'>'+esc(p.title)+'</option>').join('')+'</select><div id="leftPrev" class="preview"></div></div><div class="sub"><h3>Right Prompt</h3><select id="rightSel">'+ps.map((p)=>'<option value="'+esc(p.path)+'"'+(p.path===s.right?' selected':'')+'>'+esc(p.title)+'</option>').join('')+'</select><div id="rightPrev" class="preview"></div></div>';
+
+  for(const b of root.querySelectorAll('[data-pick]')) b.onclick=()=>{s.left=b.dataset.pick;renderPrompts();};
+  q('leftSel').onchange=(e)=>{s.left=e.target.value;renderPrompts();};
+  q('rightSel').onchange=(e)=>{s.right=e.target.value;renderPrompts();};
+  await Promise.all([renderPromptPreview('leftPrev',s.left),renderPromptPreview('rightPrev',s.right)]);
+}
+
+function moduleTitleMap(){
+  const map={};
+  for(const module of s.promptBuilder.modules||[]){
+    map[module.id]=module.title;
+  }
+  return map;
+}
+
+function moduleById(moduleId){
+  return (s.promptBuilder.modules||[]).find((entry)=>entry.id===moduleId)||null;
+}
+
+function splitTextToList(value){
+  return String(value||'')
+    .split(/\n|,/g)
+    .map((entry)=>entry.trim())
+    .filter(Boolean);
+}
+
+function arrayToText(value){
+  if(!Array.isArray(value)) return '';
+  return value.join('\n');
+}
+
+function collectFieldDefinitions(useCase,moduleOrder){
+  const map={};
+  const ordered=[];
+
+  for(const moduleId of moduleOrder||[]){
+    const module=moduleById(moduleId);
+    if(!module) continue;
+    for(const field of module.configFields||[]){
+      const name=String(field.name||'').trim();
+      if(!name||map[name]) continue;
+      map[name]={
+        name,
+        label:name,
+        type:String(field.type||'string'),
+      };
+      ordered.push(map[name]);
+    }
+  }
+
+  for(const hint of (useCase&&useCase.fieldHints)||[]){
+    const name=String(hint.name||'').trim();
+    if(!name||map[name]) continue;
+    map[name]={
+      name,
+      label:String(hint.label||name),
+      type:String(hint.type||'string'),
+    };
+    ordered.push(map[name]);
+  }
+
+  return ordered;
+}
+
+function fieldValueAsText(value,type){
+  if(type==='array') return arrayToText(value);
+  return value===undefined||value===null?'':String(value);
+}
+
+function parseFieldValue(rawValue,type){
+  if(type==='array') return splitTextToList(rawValue);
+  return String(rawValue||'');
+}
+
+function renderCanvasFieldInput(field,value){
+  const type=String(field&&field.type||'string')==='array'?'array':'string';
+  const name=escAttr(String(field&&field.name||''));
+  const label=esc(String(field&&field.label||field&&field.name||''));
+  if(type==='array'){
+    return '<label>'+label+'<textarea data-wb-field-name=\"'+name+'\" data-wb-field-type=\"array\" placeholder=\"One value per line\">'+esc(fieldValueAsText(value,'array'))+'</textarea></label>';
+  }
+  return '<label>'+label+'<input data-wb-field-name=\"'+name+'\" data-wb-field-type=\"string\" placeholder=\"Enter value\" value=\"'+escAttr(fieldValueAsText(value,'string'))+'\"></label>';
+}
+
+function ensureWorkbenchUseCaseSelection(){
+  if(!selectedUseCase()&&(s.promptBuilder.useCases||[]).length>0){
+    s.promptBuilder.selectedUseCaseId=s.promptBuilder.useCases[0].id;
+  }
+}
+
+function selectedUseCase(){
+  const id=s.promptBuilder.selectedUseCaseId;
+  return (s.promptBuilder.useCases||[]).find((entry)=>entry.id===id)||null;
+}
+
+function initializeWorkbenchForUseCase(useCase,options){
+  if(!useCase) return;
+  const opts=options||{};
+  const reset=Boolean(opts.reset);
+  const moduleSet=new Set((s.promptBuilder.modules||[]).map((entry)=>entry.id));
+
+  if(reset||s.promptBuilder.activeUseCaseId!==useCase.id){
+    s.promptBuilder.activeUseCaseId=useCase.id;
+    s.promptBuilder.moduleOrder=(useCase.defaultModuleIds||[]).filter((id)=>moduleSet.has(id));
+    s.promptBuilder.fields={
+      language:'German',
+      goal:useCase.description||useCase.title||'',
+    };
+    s.promptBuilder.additionalRequirements='';
+    s.promptBuilder.preview=null;
+    s.promptBuilder.previewEditable=false;
+    s.promptBuilder.previewEditableContent='';
+    s.promptBuilder.previewError=null;
+    s.promptBuilder.saveStatus='';
+    s.promptBuilder.selectedTemplateId=null;
+    s.promptBuilder.templateName=(useCase.title||'Prompt')+' Template';
+    s.promptBuilder.templateDescription='';
+    s.promptBuilder.templateTags='';
+  }
+
+  s.promptBuilder.moduleOrder=(s.promptBuilder.moduleOrder||[]).filter((id)=>moduleSet.has(id));
+  if(s.promptBuilder.moduleOrder.length===0){
+    s.promptBuilder.moduleOrder=(useCase.defaultModuleIds||[]).filter((id)=>moduleSet.has(id));
+  }
+  if(s.promptBuilder.moduleOrder.length===0&&(s.promptBuilder.modules||[]).length>0){
+    s.promptBuilder.moduleOrder=[s.promptBuilder.modules[0].id];
+  }
+
+  if(!s.promptBuilder.selectedModuleId||!s.promptBuilder.moduleOrder.includes(s.promptBuilder.selectedModuleId)){
+    s.promptBuilder.selectedModuleId=s.promptBuilder.moduleOrder[0]||null;
+  }
+}
+
+function selectedCanvasModule(){
+  return moduleById(s.promptBuilder.selectedModuleId);
+}
+
+function currentPreviewText(){
+  if(s.promptBuilder.previewEditable) return s.promptBuilder.previewEditableContent||'';
+  return (s.promptBuilder.preview&&s.promptBuilder.preview.content)||'';
+}
+
+function scheduleWorkbenchPreview(){
+  if(s.promptBuilder.previewDebounceHandle){
+    clearTimeout(s.promptBuilder.previewDebounceHandle);
+  }
+  s.promptBuilder.previewDebounceHandle=setTimeout(()=>{
+    s.promptBuilder.previewDebounceHandle=null;
+    generateWorkbenchPreview({silent:true});
+  },WB_PREVIEW_DEBOUNCE_MS);
+}
+
+async function refreshWorkbenchTemplates(){
+  const payload=await getJson('/api/prompt-builder/templates');
+  s.promptBuilder.templates=(payload&&Array.isArray(payload.templates))?payload.templates:[];
+}
+
+async function refreshContextSources(){
+  const payload=await getJson('/api/prompt-builder/context-sources');
+  s.promptBuilder.contextSources=(payload&&Array.isArray(payload.contextSources))?payload.contextSources:[];
+  if(!s.promptBuilder.contextSourceProgram&&s.promptBuilder.contextSources.length>0){
+    s.promptBuilder.contextSourceProgram=s.promptBuilder.contextSources[0].program||'';
+  }
+}
+
+async function loadContextSourcePrompts(program,options){
+  const opts=options||{};
+  const normalized=String(program||'').trim();
+  if(!normalized){
+    s.promptBuilder.contextSourcePrompts=[];
+    s.promptBuilder.contextSourcePromptPath='';
+    if(!opts.silent) renderWorkbench();
+    return;
+  }
+  s.promptBuilder.contextSourceProgram=normalized;
+  if(!opts.silent){
+    s.promptBuilder.contextSourceStatus='Loading context prompts...';
+    renderWorkbench();
+  }
+  try {
+    const payload=await getJson('/api/prompt-builder/context-sources/'+encodeURIComponent(normalized)+'/prompts');
+    const promptArtifacts=(payload&&Array.isArray(payload.promptArtifacts))?payload.promptArtifacts:[];
+    s.promptBuilder.contextSourcePrompts=promptArtifacts;
+    if(!promptArtifacts.some((entry)=>entry.path===s.promptBuilder.contextSourcePromptPath)){
+      s.promptBuilder.contextSourcePromptPath=promptArtifacts[0]?promptArtifacts[0].path:'';
+    }
+    s.promptBuilder.contextSourceStatus=promptArtifacts.length>0?'Context prompts loaded.':'No ai_prompt artifacts for selected run.';
+  } catch(error){
+    s.promptBuilder.contextSourcePrompts=[];
+    s.promptBuilder.contextSourcePromptPath='';
+    s.promptBuilder.contextSourceStatus='Context load failed: '+(error.message||String(error));
+  }
+  if(!opts.silent) renderWorkbench();
+}
+
+function applyImportedContextSeed(seed){
+  const content=String(seed&&seed.content||'');
+  if(!content){
+    s.promptBuilder.contextSourceStatus='Imported prompt is empty.';
+    return;
+  }
+  s.promptBuilder.previewEditable=true;
+  s.promptBuilder.previewEditableContent=content;
+  const marker='Imported context seed from '+String(seed.program||'')+'/'+String(seed.path||'');
+  const currentReq=String(s.promptBuilder.additionalRequirements||'').trim();
+  s.promptBuilder.additionalRequirements=currentReq?currentReq+'\\n'+marker:marker;
+  s.promptBuilder.contextSourceStatus='Imported '+String(seed.path||'')+' as preview seed.';
+  s.promptBuilder.saveStatus='Context seed applied.';
+}
+
+async function importContextSourcePrompt(){
+  const program=String(s.promptBuilder.contextSourceProgram||'').trim();
+  const promptPath=String(s.promptBuilder.contextSourcePromptPath||'').trim();
+  if(!program||!promptPath){
+    s.promptBuilder.contextSourceStatus='Select a run and prompt artifact first.';
+    renderWorkbench();
+    return;
+  }
+  s.promptBuilder.contextSourceStatus='Importing context prompt...';
+  renderWorkbench();
+  try {
+    const payload=await sendJson('POST','/api/prompt-builder/context-sources/import',{
+      program,
+      path:promptPath,
+    });
+    applyImportedContextSeed(payload.seed||{});
+  } catch(error){
+    s.promptBuilder.contextSourceStatus='Import failed: '+(error.message||String(error));
+  }
+  renderWorkbench();
+}
+
+async function loadPromptBuilderData(){
+  s.promptBuilder.loading=true;
+  s.promptBuilder.error=null;
+  renderWorkbench();
+
+  try {
+    const payload=await Promise.all([
+      getJson('/api/prompt-builder/use-cases'),
+      getJson('/api/prompt-builder/modules'),
+      getJson('/api/prompt-builder/templates'),
+      getJson('/api/prompt-builder/context-sources')
+    ]);
+
+    const useCases=(payload[0]&&Array.isArray(payload[0].useCases))?payload[0].useCases:[];
+    const modules=(payload[1]&&Array.isArray(payload[1].modules))?payload[1].modules:[];
+    const templates=(payload[2]&&Array.isArray(payload[2].templates))?payload[2].templates:[];
+    const contextSources=(payload[3]&&Array.isArray(payload[3].contextSources))?payload[3].contextSources:[];
+
+    s.promptBuilder.useCases=useCases;
+    s.promptBuilder.modules=modules;
+    s.promptBuilder.templates=templates;
+    s.promptBuilder.contextSources=contextSources;
+    s.promptBuilder.loaded=true;
+    if(!s.promptBuilder.contextSourceProgram&&contextSources.length>0){
+      s.promptBuilder.contextSourceProgram=contextSources[0].program||'';
+    }
+
+    ensureWorkbenchUseCaseSelection();
+    initializeWorkbenchForUseCase(selectedUseCase(),{reset:false});
+    scheduleWorkbenchPreview();
+    if(s.promptBuilder.contextSourceProgram){
+      await loadContextSourcePrompts(s.promptBuilder.contextSourceProgram,{silent:true});
+    }
+  } catch(error){
+    s.promptBuilder.error=error.message||String(error);
+  } finally {
+    s.promptBuilder.loading=false;
+    renderWorkbench();
+  }
+}
+
+function setWorkbenchUseCase(useCaseId){
+  s.promptBuilder.selectedUseCaseId=useCaseId;
+  initializeWorkbenchForUseCase(selectedUseCase(),{reset:true});
+  renderWorkbench();
+  scheduleWorkbenchPreview();
+}
+
+function addCanvasModule(moduleId){
+  if(!moduleId) return;
+  if((s.promptBuilder.moduleOrder||[]).includes(moduleId)) return;
+  s.promptBuilder.moduleOrder.push(moduleId);
+  s.promptBuilder.selectedModuleId=moduleId;
+  s.promptBuilder.saveStatus='';
+  renderWorkbench();
+  scheduleWorkbenchPreview();
+}
+
+function removeCanvasModule(index){
+  if(!Array.isArray(s.promptBuilder.moduleOrder)) return;
+  if(index<0||index>=s.promptBuilder.moduleOrder.length) return;
+  const removed=s.promptBuilder.moduleOrder[index];
+  s.promptBuilder.moduleOrder.splice(index,1);
+  if(s.promptBuilder.selectedModuleId===removed){
+    s.promptBuilder.selectedModuleId=s.promptBuilder.moduleOrder[0]||null;
+  }
+  s.promptBuilder.saveStatus='';
+  renderWorkbench();
+  scheduleWorkbenchPreview();
+}
+
+function moveCanvasModule(index,delta){
+  const target=index+delta;
+  if(!Array.isArray(s.promptBuilder.moduleOrder)) return;
+  if(index<0||index>=s.promptBuilder.moduleOrder.length) return;
+  if(target<0||target>=s.promptBuilder.moduleOrder.length) return;
+  const value=s.promptBuilder.moduleOrder[index];
+  s.promptBuilder.moduleOrder.splice(index,1);
+  s.promptBuilder.moduleOrder.splice(target,0,value);
+  s.promptBuilder.saveStatus='';
+  renderWorkbench();
+  scheduleWorkbenchPreview();
+}
+
+function updateCanvasField(name,type,value){
+  const fieldName=String(name||'').trim();
+  if(!fieldName) return;
+  if(!s.promptBuilder.fields||typeof s.promptBuilder.fields!=='object'){
+    s.promptBuilder.fields={};
+  }
+  s.promptBuilder.fields[fieldName]=parseFieldValue(value,type);
+  s.promptBuilder.saveStatus='';
+  scheduleWorkbenchPreview();
+}
+
+function tagsTextToList(value){
+  return splitTextToList(value);
+}
+
+function tagsListToText(values){
+  return (Array.isArray(values)?values:[]).join(', ');
+}
+
+function templatePayloadFromCanvas(useCase){
+  return {
+    name:String(s.promptBuilder.templateName||'').trim(),
+    description:String(s.promptBuilder.templateDescription||'').trim(),
+    useCaseId:useCase.id,
+    moduleIds:[...(s.promptBuilder.moduleOrder||[])],
+    fields:s.promptBuilder.fields||{},
+    additionalRequirements:String(s.promptBuilder.additionalRequirements||''),
+    tags:tagsTextToList(s.promptBuilder.templateTags),
+  };
+}
+
+async function saveWorkbenchTemplate(){
+  const useCase=selectedUseCase();
+  if(!useCase) return;
+  const payload=templatePayloadFromCanvas(useCase);
+  const templateId=s.promptBuilder.selectedTemplateId;
+  s.promptBuilder.saveStatus='Saving template...';
+  renderWorkbench();
+  try {
+    const result=templateId
+      ? await sendJson('PUT','/api/prompt-builder/templates/'+encodeURIComponent(templateId),payload)
+      : await sendJson('POST','/api/prompt-builder/templates',payload);
+    s.promptBuilder.selectedTemplateId=result.template.id;
+    s.promptBuilder.templateName=result.template.name||payload.name;
+    s.promptBuilder.templateDescription=result.template.description||payload.description||'';
+    s.promptBuilder.templateTags=tagsListToText(result.template.tags||payload.tags||[]);
+    await refreshWorkbenchTemplates();
+    s.promptBuilder.saveStatus='Template saved.';
+  } catch(error){
+    s.promptBuilder.saveStatus='Save failed: '+(error.message||String(error));
+  }
+  renderWorkbench();
+}
+
+async function deleteWorkbenchTemplate(){
+  const templateId=s.promptBuilder.selectedTemplateId;
+  if(!templateId) return;
+  s.promptBuilder.saveStatus='Deleting template...';
+  renderWorkbench();
+  try {
+    await sendJson('DELETE','/api/prompt-builder/templates/'+encodeURIComponent(templateId));
+    s.promptBuilder.selectedTemplateId=null;
+    s.promptBuilder.saveStatus='Template deleted.';
+    await refreshWorkbenchTemplates();
+  } catch(error){
+    s.promptBuilder.saveStatus='Delete failed: '+(error.message||String(error));
+  }
+  renderWorkbench();
+}
+
+function applyTemplateToCanvas(template){
+  if(!template||typeof template!=='object') return;
+  s.promptBuilder.selectedUseCaseId=template.useCaseId||s.promptBuilder.selectedUseCaseId;
+  const useCase=selectedUseCase();
+  if(!useCase) return;
+  initializeWorkbenchForUseCase(useCase,{reset:true});
+  s.promptBuilder.moduleOrder=Array.isArray(template.moduleIds)?[...template.moduleIds]:[];
+  initializeWorkbenchForUseCase(useCase,{reset:false});
+  s.promptBuilder.fields=(template.fields&&typeof template.fields==='object'&&!Array.isArray(template.fields))?template.fields:{};
+  s.promptBuilder.additionalRequirements=String(template.additionalRequirements||'');
+  s.promptBuilder.selectedTemplateId=template.id||null;
+  s.promptBuilder.templateName=String(template.name||'');
+  s.promptBuilder.templateDescription=String(template.description||'');
+  s.promptBuilder.templateTags=tagsListToText(template.tags||[]);
+  s.promptBuilder.preview=null;
+  s.promptBuilder.previewEditable=false;
+  s.promptBuilder.previewEditableContent='';
+  s.promptBuilder.previewError=null;
+  s.promptBuilder.saveStatus='Template loaded.';
+}
+
+async function loadWorkbenchTemplate(templateId){
+  if(!templateId) return;
+  s.promptBuilder.saveStatus='Loading template...';
+  renderWorkbench();
+  try {
+    const payload=await getJson('/api/prompt-builder/templates/'+encodeURIComponent(templateId));
+    applyTemplateToCanvas(payload.template);
+    scheduleWorkbenchPreview();
+  } catch(error){
+    s.promptBuilder.saveStatus='Load failed: '+(error.message||String(error));
+  }
+  renderWorkbench();
+}
+
+async function generateWorkbenchPreview(options){
+  const opts=options||{};
+  const useCase=selectedUseCase();
+  if(!useCase) return;
+  initializeWorkbenchForUseCase(useCase,{reset:false});
+
+  s.promptBuilder.previewLoading=true;
+  s.promptBuilder.previewError=null;
+  if(!opts.silent) renderWorkbench();
+
+  try {
+    const preview=await sendJson('POST','/api/prompt-builder/preview',{
+      useCaseId:useCase.id,
+      moduleIds:[...(s.promptBuilder.moduleOrder||[])],
+      additionalRequirements:String(s.promptBuilder.additionalRequirements||''),
+      fields:s.promptBuilder.fields||{},
+    });
+    s.promptBuilder.preview=preview.preview;
+    if(!s.promptBuilder.previewEditable){
+      s.promptBuilder.previewEditableContent=(preview&&preview.preview&&preview.preview.content)||'';
+    }
+  } catch(error){
+    s.promptBuilder.previewError=error.message||String(error);
+  } finally {
+    s.promptBuilder.previewLoading=false;
+    renderWorkbench();
+  }
+}
+
+function setPreviewEditMode(editable){
+  const enabled=Boolean(editable);
+  s.promptBuilder.previewEditable=enabled;
+  if(enabled){
+    s.promptBuilder.previewEditableContent=(s.promptBuilder.preview&&s.promptBuilder.preview.content)||s.promptBuilder.previewEditableContent||'';
+  }
+  renderWorkbench();
+}
+
+async function copyWorkbenchPreview(){
+  const text=currentPreviewText();
+  if(!text){
+    s.promptBuilder.saveStatus='Nothing to copy.';
+    renderWorkbench();
+    return;
+  }
+  try {
+    if(navigator&&navigator.clipboard&&navigator.clipboard.writeText){
+      await navigator.clipboard.writeText(text);
+    } else {
+      const area=document.createElement('textarea');
+      area.value=text;
+      document.body.appendChild(area);
+      area.focus();
+      area.select();
+      document.execCommand('copy');
+      document.body.removeChild(area);
+    }
+    s.promptBuilder.saveStatus='Preview copied.';
+  } catch(error){
+    s.promptBuilder.saveStatus='Copy failed: '+(error.message||String(error));
+  }
+  renderWorkbench();
+}
+
+function exportWorkbenchPreview(){
+  const text=currentPreviewText();
+  if(!text){
+    s.promptBuilder.saveStatus='Nothing to export.';
+    renderWorkbench();
+    return;
+  }
+  const useCase=selectedUseCase();
+  const safeName=String((s.promptBuilder.templateName||((useCase&&useCase.id)||'prompt-workbench'))).trim().toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/(^-|-$)/g,'')||'prompt-workbench';
+  const fileName=safeName+'.md';
+  const blob=new Blob([text],{type:'text/markdown;charset=utf-8'});
+  const link=document.createElement('a');
+  link.href=URL.createObjectURL(blob);
+  link.download=fileName;
+  document.body.appendChild(link);
+  link.click();
+  URL.revokeObjectURL(link.href);
+  document.body.removeChild(link);
+  s.promptBuilder.saveStatus='Exported '+fileName+'.';
+  renderWorkbench();
+}
+
+function renderWorkbench(){
+  const root=q('workbench');
+  root.classList.toggle('active',s.tab==='workbench');
+  if(s.tab!=='workbench') return;
+
+  if(s.promptBuilder.loading){
+    root.innerHTML='<div class="sub"><div class="empty">Loading Prompt Workbench use cases...</div></div>';
+    return;
+  }
+
+  if(s.promptBuilder.error){
+    root.innerHTML='<div class="sub"><div class="empty">Prompt Workbench unavailable: '+esc(s.promptBuilder.error)+'</div><div class="actions"><button class="btn" id="wbRetry">Retry</button></div></div>';
+    const retry=q('wbRetry');
+    if(retry) retry.onclick=()=>loadPromptBuilderData();
+    return;
+  }
+
+  const useCases=s.promptBuilder.useCases||[];
+  if(!useCases.length){
+    root.innerHTML='<div class="sub"><div class="empty">No prompt builder use cases available.</div></div>';
+    return;
+  }
+
+  ensureWorkbenchUseCaseSelection();
+  initializeWorkbenchForUseCase(selectedUseCase(),{reset:false});
+
+  const filter=((q('wbFilter')&&q('wbFilter').value)||'').toLowerCase();
+  const filtered=useCases.filter((entry)=>!filter||entry.title.toLowerCase().includes(filter)||entry.description.toLowerCase().includes(filter)||entry.id.toLowerCase().includes(filter));
+  const selected=selectedUseCase();
+  const moduleMap=moduleTitleMap();
+  const preview=s.promptBuilder.preview;
+  const moduleOrder=s.promptBuilder.moduleOrder||[];
+  const availableModules=(s.promptBuilder.modules||[]).filter((entry)=>!moduleOrder.includes(entry.id));
+  const selectedModule=selectedCanvasModule();
+  const fieldDefs=collectFieldDefinitions(selected,moduleOrder);
+  const activeFieldDefs=selectedModule&&Array.isArray(selectedModule.configFields)&&selectedModule.configFields.length>0
+    ? selectedModule.configFields.map((field)=>({
+      name:String(field.name||'').trim(),
+      label:String(field.name||'').trim(),
+      type:String(field.type||'string'),
+    })).filter((entry)=>entry.name)
+    : fieldDefs;
+  const previewText=currentPreviewText();
+
+  root.innerHTML='<div class="sub"><h2>Prompt Workbench</h2><p>Prompt Canvas for direct toolset implementation workflows.</p><input id="wbFilter" type="search" placeholder="Filter use cases"><div class="card-grid">'+filtered.map((entry)=>'<div class="card'+(selected&&selected.id===entry.id?' active':'')+'"><h3>'+esc(entry.title)+'</h3><p>'+esc(entry.description||'')+'</p><div class="meta"><div class="token">Priority: '+esc(entry.priority||'n/a')+'</div><div class="token">Default Modules: '+esc(String((entry.defaultModuleIds||[]).length))+'</div></div><div class="actions"><button class="btn" data-wb-select="'+esc(entry.id)+'">Select</button></div></div>').join('')+'</div><h3>Template</h3><div class="field-grid"><label>Name<input id="wbTemplateName" value="'+escAttr(s.promptBuilder.templateName||'')+'" placeholder="Template name"></label><label>Description<textarea id="wbTemplateDescription" placeholder="Template description">'+esc(s.promptBuilder.templateDescription||'')+'</textarea></label><label>Tags (comma separated)<input id="wbTemplateTags" value="'+escAttr(s.promptBuilder.templateTags||'')+'" placeholder="mvp, api, ui"></label><label>Saved Templates<select id="wbTemplateSel"><option value="">'+esc('Select saved template')+'</option>'+((s.promptBuilder.templates||[]).map((template)=>'<option value="'+esc(template.id)+'"'+(template.id===s.promptBuilder.selectedTemplateId?' selected':'')+'>'+esc(template.name)+'</option>').join(''))+'</select></label></div><div class="actions"><button class="btn" id="wbLoadTemplate">Load</button><button class="btn" id="wbSaveTemplate">Save Template</button><button class="btn" id="wbDeleteTemplate">Delete</button></div><div class="small '+(String(s.promptBuilder.saveStatus||'').toLowerCase().includes('failed')?'status-err':'status-ok')+'">'+esc(s.promptBuilder.saveStatus||'')+'</div><h3>Output Context Source</h3><div class="field-grid"><label>Analyze Run<select id="wbContextRunSel"><option value="">'+esc('Select output/<PROGRAM>')+'</option>'+((s.promptBuilder.contextSources||[]).map((entry)=>'<option value="'+esc(entry.program)+'"'+(entry.program===s.promptBuilder.contextSourceProgram?' selected':'')+'>'+esc(entry.program+' ('+(entry.promptArtifactCount||0)+' prompts)')+'</option>').join(''))+'</select></label><label>Prompt Artifact<select id="wbContextPromptSel"><option value="">'+esc('Select ai_prompt_*.md')+'</option>'+((s.promptBuilder.contextSourcePrompts||[]).map((entry)=>'<option value="'+esc(entry.path)+'"'+(entry.path===s.promptBuilder.contextSourcePromptPath?' selected':'')+'>'+esc(entry.path)+'</option>').join(''))+'</select></label></div><div class="actions"><button class="btn" id="wbContextRefresh">Refresh Runs</button><button class="btn" id="wbContextLoadPrompts">Load Prompts</button><button class="btn" id="wbContextImport">Import As Seed</button></div><div class="small '+(String(s.promptBuilder.contextSourceStatus||'').toLowerCase().includes('failed')?'status-err':'status-ok')+'">'+esc(s.promptBuilder.contextSourceStatus||'')+'</div><h3>Prompt Canvas</h3><div class="item-list">'+moduleOrder.map((moduleId,index)=>'<div class="module-row'+(s.promptBuilder.selectedModuleId===moduleId?' active':'')+'"><h4>'+esc(moduleMap[moduleId]||moduleId)+'</h4><div class="small">'+esc(moduleId)+'</div><div class="actions"><button class="btn" data-wb-module-select="'+esc(moduleId)+'">Config</button><button class="btn" data-wb-module-up="'+esc(String(index))+'">Up</button><button class="btn" data-wb-module-down="'+esc(String(index))+'">Down</button><button class="btn" data-wb-module-remove="'+esc(String(index))+'">Remove</button></div></div>').join('')+'</div><h4>Add Module</h4><div class="chips">'+(availableModules.length?availableModules.map((module)=>'<button class="btn" data-wb-module-add="'+esc(module.id)+'">+ '+esc(module.title)+'</button>').join(''):'<div class="empty">All modules in canvas.</div>')+'</div><h4>Additional Requirements</h4><textarea id="wbAddReq" style="min-height:180px" placeholder="Additional requirements for this implementation prompt...">'+esc(s.promptBuilder.additionalRequirements||'')+'</textarea></div>'+
+    '<div class="sub">'+
+    (selected?'<h2>'+esc(selected.title)+'</h2><p>'+esc(selected.description||'')+'</p><div class="tokens"><div class="token">Modules in Canvas: '+esc(String(moduleOrder.length))+'</div><div class="token">Preview tokens: '+esc(String((preview&&preview.estimatedTokens)||0))+'</div><div class="token">Mode: '+esc(s.promptBuilder.previewEditable?'edit':'live')+'</div></div><h3>Module Configuration'+(selectedModule?': '+esc(selectedModule.title):'')+'</h3>'+(activeFieldDefs.length?'<div class="field-grid">'+activeFieldDefs.map((field)=>renderCanvasFieldInput(field,(s.promptBuilder.fields||{})[field.name])).join('')+'</div>':'<div class="empty">No configurable fields for selected modules.</div>')+'<div class="actions"><button class="btn" id="wbPreviewRefresh">Refresh Preview</button><button class="btn" id="wbEditToggle">'+esc(s.promptBuilder.previewEditable?'Lock Preview':'Edit Preview')+'</button><button class="btn" id="wbCopyPreview">Copy</button><button class="btn" id="wbExportPreview">Export</button><button class="btn" id="wbToCompare">Open Prompt Compare</button></div><h3>Live Preview</h3><div id="wbPreviewPane" class="preview">'+(s.promptBuilder.previewLoading?'<pre>Generating preview...</pre>':s.promptBuilder.previewError?'<div class="empty">'+esc(s.promptBuilder.previewError)+'</div>':s.promptBuilder.previewEditable?'<textarea id="wbPreviewEditor" style="min-height:360px">'+esc(previewText)+'</textarea>':previewText?'<pre>'+esc(previewText)+'</pre>':'<div class="empty">No preview yet. Configure canvas or click refresh.</div>')+'</div>'
+    :'<div class="empty">Select a use case to start.</div>')+
+    '</div>';
+
+  const filterInput=q('wbFilter');
+  if(filterInput){
+    filterInput.value=filter;
+    filterInput.oninput=()=>renderWorkbench();
+  }
+
+  for(const b of root.querySelectorAll('[data-wb-select]')){
+    b.onclick=()=>setWorkbenchUseCase(b.dataset.wbSelect);
+  }
+
+  const templateName=q('wbTemplateName');
+  if(templateName){
+    templateName.oninput=(e)=>{s.promptBuilder.templateName=e.target.value;s.promptBuilder.saveStatus='';};
+  }
+
+  const templateDescription=q('wbTemplateDescription');
+  if(templateDescription){
+    templateDescription.oninput=(e)=>{s.promptBuilder.templateDescription=e.target.value;s.promptBuilder.saveStatus='';};
+  }
+
+  const templateTags=q('wbTemplateTags');
+  if(templateTags){
+    templateTags.oninput=(e)=>{s.promptBuilder.templateTags=e.target.value;s.promptBuilder.saveStatus='';};
+  }
+
+  const templateSel=q('wbTemplateSel');
+  if(templateSel){
+    templateSel.onchange=(e)=>{
+      s.promptBuilder.selectedTemplateId=e.target.value||null;
+      s.promptBuilder.saveStatus='';
+    };
+  }
+
+  const loadTemplateButton=q('wbLoadTemplate');
+  if(loadTemplateButton){
+    loadTemplateButton.onclick=()=>loadWorkbenchTemplate((q('wbTemplateSel')&&q('wbTemplateSel').value)||s.promptBuilder.selectedTemplateId);
+  }
+
+  const saveTemplateButton=q('wbSaveTemplate');
+  if(saveTemplateButton){
+    saveTemplateButton.onclick=()=>saveWorkbenchTemplate();
+  }
+
+  const deleteTemplateButton=q('wbDeleteTemplate');
+  if(deleteTemplateButton){
+    deleteTemplateButton.onclick=()=>deleteWorkbenchTemplate();
+  }
+
+  const contextRunSel=q('wbContextRunSel');
+  if(contextRunSel){
+    contextRunSel.onchange=(e)=>{
+      s.promptBuilder.contextSourceProgram=e.target.value||'';
+      s.promptBuilder.contextSourceStatus='';
+    };
+  }
+
+  const contextPromptSel=q('wbContextPromptSel');
+  if(contextPromptSel){
+    contextPromptSel.onchange=(e)=>{
+      s.promptBuilder.contextSourcePromptPath=e.target.value||'';
+      s.promptBuilder.contextSourceStatus='';
+    };
+  }
+
+  const contextRefresh=q('wbContextRefresh');
+  if(contextRefresh){
+    contextRefresh.onclick=async()=>{
+      s.promptBuilder.contextSourceStatus='Refreshing context runs...';
+      renderWorkbench();
+      try {
+        await refreshContextSources();
+        s.promptBuilder.contextSourceStatus='Context runs refreshed.';
+      } catch(error){
+        s.promptBuilder.contextSourceStatus='Context refresh failed: '+(error.message||String(error));
+      }
+      renderWorkbench();
+    };
+  }
+
+  const contextLoadPrompts=q('wbContextLoadPrompts');
+  if(contextLoadPrompts){
+    contextLoadPrompts.onclick=()=>loadContextSourcePrompts((q('wbContextRunSel')&&q('wbContextRunSel').value)||s.promptBuilder.contextSourceProgram);
+  }
+
+  const contextImport=q('wbContextImport');
+  if(contextImport){
+    contextImport.onclick=()=>{
+      s.promptBuilder.contextSourceProgram=(q('wbContextRunSel')&&q('wbContextRunSel').value)||s.promptBuilder.contextSourceProgram;
+      s.promptBuilder.contextSourcePromptPath=(q('wbContextPromptSel')&&q('wbContextPromptSel').value)||s.promptBuilder.contextSourcePromptPath;
+      importContextSourcePrompt();
+    };
+  }
+
+  for(const b of root.querySelectorAll('[data-wb-module-select]')){
+    b.onclick=()=>{s.promptBuilder.selectedModuleId=b.dataset.wbModuleSelect;renderWorkbench();};
+  }
+
+  for(const b of root.querySelectorAll('[data-wb-module-up]')){
+    b.onclick=()=>moveCanvasModule(Number(b.dataset.wbModuleUp),-1);
+  }
+
+  for(const b of root.querySelectorAll('[data-wb-module-down]')){
+    b.onclick=()=>moveCanvasModule(Number(b.dataset.wbModuleDown),1);
+  }
+
+  for(const b of root.querySelectorAll('[data-wb-module-remove]')){
+    b.onclick=()=>removeCanvasModule(Number(b.dataset.wbModuleRemove));
+  }
+
+  for(const b of root.querySelectorAll('[data-wb-module-add]')){
+    b.onclick=()=>addCanvasModule(b.dataset.wbModuleAdd);
+  }
+
+  const addReq=q('wbAddReq');
+  if(addReq){
+    addReq.oninput=(e)=>{
+      s.promptBuilder.additionalRequirements=e.target.value;
+      s.promptBuilder.saveStatus='';
+      scheduleWorkbenchPreview();
+    };
+  }
+
+  for(const fieldInput of root.querySelectorAll('[data-wb-field-name]')){
+    fieldInput.oninput=(e)=>{
+      updateCanvasField(e.target.dataset.wbFieldName,e.target.dataset.wbFieldType,e.target.value);
+    };
+  }
+
+  const previewRefresh=q('wbPreviewRefresh');
+  if(previewRefresh){
+    previewRefresh.onclick=()=>generateWorkbenchPreview();
+  }
+
+  const editToggle=q('wbEditToggle');
+  if(editToggle){
+    editToggle.onclick=()=>setPreviewEditMode(!s.promptBuilder.previewEditable);
+  }
+
+  const copyPreview=q('wbCopyPreview');
+  if(copyPreview){
+    copyPreview.onclick=()=>copyWorkbenchPreview();
+  }
+
+  const exportPreview=q('wbExportPreview');
+  if(exportPreview){
+    exportPreview.onclick=()=>exportWorkbenchPreview();
+  }
+
+  const previewEditor=q('wbPreviewEditor');
+  if(previewEditor){
+    previewEditor.oninput=(e)=>{s.promptBuilder.previewEditableContent=e.target.value;};
+  }
+
+  const toCompare=q('wbToCompare');
+  if(toCompare){
+    toCompare.onclick=()=>{s.tab='prompts';render();};
+  }
+}
+function renderArtifacts(){
+  const root=q('artifacts');
+  root.classList.toggle('active',s.tab==='artifacts');
+  if(s.tab!=='artifacts') return;
+
+  if(!s.detail||!s.detail.artifacts.length){
+    root.innerHTML='<div class="sub"><div class="empty">No artifacts.</div></div>';
+    return;
+  }
+
+  root.innerHTML='<div class="sub"><h2>Artifact Explorer</h2><p>Artifacts are fetched only when selected.</p><div class="item-list">'+s.detail.artifacts.map((a)=>'<button class="item'+(a.path===s.artifact?' active':'')+'" data-aid="'+esc(a.path)+'"><strong>'+esc(a.path)+'</strong><div>'+esc(a.kind)+' • '+esc(String(a.sizeBytes))+' bytes</div></button>').join('')+'</div></div><div class="sub"><div class="stack"><h2 id="aTitle">Artifact Preview</h2><p id="aSub">Choose an artifact.</p></div><a id="aRaw" class="btn" target="_blank" rel="noreferrer" hidden>Open Raw</a><div id="aPrev" class="preview"><div class="empty">No artifact selected.</div></div></div>';
+
+  for(const b of root.querySelectorAll('[data-aid]')){
+    b.onclick=()=>{
+      s.artifact=b.dataset.aid;
+      renderArtifacts();
+      renderArtifactPreview();
+    };
+  }
+}
+
+async function renderArtifactPreview(){
+  if(s.tab!=='artifacts') return;
+
+  const root=q('aPrev');
+  const title=q('aTitle');
+  const sub=q('aSub');
+  const raw=q('aRaw');
+
+  if(!s.artifact){
+    title.textContent='Artifact Preview';
+    sub.textContent='Choose an artifact.';
+    root.innerHTML='<div class="empty">No artifact selected.</div>';
+    raw.hidden=true;
+    return;
+  }
+
+  const art=s.detail.artifacts.find((a)=>a.path===s.artifact);
+  if(!art){
+    root.innerHTML='<div class="empty">Artifact not found.</div>';
+    raw.hidden=true;
+    return;
+  }
+
+  title.textContent=art.path;
+  sub.textContent=art.kind+' preview';
+
+  const rawUrl='/runs/'+encodeURIComponent(s.program)+'/artifacts/raw?path='+encodeURIComponent(art.path);
+  raw.href=rawUrl;
+  raw.hidden=false;
+
+  if(art.kind==='html'){
+    root.innerHTML='<iframe src="'+rawUrl+'"></iframe>';
+    return;
+  }
+
+  root.innerHTML='<pre>Loading...</pre>';
+  const p=await getArtifact(art.path);
+  const c=art.kind==='json'?JSON.stringify(JSON.parse(p.content),null,2):p.content;
+  root.innerHTML='<pre>'+esc(c)+'</pre>';
+}
+
+async function selectTab(tab){
+  s.tab=tab;
+  await render();
+}
+
+async function render(){
+  renderTabs();
+  renderGraph();
+  renderDb2();
+  await renderPrompts();
+  renderWorkbench();
+  renderArtifacts();
+  await renderArtifactPreview();
+}
+
+async function selectRun(program){
+  s.program=program;
+  s.cache.clear();
+  renderRuns();
+
+  s.detail=await getJson('/api/runs/'+encodeURIComponent(program));
+  s.artifact=runDefaultArtifact();
+  s.node=s.detail.views.graph.nodes[0]&&s.detail.views.graph.nodes[0].id||null;
+  s.table=s.detail.views.db2.tables[0]&&s.detail.views.db2.tables[0].id||null;
+
+  const ps=s.detail.views.prompts.artifacts;
+  s.left=ps[0]&&ps[0].path||null;
+  s.right=ps[1]&&ps[1].path||s.left;
+
+  renderHero();
+  renderMetrics();
+  await render();
+}
+
+async function boot(){
+  await loadPromptBuilderData();
+  s.runs=await getJson('/api/runs');
+  renderRuns();
+  renderTabs();
+  if(s.runs.length) await selectRun(s.runs[0].program);
+  else await render();
+}
+
+boot().catch((e)=>{
+  q('artifacts').classList.add('active');
+  q('artifacts').innerHTML='<div class="sub"><div class="empty">'+esc(e.message||String(e))+'</div></div>';
+});
+</script>
+</body>
+</html>`;
 }
 
 module.exports = {

--- a/src/ui/promptWorkbenchRegistry.js
+++ b/src/ui/promptWorkbenchRegistry.js
@@ -1,0 +1,521 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+function normalizeString(value, fallback = '') {
+  const normalized = String(value === undefined || value === null ? '' : value).trim();
+  return normalized || fallback;
+}
+
+function normalizeArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => String(entry || '').trim())
+    .filter(Boolean);
+}
+
+function asMarkdownList(values, emptyText = '- none') {
+  const lines = normalizeArray(values);
+  if (lines.length === 0) return emptyText;
+  return lines.map((line) => `- ${line}`).join('\n');
+}
+
+function dedupe(values) {
+  const seen = new Set();
+  const result = [];
+  for (const value of normalizeArray(values)) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+const MODULE_REGISTRY = Object.freeze({
+  'system-role': Object.freeze({
+    id: 'system-role',
+    title: 'System Role',
+    category: 'foundation',
+    description: 'Sets the assistant role, scope, and engineering mode.',
+    configFields: Object.freeze([
+      Object.freeze({ name: 'assistantRole', type: 'string', required: false }),
+      Object.freeze({ name: 'language', type: 'string', required: false }),
+    ]),
+    render(context) {
+      const role = normalizeString(context.fields.assistantRole, 'Senior Node.js and AI Engineer for zeus-rpg-promptkit');
+      const language = normalizeString(context.fields.language, 'German');
+      return [
+        '## Role',
+        `You are a ${role}.`,
+        'Work directly in the zeus-rpg-promptkit repository and optimize for production-ready implementation quality.',
+        `Response language: ${language}.`,
+      ].join('\n');
+    },
+  }),
+  'toolset-context': Object.freeze({
+    id: 'toolset-context',
+    title: 'Toolset Context',
+    category: 'context',
+    description: 'Pins work to the toolset implementation scope and current repository constraints.',
+    configFields: Object.freeze([
+      Object.freeze({ name: 'repoName', type: 'string', required: false }),
+      Object.freeze({ name: 'livingDocPath', type: 'string', required: false }),
+      Object.freeze({ name: 'technicalStrategy', type: 'string', required: false }),
+    ]),
+    render(context) {
+      const repoName = normalizeString(context.fields.repoName, 'zeus-rpg-promptkit');
+      const livingDocPath = normalizeString(context.fields.livingDocPath, 'config/local-only/GUI_PROMPT_BUILDER_LIVING_DOC.md');
+      const technicalStrategy = normalizeString(context.fields.technicalStrategy, 'Node.js-first');
+      return [
+        '## Project Context',
+        `- Repository: \`${repoName}\``,
+        `- Living document: \`${livingDocPath}\``,
+        `- Technical strategy: ${technicalStrategy}`,
+        '- Focus: implement Prompt Workbench capabilities in the toolset itself (not source-program analysis output writing).',
+      ].join('\n');
+    },
+  }),
+  'implementation-task': Object.freeze({
+    id: 'implementation-task',
+    title: 'Implementation Task',
+    category: 'task',
+    description: 'Defines the concrete implementation goal for the selected use case.',
+    configFields: Object.freeze([
+      Object.freeze({ name: 'goal', type: 'string', required: false }),
+      Object.freeze({ name: 'inScope', type: 'array', required: false }),
+      Object.freeze({ name: 'outOfScope', type: 'array', required: false }),
+    ]),
+    render(context) {
+      const goal = normalizeString(context.fields.goal, context.useCase.defaultGoal);
+      const inScope = normalizeArray(context.fields.inScope);
+      const outOfScope = normalizeArray(context.fields.outOfScope);
+      const lines = [
+        '## Task',
+        goal,
+      ];
+      if (inScope.length > 0) {
+        lines.push('', '### In Scope', asMarkdownList(inScope));
+      }
+      if (outOfScope.length > 0) {
+        lines.push('', '### Out Of Scope', asMarkdownList(outOfScope));
+      }
+      return lines.join('\n');
+    },
+  }),
+  'output-contract': Object.freeze({
+    id: 'output-contract',
+    title: 'Output Contract',
+    category: 'quality',
+    description: 'Defines the expected delivery structure and acceptance shape.',
+    configFields: Object.freeze([
+      Object.freeze({ name: 'outputSections', type: 'array', required: false }),
+      Object.freeze({ name: 'deliverables', type: 'array', required: false }),
+    ]),
+    render(context) {
+      const outputSections = normalizeArray(context.fields.outputSections);
+      const deliverables = normalizeArray(context.fields.deliverables);
+      const sectionList = outputSections.length > 0 ? outputSections : context.useCase.defaultOutputSections;
+      const deliverableList = deliverables.length > 0 ? deliverables : context.useCase.defaultDeliverables;
+
+      return [
+        '## Output Contract',
+        '### Required Sections',
+        asMarkdownList(sectionList),
+        '',
+        '### Deliverables',
+        asMarkdownList(deliverableList),
+      ].join('\n');
+    },
+  }),
+  'quality-guardrails': Object.freeze({
+    id: 'quality-guardrails',
+    title: 'Quality Guardrails',
+    category: 'quality',
+    description: 'Adds non-functional constraints to keep changes safe and reviewable.',
+    configFields: Object.freeze([
+      Object.freeze({ name: 'qualityRules', type: 'array', required: false }),
+      Object.freeze({ name: 'riskNotes', type: 'array', required: false }),
+    ]),
+    render(context) {
+      const rules = normalizeArray(context.fields.qualityRules);
+      const risks = normalizeArray(context.fields.riskNotes);
+      const effectiveRules = rules.length > 0 ? rules : context.useCase.defaultQualityRules;
+
+      const lines = [
+        '## Guardrails',
+        asMarkdownList(effectiveRules),
+      ];
+      if (risks.length > 0) {
+        lines.push('', '### Risks To Watch', asMarkdownList(risks));
+      }
+      return lines.join('\n');
+    },
+  }),
+  'additional-requirements': Object.freeze({
+    id: 'additional-requirements',
+    title: 'Additional Requirements',
+    category: 'input',
+    description: 'Appends free-form requirements from the Prompt Canvas input field.',
+    configFields: Object.freeze([
+      Object.freeze({ name: 'additionalRequirements', type: 'string', required: false }),
+    ]),
+    render(context) {
+      const additional = normalizeString(context.additionalRequirements || context.fields.additionalRequirements);
+      return [
+        '## Additional Requirements',
+        additional || '- none',
+      ].join('\n');
+    },
+  }),
+});
+
+const USE_CASES = Object.freeze([
+  Object.freeze({
+    id: 'documentation-generation',
+    title: 'Documentation Generation',
+    description: 'Generate implementation-focused documentation prompts for the Prompt Workbench feature set.',
+    priority: 'high',
+    defaultGoal: 'Produce concise technical documentation for the Prompt Workbench implementation changes.',
+    defaultModuleIds: Object.freeze([
+      'system-role',
+      'toolset-context',
+      'implementation-task',
+      'output-contract',
+      'quality-guardrails',
+      'additional-requirements',
+    ]),
+    defaultOutputSections: Object.freeze([
+      'Feature summary and intent',
+      'Architecture and module boundaries',
+      'API and contract notes',
+      'Testing and validation notes',
+      'Open risks and follow-ups',
+    ]),
+    defaultDeliverables: Object.freeze([
+      'Markdown implementation summary',
+      'List of changed files and why they changed',
+      'Verification checklist',
+    ]),
+    defaultQualityRules: Object.freeze([
+      'Do not invent files or behavior that is not present in repository code.',
+      'Keep explanations grounded in actual module boundaries and contracts.',
+      'Highlight residual uncertainty explicitly.',
+    ]),
+    fieldHints: Object.freeze([
+      Object.freeze({ name: 'goal', label: 'Goal', type: 'string' }),
+      Object.freeze({ name: 'inScope', label: 'In Scope', type: 'array' }),
+      Object.freeze({ name: 'outOfScope', label: 'Out Of Scope', type: 'array' }),
+      Object.freeze({ name: 'additionalRequirements', label: 'Additional Requirements', type: 'string' }),
+    ]),
+  }),
+  Object.freeze({
+    id: 'impact-change-analysis',
+    title: 'Impact / Change Analysis',
+    description: 'Assess blast radius and regression risks of Prompt Workbench code changes before merge.',
+    priority: 'high',
+    defaultGoal: 'Analyze implementation change impact across Local UI, API contracts, and workflow integration points.',
+    defaultModuleIds: Object.freeze([
+      'system-role',
+      'toolset-context',
+      'implementation-task',
+      'output-contract',
+      'quality-guardrails',
+      'additional-requirements',
+    ]),
+    defaultOutputSections: Object.freeze([
+      'Scope and assumptions',
+      'Potentially affected modules and routes',
+      'Regression risk table',
+      'Backward compatibility checks',
+      'Recommended mitigation and test plan',
+    ]),
+    defaultDeliverables: Object.freeze([
+      'Impact summary',
+      'Risk-ranked change matrix',
+      'Go/No-Go recommendation with checks',
+    ]),
+    defaultQualityRules: Object.freeze([
+      'Separate confirmed impact from inferred impact.',
+      'Call out compatibility risks for existing CLI and Local UI flows.',
+      'No merge recommendation without verification steps.',
+    ]),
+    fieldHints: Object.freeze([
+      Object.freeze({ name: 'goal', label: 'Planned Change', type: 'string' }),
+      Object.freeze({ name: 'riskNotes', label: 'Risk Notes', type: 'array' }),
+      Object.freeze({ name: 'additionalRequirements', label: 'Additional Requirements', type: 'string' }),
+    ]),
+  }),
+  Object.freeze({
+    id: 'security-access-review',
+    title: 'Security & Access Review',
+    description: 'Review Prompt Workbench endpoint behavior, storage safety, and access assumptions.',
+    priority: 'high',
+    defaultGoal: 'Identify security and access-control risks in Prompt Workbench backend and local template storage flows.',
+    defaultModuleIds: Object.freeze([
+      'system-role',
+      'toolset-context',
+      'implementation-task',
+      'output-contract',
+      'quality-guardrails',
+      'additional-requirements',
+    ]),
+    defaultOutputSections: Object.freeze([
+      'Threat surface overview',
+      'Input validation and serialization risks',
+      'Storage and path safety checks',
+      'Error handling and disclosure risks',
+      'Hardening actions by priority',
+    ]),
+    defaultDeliverables: Object.freeze([
+      'Risk finding list (high/medium/low)',
+      'Mitigation checklist',
+      'Verification tests for critical controls',
+    ]),
+    defaultQualityRules: Object.freeze([
+      'Every finding must include evidence and proposed mitigation.',
+      'Differentiate exploitable paths from theoretical concerns.',
+      'Flag unsafe filesystem or request-body handling explicitly.',
+    ]),
+    fieldHints: Object.freeze([
+      Object.freeze({ name: 'complianceContext', label: 'Compliance Context', type: 'string' }),
+      Object.freeze({ name: 'riskNotes', label: 'Risk Notes', type: 'array' }),
+      Object.freeze({ name: 'additionalRequirements', label: 'Additional Requirements', type: 'string' }),
+    ]),
+  }),
+  Object.freeze({
+    id: 'modernization-roadmap',
+    title: 'Modernization Roadmap',
+    description: 'Plan phased delivery of Prompt Workbench capabilities in the current Node.js architecture.',
+    priority: 'high',
+    defaultGoal: 'Create a phased implementation roadmap for Prompt Workbench with safe incremental delivery steps.',
+    defaultModuleIds: Object.freeze([
+      'system-role',
+      'toolset-context',
+      'implementation-task',
+      'output-contract',
+      'quality-guardrails',
+      'additional-requirements',
+    ]),
+    defaultOutputSections: Object.freeze([
+      'Current baseline and blockers',
+      'Target architecture slices',
+      'Phase plan with dependencies',
+      'Quick wins and reversible steps',
+      'Risk controls and exit criteria',
+    ]),
+    defaultDeliverables: Object.freeze([
+      'Phased roadmap',
+      'Dependency-aware sequencing plan',
+      'Pilot slice recommendation',
+    ]),
+    defaultQualityRules: Object.freeze([
+      'Prefer additive and reversible increments.',
+      'Keep architecture aligned with existing Local UI server foundation.',
+      'Include explicit validation checkpoint for each phase.',
+    ]),
+    fieldHints: Object.freeze([
+      Object.freeze({ name: 'timeline', label: 'Timeline', type: 'string' }),
+      Object.freeze({ name: 'inScope', label: 'In Scope', type: 'array' }),
+      Object.freeze({ name: 'additionalRequirements', label: 'Additional Requirements', type: 'string' }),
+    ]),
+  }),
+  Object.freeze({
+    id: 'test-case-generation',
+    title: 'Test-Case Generation',
+    description: 'Produce test strategy prompts for Prompt Workbench backend and integration routes.',
+    priority: 'medium',
+    defaultGoal: 'Generate a risk-based test plan for Prompt Workbench APIs, template storage, and regression safety.',
+    defaultModuleIds: Object.freeze([
+      'system-role',
+      'toolset-context',
+      'implementation-task',
+      'output-contract',
+      'quality-guardrails',
+      'additional-requirements',
+    ]),
+    defaultOutputSections: Object.freeze([
+      'Test scope and priorities',
+      'Endpoint and contract test cases',
+      'Negative and boundary tests',
+      'Regression coverage expectations',
+      'Minimal CI-ready test pack',
+    ]),
+    defaultDeliverables: Object.freeze([
+      'Test matrix',
+      'Example assertions per risk area',
+      'Execution checklist',
+    ]),
+    defaultQualityRules: Object.freeze([
+      'Prioritize tests around behavior regressions and unsafe input paths.',
+      'Include negative tests for invalid payloads and path handling.',
+      'Keep test proposals directly mapped to implementation contracts.',
+    ]),
+    fieldHints: Object.freeze([
+      Object.freeze({ name: 'testGoal', label: 'Test Goal', type: 'string' }),
+      Object.freeze({ name: 'qualityRules', label: 'Quality Rules', type: 'array' }),
+      Object.freeze({ name: 'additionalRequirements', label: 'Additional Requirements', type: 'string' }),
+    ]),
+  }),
+  Object.freeze({
+    id: 'onboarding-knowledge-transfer',
+    title: 'Onboarding / Knowledge Transfer',
+    description: 'Create structured prompts for handing Prompt Workbench implementation context to new contributors.',
+    priority: 'medium',
+    defaultGoal: 'Prepare onboarding guidance for engineers extending Prompt Workbench in zeus-rpg-promptkit.',
+    defaultModuleIds: Object.freeze([
+      'system-role',
+      'toolset-context',
+      'implementation-task',
+      'output-contract',
+      'quality-guardrails',
+      'additional-requirements',
+    ]),
+    defaultOutputSections: Object.freeze([
+      'What was built and why',
+      'How the architecture is organized',
+      'How to run and validate locally',
+      'Common pitfalls and review notes',
+      'First safe contribution path',
+    ]),
+    defaultDeliverables: Object.freeze([
+      'Onboarding summary',
+      'Step-by-step contributor checklist',
+      'Open questions for handover',
+    ]),
+    defaultQualityRules: Object.freeze([
+      'Keep guidance practical and repo-specific.',
+      'Map onboarding steps to actual files and commands.',
+      'Call out assumptions and prerequisites clearly.',
+    ]),
+    fieldHints: Object.freeze([
+      Object.freeze({ name: 'targetRole', label: 'Target Role', type: 'string' }),
+      Object.freeze({ name: 'onboardingWindow', label: 'Onboarding Window', type: 'string' }),
+      Object.freeze({ name: 'additionalRequirements', label: 'Additional Requirements', type: 'string' }),
+    ]),
+  }),
+]);
+
+const USE_CASE_MAP = Object.freeze(new Map(USE_CASES.map((entry) => [entry.id, entry])));
+
+function listUseCases() {
+  return USE_CASES.map((entry) => ({
+    id: entry.id,
+    title: entry.title,
+    description: entry.description,
+    priority: entry.priority,
+    defaultModuleIds: [...entry.defaultModuleIds],
+    fieldHints: [...entry.fieldHints],
+  }));
+}
+
+function listModules() {
+  return Object.values(MODULE_REGISTRY).map((module) => ({
+    id: module.id,
+    title: module.title,
+    category: module.category,
+    description: module.description,
+    configFields: [...module.configFields],
+  }));
+}
+
+function resolveUseCase(useCaseId) {
+  const normalized = normalizeString(useCaseId);
+  const useCase = USE_CASE_MAP.get(normalized);
+  if (!useCase) {
+    throw new Error(`Unknown prompt-builder use case: ${useCaseId}`);
+  }
+  return useCase;
+}
+
+function resolveModule(moduleId) {
+  const normalized = normalizeString(moduleId);
+  const module = MODULE_REGISTRY[normalized];
+  if (!module) {
+    throw new Error(`Unknown prompt-builder module: ${moduleId}`);
+  }
+  return module;
+}
+
+function normalizeFields(fields) {
+  if (!fields || typeof fields !== 'object' || Array.isArray(fields)) {
+    return {};
+  }
+  return fields;
+}
+
+function buildPromptPreview(input = {}) {
+  const useCase = resolveUseCase(input.useCaseId);
+  const requestedModuleIds = Array.isArray(input.moduleIds) && input.moduleIds.length > 0
+    ? input.moduleIds
+    : useCase.defaultModuleIds;
+
+  const moduleIds = dedupe(requestedModuleIds);
+  if (moduleIds.length === 0) {
+    throw new Error('Prompt-builder preview requires at least one module.');
+  }
+
+  const fields = normalizeFields(input.fields);
+  const additionalRequirements = normalizeString(input.additionalRequirements || fields.additionalRequirements);
+
+  const context = {
+    useCase,
+    fields,
+    additionalRequirements,
+  };
+
+  const renderedModules = moduleIds.map((moduleId) => {
+    const module = resolveModule(moduleId);
+    return {
+      id: module.id,
+      title: module.title,
+      content: module.render(context),
+    };
+  });
+
+  const header = [
+    '# Zeus Prompt Workbench Prompt',
+    '',
+    `Use Case: ${useCase.title} (${useCase.id})`,
+  ].join('\n');
+
+  const body = renderedModules
+    .map((entry) => entry.content)
+    .join('\n\n');
+
+  const content = `${header}\n\n${body}\n`;
+
+  return {
+    useCase: {
+      id: useCase.id,
+      title: useCase.title,
+      priority: useCase.priority,
+    },
+    moduleIds,
+    modules: renderedModules.map((entry) => ({
+      id: entry.id,
+      title: entry.title,
+    })),
+    content,
+    warnings: [],
+  };
+}
+
+module.exports = {
+  MODULE_REGISTRY,
+  USE_CASES,
+  buildPromptPreview,
+  listModules,
+  listUseCases,
+  resolveModule,
+  resolveUseCase,
+};

--- a/src/ui/promptWorkbenchService.js
+++ b/src/ui/promptWorkbenchService.js
@@ -1,0 +1,323 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+const path = require('path');
+const { estimateTokens } = require('../ai/tokenEstimator');
+const {
+  buildPromptPreview,
+  listModules,
+  listUseCases,
+  resolveUseCase,
+} = require('./promptWorkbenchRegistry');
+const {
+  createTemplate,
+  deleteTemplate,
+  listTemplates,
+  normalizeTemplateStorePath,
+  readTemplate,
+  updateTemplate,
+} = require('./promptWorkbenchTemplateStore');
+const {
+  listAnalysisRuns,
+  readAnalysisRun,
+  readArtifactContent,
+} = require('./localUiDataApi');
+
+const CONTEXT_PROMPT_PATTERN = /(^|\/)ai_prompt_.*\.md$/i;
+
+const PROMPT_WORKBENCH_CONTRACT = Object.freeze({
+  version: 1,
+  routes: Object.freeze({
+    useCases: Object.freeze({
+      path: '/api/prompt-builder/use-cases',
+      method: 'GET',
+      response: '{ useCases: UseCase[] }',
+    }),
+    modules: Object.freeze({
+      path: '/api/prompt-builder/modules',
+      method: 'GET',
+      response: '{ modules: Module[] }',
+    }),
+    preview: Object.freeze({
+      path: '/api/prompt-builder/preview',
+      method: 'POST',
+      request: '{ useCaseId: string, moduleIds?: string[], fields?: object, additionalRequirements?: string }',
+      response: '{ preview: PromptPreview }',
+    }),
+    templatesList: Object.freeze({
+      path: '/api/prompt-builder/templates',
+      method: 'GET',
+      response: '{ templates: PromptTemplateSummary[] }',
+    }),
+    templatesCreate: Object.freeze({
+      path: '/api/prompt-builder/templates',
+      method: 'POST',
+      request: '{ name: string, useCaseId: string, moduleIds: string[], description?: string, fields?: object, additionalRequirements?: string, tags?: string[] }',
+      response: '{ template: PromptTemplate }',
+    }),
+    templatesRead: Object.freeze({
+      path: '/api/prompt-builder/templates/:templateId',
+      method: 'GET',
+      response: '{ template: PromptTemplate }',
+    }),
+    templatesUpdate: Object.freeze({
+      path: '/api/prompt-builder/templates/:templateId',
+      method: 'PUT',
+      request: '{ name: string, useCaseId: string, moduleIds: string[], description?: string, fields?: object, additionalRequirements?: string, tags?: string[] }',
+      response: '{ template: PromptTemplate }',
+    }),
+    templatesDelete: Object.freeze({
+      path: '/api/prompt-builder/templates/:templateId',
+      method: 'DELETE',
+      response: '{ deleted: PromptTemplateSummary }',
+    }),
+    contextSourcesList: Object.freeze({
+      path: '/api/prompt-builder/context-sources',
+      method: 'GET',
+      response: '{ contextSources: PromptContextSource[] }',
+    }),
+    contextSourcesPrompts: Object.freeze({
+      path: '/api/prompt-builder/context-sources/:program/prompts',
+      method: 'GET',
+      response: '{ program: string, promptArtifacts: PromptArtifact[] }',
+    }),
+    contextSourcesImport: Object.freeze({
+      path: '/api/prompt-builder/context-sources/import',
+      method: 'POST',
+      request: '{ program: string, path: string }',
+      response: '{ seed: PromptSeed }',
+    }),
+  }),
+});
+
+function normalizeInputObject(value, errorMessage) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(errorMessage);
+  }
+  return value;
+}
+
+function validatePreviewInput(value) {
+  const input = normalizeInputObject(value, 'Prompt preview payload must be an object.');
+  if (typeof input.useCaseId !== 'string' || input.useCaseId.trim().length === 0) {
+    throw new Error('Prompt preview payload requires useCaseId.');
+  }
+
+  if (input.moduleIds !== undefined && !Array.isArray(input.moduleIds)) {
+    throw new Error('Prompt preview payload moduleIds must be an array when provided.');
+  }
+
+  if (input.fields !== undefined && (typeof input.fields !== 'object' || Array.isArray(input.fields) || input.fields === null)) {
+    throw new Error('Prompt preview payload fields must be an object when provided.');
+  }
+
+  return {
+    useCaseId: input.useCaseId,
+    moduleIds: Array.isArray(input.moduleIds) ? input.moduleIds : undefined,
+    fields: input.fields || {},
+    additionalRequirements: input.additionalRequirements,
+  };
+}
+
+function validateTemplatePayload(value) {
+  const input = normalizeInputObject(value, 'Prompt template payload must be an object.');
+  const useCaseId = String(input.useCaseId || '').trim();
+  if (!useCaseId) {
+    throw new Error('Prompt template payload requires useCaseId.');
+  }
+  resolveUseCase(useCaseId);
+
+  return {
+    name: input.name,
+    description: input.description,
+    useCaseId,
+    moduleIds: input.moduleIds,
+    fields: input.fields,
+    additionalRequirements: input.additionalRequirements,
+    tags: input.tags,
+  };
+}
+
+function isPromptArtifactPath(artifactPath) {
+  return CONTEXT_PROMPT_PATTERN.test(String(artifactPath || '').trim());
+}
+
+function normalizePromptArtifact(artifact, fallbackProgram) {
+  const relativePath = String((artifact && artifact.path) || '').trim();
+  return {
+    program: String((artifact && artifact.program) || fallbackProgram || '').trim(),
+    path: relativePath,
+    title: String((artifact && artifact.title) || relativePath).trim() || relativePath,
+    kind: String((artifact && artifact.kind) || '').trim() || 'markdown',
+    sizeBytes: Number(artifact && artifact.sizeBytes) || 0,
+  };
+}
+
+function listPromptArtifactsFromRunDetail(runDetail) {
+  const views = runDetail && runDetail.views ? runDetail.views : {};
+  const artifacts = views.prompts && Array.isArray(views.prompts.artifacts)
+    ? views.prompts.artifacts
+    : [];
+
+  return artifacts
+    .filter((entry) => isPromptArtifactPath(entry.path))
+    .map((entry) => normalizePromptArtifact(entry, runDetail && runDetail.summary && runDetail.summary.program));
+}
+
+function validateImportPayload(value) {
+  const input = normalizeInputObject(value, 'Prompt context import payload must be an object.');
+  const program = String(input.program || '').trim();
+  const artifactPath = String(input.path || '').trim();
+  if (!program) {
+    throw new Error('Prompt context import payload requires program.');
+  }
+  if (!artifactPath) {
+    throw new Error('Prompt context import payload requires path.');
+  }
+  if (!isPromptArtifactPath(artifactPath)) {
+    throw new Error('Prompt context import path must target ai_prompt_*.md artifacts.');
+  }
+  return {
+    program,
+    artifactPath,
+  };
+}
+
+function createPromptWorkbenchService(options = {}) {
+  const templateStorePath = normalizeTemplateStorePath(options.templateStorePath, options.cwd);
+  const resolvedOutputRoot = path.resolve(options.outputRoot || options.sourceOutputRoot || 'output');
+
+  return {
+    getContract() {
+      return {
+        ...PROMPT_WORKBENCH_CONTRACT,
+        templateStorePath,
+        outputRoot: resolvedOutputRoot,
+      };
+    },
+
+    listUseCases() {
+      return {
+        useCases: listUseCases(),
+      };
+    },
+
+    listModules() {
+      return {
+        modules: listModules(),
+      };
+    },
+
+    previewPrompt(payload) {
+      const validated = validatePreviewInput(payload);
+      const preview = buildPromptPreview(validated);
+      return {
+        preview: {
+          ...preview,
+          estimatedTokens: estimateTokens(preview.content),
+        },
+      };
+    },
+
+    listTemplates() {
+      return {
+        templates: listTemplates(templateStorePath),
+      };
+    },
+
+    readTemplate(templateId) {
+      return {
+        template: readTemplate(templateStorePath, templateId),
+      };
+    },
+
+    createTemplate(payload) {
+      const validated = validateTemplatePayload(payload);
+      return {
+        template: createTemplate(templateStorePath, validated),
+      };
+    },
+
+    updateTemplate(templateId, payload) {
+      const validated = validateTemplatePayload(payload);
+      return {
+        template: updateTemplate(templateStorePath, templateId, validated),
+      };
+    },
+
+    deleteTemplate(templateId) {
+      return {
+        deleted: deleteTemplate(templateStorePath, templateId),
+      };
+    },
+
+    listContextSources() {
+      const runs = listAnalysisRuns(resolvedOutputRoot);
+      const contextSources = runs.map((run) => {
+        let promptArtifacts = [];
+        try {
+          const runDetail = readAnalysisRun(resolvedOutputRoot, run.program);
+          promptArtifacts = listPromptArtifactsFromRunDetail(runDetail);
+        } catch (error) {
+          promptArtifacts = [];
+        }
+        return {
+          program: run.program,
+          status: run.status,
+          completedAt: run.completedAt,
+          workflowMode: run.workflowMode,
+          workflowPreset: run.workflowPreset,
+          promptArtifactCount: promptArtifacts.length,
+          promptArtifacts,
+        };
+      });
+
+      return {
+        contextSources,
+      };
+    },
+
+    listContextSourcePrompts(program) {
+      const normalizedProgram = String(program || '').trim();
+      if (!normalizedProgram) {
+        throw new Error('Prompt context source program is required.');
+      }
+
+      const runDetail = readAnalysisRun(resolvedOutputRoot, normalizedProgram);
+      return {
+        program: normalizedProgram,
+        promptArtifacts: listPromptArtifactsFromRunDetail(runDetail),
+      };
+    },
+
+    importContextPrompt(payload) {
+      const validated = validateImportPayload(payload);
+      const artifact = readArtifactContent(resolvedOutputRoot, validated.program, validated.artifactPath);
+      return {
+        seed: {
+          program: validated.program,
+          path: artifact.path,
+          kind: artifact.kind,
+          content: artifact.content,
+          estimatedTokens: estimateTokens(artifact.content),
+        },
+      };
+    },
+  };
+}
+
+module.exports = {
+  PROMPT_WORKBENCH_CONTRACT,
+  createPromptWorkbenchService,
+};

--- a/src/ui/promptWorkbenchTemplateStore.js
+++ b/src/ui/promptWorkbenchTemplateStore.js
@@ -1,0 +1,249 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+const fs = require('fs');
+const path = require('path');
+const { randomUUID } = require('crypto');
+
+const STORE_SCHEMA_VERSION = 1;
+
+function normalizeString(value, fallback = '') {
+  const normalized = String(value === undefined || value === null ? '' : value).trim();
+  return normalized || fallback;
+}
+
+function normalizeArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => String(entry || '').trim())
+    .filter(Boolean);
+}
+
+function normalizeFields(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value;
+}
+
+function normalizeTemplateStorePath(templateStorePath, cwd = process.cwd()) {
+  const provided = normalizeString(templateStorePath);
+  if (!provided) {
+    return path.resolve(cwd, 'config', 'local-only', 'prompt-workbench', 'templates.json');
+  }
+  return path.resolve(cwd, provided);
+}
+
+function ensureStoreDirectory(templateStorePath) {
+  const directory = path.dirname(path.resolve(templateStorePath));
+  fs.mkdirSync(directory, { recursive: true });
+}
+
+function buildEmptyStore() {
+  return {
+    schemaVersion: STORE_SCHEMA_VERSION,
+    templates: [],
+  };
+}
+
+function readTemplateStore(templateStorePath) {
+  const resolvedPath = path.resolve(templateStorePath);
+  if (!fs.existsSync(resolvedPath)) {
+    return buildEmptyStore();
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`Invalid prompt template store payload: ${resolvedPath}`);
+  }
+
+  if (!Array.isArray(parsed.templates)) {
+    throw new Error(`Invalid prompt template store templates array: ${resolvedPath}`);
+  }
+
+  return {
+    schemaVersion: Number(parsed.schemaVersion) || STORE_SCHEMA_VERSION,
+    templates: parsed.templates,
+  };
+}
+
+function writeTemplateStore(templateStorePath, store) {
+  ensureStoreDirectory(templateStorePath);
+  const payload = {
+    schemaVersion: STORE_SCHEMA_VERSION,
+    templates: Array.isArray(store.templates) ? store.templates : [],
+  };
+  fs.writeFileSync(path.resolve(templateStorePath), `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function sanitizeTemplateName(name) {
+  const normalized = normalizeString(name);
+  if (!normalized) {
+    throw new Error('Prompt template name is required.');
+  }
+  if (normalized.length > 120) {
+    throw new Error('Prompt template name exceeds 120 characters.');
+  }
+  return normalized;
+}
+
+function sanitizeTemplatePayload(input = {}) {
+  const name = sanitizeTemplateName(input.name);
+  const description = normalizeString(input.description);
+  const useCaseId = normalizeString(input.useCaseId);
+  if (!useCaseId) {
+    throw new Error('Prompt template useCaseId is required.');
+  }
+
+  const moduleIds = normalizeArray(input.moduleIds);
+  if (moduleIds.length === 0) {
+    throw new Error('Prompt template requires at least one moduleId.');
+  }
+
+  return {
+    name,
+    description,
+    useCaseId,
+    moduleIds,
+    fields: normalizeFields(input.fields),
+    additionalRequirements: normalizeString(input.additionalRequirements),
+    tags: normalizeArray(input.tags),
+  };
+}
+
+function createTemplateId(name) {
+  const base = normalizeString(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 40) || 'prompt-template';
+  const suffix = randomUUID().split('-')[0];
+  return `${base}-${suffix}`;
+}
+
+function summarizeTemplate(template) {
+  return {
+    id: template.id,
+    name: template.name,
+    description: template.description,
+    useCaseId: template.useCaseId,
+    moduleIds: [...template.moduleIds],
+    tags: [...(template.tags || [])],
+    createdAt: template.createdAt,
+    updatedAt: template.updatedAt,
+  };
+}
+
+function listTemplates(templateStorePath) {
+  const store = readTemplateStore(templateStorePath);
+  return store.templates
+    .map((entry) => summarizeTemplate(entry))
+    .sort((left, right) => {
+      const leftTime = Date.parse(left.updatedAt || left.createdAt || 0) || 0;
+      const rightTime = Date.parse(right.updatedAt || right.createdAt || 0) || 0;
+      if (rightTime !== leftTime) {
+        return rightTime - leftTime;
+      }
+      return left.name.localeCompare(right.name);
+    });
+}
+
+function readTemplate(templateStorePath, templateId) {
+  const normalizedId = normalizeString(templateId);
+  if (!normalizedId) {
+    throw new Error('Template id is required.');
+  }
+  const store = readTemplateStore(templateStorePath);
+  const entry = store.templates.find((template) => template.id === normalizedId);
+  if (!entry) {
+    throw new Error(`Prompt template not found: ${normalizedId}`);
+  }
+  return {
+    ...entry,
+    moduleIds: [...(entry.moduleIds || [])],
+    fields: normalizeFields(entry.fields),
+    tags: normalizeArray(entry.tags),
+  };
+}
+
+function createTemplate(templateStorePath, input = {}) {
+  const store = readTemplateStore(templateStorePath);
+  const payload = sanitizeTemplatePayload(input);
+  const now = new Date().toISOString();
+  const entry = {
+    id: createTemplateId(payload.name),
+    ...payload,
+    createdAt: now,
+    updatedAt: now,
+  };
+  store.templates.push(entry);
+  writeTemplateStore(templateStorePath, store);
+  return readTemplate(templateStorePath, entry.id);
+}
+
+function updateTemplate(templateStorePath, templateId, input = {}) {
+  const normalizedId = normalizeString(templateId);
+  if (!normalizedId) {
+    throw new Error('Template id is required.');
+  }
+
+  const store = readTemplateStore(templateStorePath);
+  const index = store.templates.findIndex((entry) => entry.id === normalizedId);
+  if (index < 0) {
+    throw new Error(`Prompt template not found: ${normalizedId}`);
+  }
+
+  const payload = sanitizeTemplatePayload(input);
+  const current = store.templates[index];
+  store.templates[index] = {
+    ...current,
+    ...payload,
+    id: current.id,
+    createdAt: current.createdAt,
+    updatedAt: new Date().toISOString(),
+  };
+
+  writeTemplateStore(templateStorePath, store);
+  return readTemplate(templateStorePath, normalizedId);
+}
+
+function deleteTemplate(templateStorePath, templateId) {
+  const normalizedId = normalizeString(templateId);
+  if (!normalizedId) {
+    throw new Error('Template id is required.');
+  }
+
+  const store = readTemplateStore(templateStorePath);
+  const index = store.templates.findIndex((entry) => entry.id === normalizedId);
+  if (index < 0) {
+    throw new Error(`Prompt template not found: ${normalizedId}`);
+  }
+
+  const [removed] = store.templates.splice(index, 1);
+  writeTemplateStore(templateStorePath, store);
+  return summarizeTemplate(removed);
+}
+
+module.exports = {
+  STORE_SCHEMA_VERSION,
+  createTemplate,
+  deleteTemplate,
+  listTemplates,
+  normalizeTemplateStorePath,
+  readTemplate,
+  readTemplateStore,
+  summarizeTemplate,
+  updateTemplate,
+  writeTemplateStore,
+};

--- a/tests/local-ui-server.test.js
+++ b/tests/local-ui-server.test.js
@@ -117,17 +117,19 @@ function createUiFixture() {
   return {
     tempRoot,
     outputRoot,
+    templateStorePath: path.join(tempRoot, 'config', 'local-only', 'prompt-workbench', 'templates.json'),
   };
 }
 
 test('local UI server exposes runs, details, and artifact content through a read-only API', async () => {
-  const { tempRoot, outputRoot } = createUiFixture();
+  const { tempRoot, outputRoot, templateStorePath } = createUiFixture();
   let started = null;
 
   try {
     started = await startLocalUiServer({
       outputRoot,
       port: 0,
+      templateStorePath,
     });
 
     const health = await fetch(`${started.url}/api/health`).then((response) => response.json());
@@ -169,9 +171,185 @@ test('local UI server exposes runs, details, and artifact content through a read
     assert.match(shellHtml, /Graph Explorer|Graph/);
     assert.match(shellHtml, /DB2\/Test Data/);
     assert.match(shellHtml, /Prompt Compare/);
+    assert.match(shellHtml, /Prompt Workbench/);
+    assert.match(shellHtml, /Prompt Canvas/);
+    assert.match(shellHtml, /Output Context Source/);
+
+    const promptContracts = await fetch(`${started.url}/api/prompt-builder/contracts`).then((response) => response.json());
+    assert.equal(promptContracts.version, 1);
+    assert.equal(promptContracts.routes.preview.path, '/api/prompt-builder/preview');
+
+    const useCasesPayload = await fetch(`${started.url}/api/prompt-builder/use-cases`).then((response) => response.json());
+    assert.ok(Array.isArray(useCasesPayload.useCases));
+    assert.ok(useCasesPayload.useCases.some((entry) => entry.id === 'documentation-generation'));
+
+    const modulesPayload = await fetch(`${started.url}/api/prompt-builder/modules`).then((response) => response.json());
+    assert.ok(Array.isArray(modulesPayload.modules));
+    assert.ok(modulesPayload.modules.some((entry) => entry.id === 'system-role'));
+
+    const previewPayload = await fetch(`${started.url}/api/prompt-builder/preview`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        useCaseId: 'documentation-generation',
+        fields: {
+          goal: 'Document Prompt Workbench implementation for maintainers.',
+          language: 'English',
+        },
+        additionalRequirements: 'Reference changed files and test scope.',
+      }),
+    }).then((response) => response.json());
+    assert.equal(previewPayload.preview.useCase.id, 'documentation-generation');
+    assert.ok(previewPayload.preview.estimatedTokens > 0);
+    assert.match(previewPayload.preview.content, /Prompt Workbench/);
+
+    const emptyTemplates = await fetch(`${started.url}/api/prompt-builder/templates`).then((response) => response.json());
+    assert.deepEqual(emptyTemplates.templates, []);
+
+    const createdTemplate = await fetch(`${started.url}/api/prompt-builder/templates`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'Workbench API Contract Review',
+        description: 'Template for API-first implementation review.',
+        useCaseId: 'impact-change-analysis',
+        moduleIds: ['system-role', 'toolset-context', 'implementation-task', 'quality-guardrails'],
+        fields: {
+          goal: 'Assess impact of new prompt builder routes.',
+        },
+      }),
+    }).then((response) => response.json());
+    assert.equal(typeof createdTemplate.template.id, 'string');
+    assert.equal(createdTemplate.template.useCaseId, 'impact-change-analysis');
+
+    const listedTemplates = await fetch(`${started.url}/api/prompt-builder/templates`).then((response) => response.json());
+    assert.equal(listedTemplates.templates.length, 1);
+    const templateId = listedTemplates.templates[0].id;
+
+    const loadedTemplate = await fetch(`${started.url}/api/prompt-builder/templates/${encodeURIComponent(templateId)}`).then((response) => response.json());
+    assert.equal(loadedTemplate.template.id, templateId);
+    assert.equal(loadedTemplate.template.name, 'Workbench API Contract Review');
+
+    const updatedTemplate = await fetch(`${started.url}/api/prompt-builder/templates/${encodeURIComponent(templateId)}`, {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'Workbench API Contract Review v2',
+        description: 'Updated template',
+        useCaseId: 'impact-change-analysis',
+        moduleIds: ['system-role', 'toolset-context', 'implementation-task', 'output-contract'],
+        fields: {
+          goal: 'Assess impact and regression risks of prompt builder APIs.',
+        },
+      }),
+    }).then((response) => response.json());
+    assert.equal(updatedTemplate.template.id, templateId);
+    assert.equal(updatedTemplate.template.name, 'Workbench API Contract Review v2');
+
+    const deletedTemplate = await fetch(`${started.url}/api/prompt-builder/templates/${encodeURIComponent(templateId)}`, {
+      method: 'DELETE',
+    }).then((response) => response.json());
+    assert.equal(deletedTemplate.deleted.id, templateId);
+
+    const templatesAfterDelete = await fetch(`${started.url}/api/prompt-builder/templates`).then((response) => response.json());
+    assert.deepEqual(templatesAfterDelete.templates, []);
+
+    const promptBuilderMethodError = await fetch(`${started.url}/api/prompt-builder/use-cases`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    });
+    assert.equal(promptBuilderMethodError.status, 405);
+    assert.match(promptBuilderMethodError.headers.get('allow') || '', /GET/);
+
+    const invalidPreviewJson = await fetch(`${started.url}/api/prompt-builder/preview`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: '{"useCaseId":',
+    });
+    assert.equal(invalidPreviewJson.status, 400);
+
+    const invalidPreviewPayload = await fetch(`${started.url}/api/prompt-builder/preview`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        fields: {},
+      }),
+    });
+    assert.equal(invalidPreviewPayload.status, 400);
+
+    const templateNotFound = await fetch(`${started.url}/api/prompt-builder/templates/does-not-exist`);
+    assert.equal(templateNotFound.status, 404);
+
+    const contextSources = await fetch(`${started.url}/api/prompt-builder/context-sources`).then((response) => response.json());
+    assert.equal(contextSources.contextSources.length, 1);
+    assert.equal(contextSources.contextSources[0].program, 'ORDERPGM');
+    assert.ok(contextSources.contextSources[0].promptArtifacts.some((entry) => entry.path === 'ai_prompt_documentation.md'));
+
+    const contextPrompts = await fetch(`${started.url}/api/prompt-builder/context-sources/ORDERPGM/prompts`).then((response) => response.json());
+    assert.equal(contextPrompts.program, 'ORDERPGM');
+    assert.ok(contextPrompts.promptArtifacts.some((entry) => entry.path === 'ai_prompt_modernization.md'));
+
+    const importedPrompt = await fetch(`${started.url}/api/prompt-builder/context-sources/import`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        program: 'ORDERPGM',
+        path: 'ai_prompt_documentation.md',
+      }),
+    }).then((response) => response.json());
+    assert.equal(importedPrompt.seed.program, 'ORDERPGM');
+    assert.equal(importedPrompt.seed.path, 'ai_prompt_documentation.md');
+    assert.match(importedPrompt.seed.content, /Documentation Prompt/);
+
+    const invalidImportedPrompt = await fetch(`${started.url}/api/prompt-builder/context-sources/import`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        program: 'ORDERPGM',
+        path: 'report.md',
+      }),
+    });
+    assert.equal(invalidImportedPrompt.status, 400);
+
+    const missingImportedPromptPayload = await fetch(`${started.url}/api/prompt-builder/context-sources/import`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        program: 'ORDERPGM',
+      }),
+    });
+    assert.equal(missingImportedPromptPayload.status, 400);
+
+    const missingRunContextPrompts = await fetch(`${started.url}/api/prompt-builder/context-sources/UNKNOWNPGM/prompts`);
+    assert.equal(missingRunContextPrompts.status, 404);
 
     const traversal = await fetch(`${started.url}/api/runs/ORDERPGM/artifacts/content?path=..%2Fsecret.txt`);
     assert.equal(traversal.status, 400);
+
+    const readOnlyRouteMethodError = await fetch(`${started.url}/api/runs`, {
+      method: 'POST',
+    });
+    assert.equal(readOnlyRouteMethodError.status, 405);
+    assert.match(readOnlyRouteMethodError.headers.get('allow') || '', /GET/);
   } finally {
     if (started) {
       await new Promise((resolve) => started.server.close(resolve));

--- a/tests/prompt-workbench-service.test.js
+++ b/tests/prompt-workbench-service.test.js
@@ -1,0 +1,153 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { createPromptWorkbenchService } = require('../src/ui/promptWorkbenchService');
+
+function createServiceFixture() {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-prompt-workbench-service-'));
+  const templateStorePath = path.join(tempRoot, 'config', 'local-only', 'prompt-workbench', 'templates.json');
+  const outputRoot = path.join(tempRoot, 'output');
+  const programDir = path.join(outputRoot, 'ORDERPGM');
+  fs.mkdirSync(programDir, { recursive: true });
+  fs.writeFileSync(path.join(programDir, 'ai_prompt_documentation.md'), '# Documentation Prompt\n\nExplain ORDERPGM.\n', 'utf8');
+  fs.writeFileSync(path.join(programDir, 'analyze-run-manifest.json'), `${JSON.stringify({
+    schemaVersion: 1,
+    tool: { name: 'zeus-rpg-promptkit', command: 'analyze' },
+    run: {
+      status: 'succeeded',
+      completedAt: '2026-04-14T12:00:00.000Z',
+    },
+    inputs: {
+      sourceRoot: '/tmp/src',
+      options: {
+        guidedMode: { name: 'documentation' },
+      },
+      sourceSnapshot: {
+        fileCount: 1,
+      },
+    },
+    summary: {
+      stageCount: 3,
+      diagnosticCount: 0,
+    },
+    artifacts: [
+      { path: 'ai_prompt_documentation.md', kind: 'markdown', sizeBytes: 42, sha256: 'a' },
+    ],
+  }, null, 2)}\n`, 'utf8');
+  const service = createPromptWorkbenchService({ templateStorePath, outputRoot });
+  return {
+    tempRoot,
+    templateStorePath,
+    outputRoot,
+    service,
+  };
+}
+
+test('prompt workbench service exposes contracts, registries, preview, and template CRUD', () => {
+  const fixture = createServiceFixture();
+  try {
+    const contract = fixture.service.getContract();
+    assert.equal(contract.version, 1);
+    assert.equal(contract.routes.preview.path, '/api/prompt-builder/preview');
+    assert.equal(contract.routes.contextSourcesList.path, '/api/prompt-builder/context-sources');
+    assert.equal(contract.routes.contextSourcesImport.path, '/api/prompt-builder/context-sources/import');
+
+    const useCases = fixture.service.listUseCases();
+    assert.ok(useCases.useCases.length >= 6);
+    assert.ok(useCases.useCases.some((entry) => entry.id === 'documentation-generation'));
+
+    const modules = fixture.service.listModules();
+    assert.ok(modules.modules.length >= 6);
+    assert.ok(modules.modules.some((entry) => entry.id === 'system-role'));
+
+    const preview = fixture.service.previewPrompt({
+      useCaseId: 'documentation-generation',
+      fields: {
+        goal: 'Document Prompt Workbench backend implementation details.',
+        language: 'English',
+      },
+      additionalRequirements: 'Include route-level validation behavior.',
+    });
+    assert.equal(preview.preview.useCase.id, 'documentation-generation');
+    assert.ok(preview.preview.estimatedTokens > 0);
+    assert.match(preview.preview.content, /Output Contract/);
+
+    assert.throws(() => fixture.service.previewPrompt({ fields: {} }), /useCaseId/);
+    assert.throws(() => fixture.service.previewPrompt({
+      useCaseId: 'documentation-generation',
+      moduleIds: 'system-role',
+    }), /moduleIds/);
+
+    const created = fixture.service.createTemplate({
+      name: 'Prompt Workbench API Implementation',
+      description: 'Template for backend contract work.',
+      useCaseId: 'impact-change-analysis',
+      moduleIds: ['system-role', 'toolset-context', 'implementation-task', 'quality-guardrails'],
+      fields: {
+        goal: 'Assess blast radius of API changes.',
+      },
+    });
+
+    const templateId = created.template.id;
+    assert.equal(typeof templateId, 'string');
+
+    const listAfterCreate = fixture.service.listTemplates();
+    assert.equal(listAfterCreate.templates.length, 1);
+
+    const loaded = fixture.service.readTemplate(templateId);
+    assert.equal(loaded.template.name, 'Prompt Workbench API Implementation');
+
+    const updated = fixture.service.updateTemplate(templateId, {
+      name: 'Prompt Workbench API Implementation v2',
+      description: 'Updated template',
+      useCaseId: 'impact-change-analysis',
+      moduleIds: ['system-role', 'toolset-context', 'implementation-task', 'output-contract'],
+      fields: {
+        goal: 'Assess blast radius and regression checks.',
+      },
+    });
+    assert.equal(updated.template.name, 'Prompt Workbench API Implementation v2');
+
+    const removed = fixture.service.deleteTemplate(templateId);
+    assert.equal(removed.deleted.id, templateId);
+
+    const listAfterDelete = fixture.service.listTemplates();
+    assert.equal(listAfterDelete.templates.length, 0);
+
+    const contextSources = fixture.service.listContextSources();
+    assert.equal(contextSources.contextSources.length, 1);
+    assert.equal(contextSources.contextSources[0].program, 'ORDERPGM');
+    assert.ok(contextSources.contextSources[0].promptArtifacts.some((entry) => entry.path === 'ai_prompt_documentation.md'));
+
+    const contextPrompts = fixture.service.listContextSourcePrompts('ORDERPGM');
+    assert.equal(contextPrompts.program, 'ORDERPGM');
+    assert.ok(contextPrompts.promptArtifacts.some((entry) => entry.path === 'ai_prompt_documentation.md'));
+
+    const imported = fixture.service.importContextPrompt({
+      program: 'ORDERPGM',
+      path: 'ai_prompt_documentation.md',
+    });
+    assert.match(imported.seed.content, /Documentation Prompt/);
+    assert.ok(imported.seed.estimatedTokens > 0);
+
+    assert.throws(() => fixture.service.importContextPrompt({
+      program: 'ORDERPGM',
+      path: 'report.md',
+    }), /ai_prompt_/);
+    assert.throws(() => fixture.service.createTemplate({
+      name: 'Invalid use case',
+      useCaseId: 'not-real',
+      moduleIds: ['system-role'],
+    }), /Unknown prompt-builder use case/);
+    assert.throws(() => fixture.service.listContextSourcePrompts(''), /program is required/i);
+    assert.throws(() => fixture.service.importContextPrompt({
+      program: '',
+      path: '',
+    }), /requires program/i);
+  } finally {
+    fs.rmSync(fixture.tempRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/prompt-workbench-template-store.test.js
+++ b/tests/prompt-workbench-template-store.test.js
@@ -1,0 +1,93 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createTemplate,
+  deleteTemplate,
+  listTemplates,
+  normalizeTemplateStorePath,
+  readTemplate,
+  readTemplateStore,
+  updateTemplate,
+} = require('../src/ui/promptWorkbenchTemplateStore');
+
+test('template store supports CRUD and validation boundaries', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-template-store-'));
+  const storePath = normalizeTemplateStorePath('', tempRoot);
+
+  try {
+    assert.equal(storePath.endsWith(path.join('config', 'local-only', 'prompt-workbench', 'templates.json')), true);
+    assert.deepEqual(readTemplateStore(storePath), {
+      schemaVersion: 1,
+      templates: [],
+    });
+
+    const created = createTemplate(storePath, {
+      name: 'Prompt Canvas Baseline',
+      description: 'Initial template',
+      useCaseId: 'documentation-generation',
+      moduleIds: ['system-role', 'toolset-context'],
+      fields: {
+        goal: 'Document architecture and API changes.',
+      },
+      additionalRequirements: 'Keep existing routes backward compatible.',
+      tags: ['mvp', 'docs'],
+    });
+
+    assert.equal(typeof created.id, 'string');
+    assert.equal(created.name, 'Prompt Canvas Baseline');
+    assert.deepEqual(created.moduleIds, ['system-role', 'toolset-context']);
+
+    const listed = listTemplates(storePath);
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].id, created.id);
+
+    const updated = updateTemplate(storePath, created.id, {
+      name: 'Prompt Canvas Baseline v2',
+      description: 'Updated template',
+      useCaseId: 'documentation-generation',
+      moduleIds: ['system-role', 'toolset-context', 'output-contract'],
+      fields: {
+        goal: 'Document architecture, API contracts, and tests.',
+      },
+      additionalRequirements: 'Explicitly call out regressions.',
+      tags: ['mvp', 'docs', 'tests'],
+    });
+
+    assert.equal(updated.id, created.id);
+    assert.equal(updated.name, 'Prompt Canvas Baseline v2');
+    assert.deepEqual(updated.moduleIds, ['system-role', 'toolset-context', 'output-contract']);
+
+    const loaded = readTemplate(storePath, created.id);
+    assert.equal(loaded.name, 'Prompt Canvas Baseline v2');
+
+    const deleted = deleteTemplate(storePath, created.id);
+    assert.equal(deleted.id, created.id);
+    assert.deepEqual(listTemplates(storePath), []);
+
+    assert.throws(() => createTemplate(storePath, {
+      name: '',
+      useCaseId: 'documentation-generation',
+      moduleIds: ['system-role'],
+    }), /name is required/i);
+
+    assert.throws(() => createTemplate(storePath, {
+      name: 'Invalid Modules',
+      useCaseId: 'documentation-generation',
+      moduleIds: [],
+    }), /at least one moduleid/i);
+
+    assert.throws(() => readTemplate(storePath, 'missing-template-id'), /not found/i);
+    assert.throws(() => updateTemplate(storePath, 'missing-template-id', {
+      name: 'x',
+      useCaseId: 'documentation-generation',
+      moduleIds: ['system-role'],
+    }), /not found/i);
+    assert.throws(() => deleteTemplate(storePath, 'missing-template-id'), /not found/i);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add Prompt Workbench backend endpoints under `/api/prompt-builder/*`
- add use-case/module registry, prompt preview composition, and local template CRUD store
- integrate Prompt Workbench UI tab with prompt canvas flow (module ordering, field config, live preview, copy/export)
- add output-context source integration for `output/<PROGRAM>` prompt artifacts (`ai_prompt_*.md`) and seed import
- add architecture + quality-gate docs for the feature

## API
- `GET /api/prompt-builder/contracts`
- `GET /api/prompt-builder/use-cases`
- `GET /api/prompt-builder/modules`
- `POST /api/prompt-builder/preview`
- `GET/POST /api/prompt-builder/templates`
- `GET/PUT/DELETE /api/prompt-builder/templates/:templateId`
- `GET /api/prompt-builder/context-sources`
- `GET /api/prompt-builder/context-sources/:program/prompts`
- `POST /api/prompt-builder/context-sources/import`

## Testing
- `node --test tests/prompt-workbench-template-store.test.js tests/prompt-workbench-service.test.js tests/local-ui-server.test.js`
- result: pass (4/4)

## Notes
- existing run-explorer routes remain additive and backward-compatible
- prompt-workbench template persistence defaults to `config/local-only/prompt-workbench/templates.json`
