### PR TITLE
Add analyses workspace management and safe redaction defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,12 @@ java/lib/
 
 .local/
 .local-roadmap/
+
+# -----------------------------
+# Local analyses registry/workspaces
+# -----------------------------
+
+# Optional local registry file (if kept inside this repository)
+config/analyses-registry.json
+# Optional in-repo analyses workspaces
+analyses/

--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -38,6 +38,7 @@ const { run: runPuiEdit } = require('../src/cli/commands/puiEditCommand');
 const { runSearchSource } = require('../src/cli/commands/searchSourceCommand');
 const { runJoblog } = require('../src/cli/commands/joblogCommand');
 const { runDocsGenerateCatalog } = require('./commands/generate-tool-catalog');
+const { run: runAnalyses } = require('../src/cli/commands/analysesCommand');
 
 function printHelp() {
   console.log('Usage:');
@@ -51,6 +52,7 @@ function printHelp() {
   console.log('  zeus [--config <path>] generate-checklist --program <name> [--type DDL_CHANGE|CODE_CHANGE|BOTH] [--affected <P1,P2,...>] [--table <name>] [--impact LOW|MEDIUM|HIGH] [--out <path>] [--verbose]');
   console.log('  zeus [--config <path>] fetch --host <hostname> --user <username> --password <password> --source-lib <objectLib> [--source-library <objectLib>] --ifs-dir <ifsPath> --out <localPath> [--files <sourceFiles>] [--source-files <sourceFiles>] [--members <list>] [--replace true|false] [--streamfile-ccsid <ccsid>] [--transport auto|sftp|jt400|ftp] [--network-type local|internet] [--prefer-transport sftp|jt400|ftp] [--diagnose-transport] [--transport-timeout-ms <n>] [--profile <name>] [--verbose]');
   console.log('  zeus [--config <path>] serve [--source-output-root <path>] [--profile <name>] [--host 127.0.0.1] [--port <n>] [--verbose]');
+  console.log('  zeus [--config <path>] analyses <list|register|index|open|show|unregister> [options]');
   console.log('  zeus [--config <path>] doctor --profile <name> [--show-resolved]');
   console.log('  zeus [--config <path>] query-table --profile <name> --table <name> [--schema <name>] [--filter <pattern>]');
   console.log('  zeus [--config <path>] query-sql --profile <name> (--sql "SELECT ..." | --file <path>) [--default-schema <schema>] [--liblist <lib1,lib2,...>] [--max-rows <n>] [--output table|csv]');
@@ -172,6 +174,11 @@ async function main() {
 
   if (command === 'serve') {
     await runServe(args);
+    return;
+  }
+
+  if (command === 'analyses') {
+    await runAnalyses(args);
     return;
   }
 

--- a/config/profiles.example.json
+++ b/config/profiles.example.json
@@ -43,6 +43,8 @@
   },
   "default-shared": {
     "outputRoot": "${env:ZEUS_OUTPUT_ROOT}",
+    "analysesRegistryPath": "${env:ZEUS_ANALYSES_REGISTRY}",
+    "defaultWorkspaceRoot": "${env:ZEUS_ANALYSES_ROOT}",
     "extensions": [".rpgle", ".sqlrpgle", ".clle", ".clp", ".dds", ".pf", ".lf", ".bnd", ".cpy"],
     "db": {
       "host": "${env:ZEUS_DB_HOST}",

--- a/src/cli/commands/analysesCommand.js
+++ b/src/cli/commands/analysesCommand.js
@@ -1,0 +1,266 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const path = require('path');
+
+const { loadProfiles, resolveProfile } = require('../../config/runtimeConfig');
+const { renderAsciiTable } = require('../helpers/asciiTable');
+const {
+  deriveWorkspaceId,
+  listWorkspaces,
+  readWorkspaceById,
+  registerWorkspace,
+  resolveRegistryPath,
+  touchWorkspace,
+  unregisterWorkspace,
+} = require('../../workspace/analysisRegistryService');
+const {
+  readWorkspaceIndex,
+  writeWorkspaceIndex,
+} = require('../../workspace/workspaceIndexBuilder');
+const { startLocalUiServer, DEFAULT_UI_HOST, DEFAULT_UI_PORT } = require('../../ui/localUiServer');
+
+function parsePort(value, fallback) {
+  if (value === undefined || value === null || value === true) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(String(value).trim(), 10);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error('Invalid option: --port must be a non-negative integer');
+  }
+  return parsed;
+}
+
+function resolveProfileIfRequested(args, runtime) {
+  if (!args.profile) {
+    return null;
+  }
+  const profiles = loadProfiles({ cwd: runtime.cwd, env: runtime.env, args });
+  return resolveProfile(profiles, args.profile, { env: runtime.env });
+}
+
+function resolveCommandContext(args, runtime = {}) {
+  const resolvedRuntime = {
+    cwd: runtime.cwd || process.cwd(),
+    env: runtime.env || process.env,
+  };
+  const profile = resolveProfileIfRequested(args, resolvedRuntime);
+  const registryPath = resolveRegistryPath({
+    registryPath: args['registry-path'],
+    cwd: resolvedRuntime.cwd,
+    env: resolvedRuntime.env,
+    profile,
+  });
+
+  return {
+    ...resolvedRuntime,
+    profile,
+    registryPath,
+  };
+}
+
+function requireSubcommand(args) {
+  const subcommand = Array.isArray(args._) && args._.length > 0
+    ? String(args._[0] || '').trim().toLowerCase()
+    : '';
+  if (!subcommand) {
+    throw new Error('Missing analyses subcommand. Use: list | register | index | open | show | unregister');
+  }
+  return subcommand;
+}
+
+function resolveWorkspacePathForIndex(args, context) {
+  if (args.path) {
+    return path.resolve(context.cwd, String(args.path));
+  }
+  if (args.id) {
+    const workspace = readWorkspaceById(context.registryPath, args.id);
+    if (!workspace) {
+      throw new Error(`Workspace not found: ${args.id}`);
+    }
+    return workspace.path;
+  }
+  throw new Error('Missing required option: --path <workspace-root> (or --id <workspace-id>)');
+}
+
+function printWorkspaceList(context) {
+  const workspaces = listWorkspaces(context.registryPath);
+  if (workspaces.length === 0) {
+    console.log(`No workspaces registered in ${context.registryPath}`);
+    return;
+  }
+
+  const rows = workspaces.map((workspace) => {
+    const index = readWorkspaceIndex(workspace.path);
+    const programCount = index && Array.isArray(index.programs) ? index.programs.length : 0;
+    return [
+      workspace.id,
+      workspace.name || '',
+      workspace.outputDir || 'output',
+      programCount,
+      workspace.lastAccessedAt || '',
+    ];
+  });
+
+  console.log(renderAsciiTable(
+    ['ID', 'Name', 'Output Dir', 'Programs', 'Last Accessed'],
+    rows,
+    { maxCellWidth: 42 },
+  ));
+}
+
+function runRegister(args, context) {
+  if (!args.path) {
+    throw new Error('Missing required option: --path <workspace-root>');
+  }
+
+  const workspacePath = path.resolve(context.cwd, String(args.path));
+  const id = args.id ? String(args.id).trim().toLowerCase() : deriveWorkspaceId(path.basename(workspacePath));
+  const workspace = registerWorkspace(context.registryPath, {
+    id,
+    name: args.name || id,
+    description: args.description || '',
+    system: args.system || '',
+    library: args.library || '',
+    profile: args['profile-name'] || args.profile || '',
+    path: workspacePath,
+    outputDir: args['output-dir'] || 'output',
+    sourceDir: args['source-dir'] || 'rpg_sources',
+    tags: args.tags ? String(args.tags).split(',').map((entry) => entry.trim()).filter(Boolean) : [],
+  });
+
+  const indexResult = writeWorkspaceIndex(workspace.path, workspace);
+
+  console.log(`Workspace registered: ${workspace.id}`);
+  console.log(`Registry: ${context.registryPath}`);
+  console.log(`Index: ${indexResult.path}`);
+}
+
+function runIndex(args, context) {
+  const workspacePath = resolveWorkspacePathForIndex(args, context);
+  const knownWorkspace = args.id ? readWorkspaceById(context.registryPath, args.id) : null;
+  const entry = knownWorkspace || {
+    id: args.id || deriveWorkspaceId(path.basename(workspacePath)),
+    name: args.name || path.basename(workspacePath),
+    system: args.system || '',
+    library: args.library || '',
+    outputDir: args['output-dir'] || 'output',
+    sourceDir: args['source-dir'] || 'rpg_sources',
+  };
+
+  const indexResult = writeWorkspaceIndex(workspacePath, entry);
+  console.log(`Workspace index written: ${indexResult.path}`);
+  console.log(`Programs indexed: ${indexResult.index.programs.length}`);
+}
+
+function runShow(args, context) {
+  if (!args.id) {
+    throw new Error('Missing required option: --id <workspace-id>');
+  }
+  const workspace = readWorkspaceById(context.registryPath, args.id);
+  if (!workspace) {
+    throw new Error(`Workspace not found: ${args.id}`);
+  }
+
+  const index = readWorkspaceIndex(workspace.path);
+  const programs = index && Array.isArray(index.programs) ? index.programs : [];
+
+  console.log(`ID: ${workspace.id}`);
+  console.log(`Name: ${workspace.name}`);
+  console.log(`Path: ${workspace.path}`);
+  console.log(`Output Dir: ${workspace.outputDir}`);
+  console.log(`Source Dir: ${workspace.sourceDir}`);
+  console.log(`Programs: ${programs.length}`);
+  console.log(`Last Accessed: ${workspace.lastAccessedAt || 'n/a'}`);
+}
+
+async function runOpen(args, context) {
+  if (!args.id) {
+    throw new Error('Missing required option: --id <workspace-id>');
+  }
+
+  const workspace = touchWorkspace(context.registryPath, args.id);
+  const outputRoot = path.resolve(workspace.path, workspace.outputDir || 'output');
+  const host = args.host || DEFAULT_UI_HOST;
+  const port = parsePort(args.port, DEFAULT_UI_PORT);
+
+  const result = await startLocalUiServer({
+    outputRoot,
+    host,
+    port,
+    registryPath: context.registryPath,
+  });
+
+  console.log(`Zeus local UI available at: ${result.url}`);
+  console.log(`Serving workspace: ${workspace.id}`);
+  console.log('Press Ctrl+C to stop.');
+
+  const shutdown = () => {
+    result.server.close(() => {
+      process.exit(0);
+    });
+  };
+
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+
+  return result;
+}
+
+function runUnregister(args, context) {
+  if (!args.id) {
+    throw new Error('Missing required option: --id <workspace-id>');
+  }
+  const removed = unregisterWorkspace(context.registryPath, args.id);
+  if (!removed) {
+    throw new Error(`Workspace not found: ${args.id}`);
+  }
+  console.log(`Workspace removed: ${args.id}`);
+}
+
+async function run(args = {}, runtime = {}) {
+  const context = resolveCommandContext(args, runtime);
+  const subcommand = requireSubcommand(args);
+
+  if (subcommand === 'list') {
+    printWorkspaceList(context);
+    return;
+  }
+  if (subcommand === 'register') {
+    runRegister(args, context);
+    return;
+  }
+  if (subcommand === 'index') {
+    runIndex(args, context);
+    return;
+  }
+  if (subcommand === 'show') {
+    runShow(args, context);
+    return;
+  }
+  if (subcommand === 'open') {
+    await runOpen(args, context);
+    return;
+  }
+  if (subcommand === 'unregister') {
+    runUnregister(args, context);
+    return;
+  }
+
+  throw new Error(`Unsupported analyses subcommand: ${subcommand}`);
+}
+
+module.exports = {
+  run,
+  resolveCommandContext,
+};

--- a/src/cli/commands/doctorCommand.js
+++ b/src/cli/commands/doctorCommand.js
@@ -251,6 +251,14 @@ function buildEnvironmentChecks({ profile, analyzeConfig, fetchConfig, env }) {
     required: false,
     hint: 'C:/Projekte/ticket/zeus-source',
   });
+  addEnvCheck(checks, {
+    name: 'ZEUS_ANALYSES_REGISTRY',
+    expected: true,
+    envValue: env.ZEUS_ANALYSES_REGISTRY,
+    fallbackValue: profile && profile.analysesRegistryPath,
+    required: false,
+    hint: 'C:/Projekte/analyses/_registry.json',
+  });
 
   return checks;
 }

--- a/src/cli/commands/serveCommand.js
+++ b/src/cli/commands/serveCommand.js
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const path = require('path');
 
-const { resolveBundleConfig } = require('../../config/runtimeConfig');
+const { loadProfiles, resolveBundleConfig, resolveProfile } = require('../../config/runtimeConfig');
+const { resolveRegistryPath } = require('../../workspace/analysisRegistryService');
 const { startLocalUiServer, DEFAULT_UI_HOST, DEFAULT_UI_PORT } = require('../../ui/localUiServer');
 
 function parsePort(value, fallback) {
@@ -31,6 +32,16 @@ function parsePort(value, fallback) {
 async function runServe(args) {
   const verbose = Boolean(args.verbose);
   const config = resolveBundleConfig(args);
+  const profiles = loadProfiles({ cwd: process.cwd(), env: process.env, args });
+  const profile = args.profile ? resolveProfile(profiles, args.profile, { env: process.env }) : null;
+  const hasRegistryConfig = Boolean(args['registry-path'] || process.env.ZEUS_ANALYSES_REGISTRY || (profile && profile.analysesRegistryPath));
+  const registryPath = hasRegistryConfig
+    ? resolveRegistryPath({
+      registryPath: args['registry-path'],
+      profile,
+      env: process.env,
+    })
+    : null;
   const outputRoot = path.resolve(process.cwd(), config.sourceOutputRoot);
   const host = args.host || DEFAULT_UI_HOST;
   const port = parsePort(args.port, DEFAULT_UI_PORT);
@@ -39,11 +50,13 @@ async function runServe(args) {
     outputRoot,
     host,
     port,
+    registryPath,
   });
 
   if (verbose) {
     console.log(`[verbose] Output root: ${result.outputRoot}`);
-    console.log('[verbose] API routes: /api/health, /api/runs, /api/runs/:program, /api/runs/:program/artifacts/content, /api/prompt-builder/*');
+    console.log(`[verbose] Registry path: ${registryPath || 'not configured (fallback workspace mode)'}`);
+    console.log('[verbose] API routes: /api/health, /api/runs, /api/runs/:program, /api/runs/:program/artifacts/content, /api/analyses*, /api/prompt-builder/*');
   }
 
   console.log(`Zeus local UI available at: ${result.url}`);

--- a/src/report/jsonReport.js
+++ b/src/report/jsonReport.js
@@ -12,9 +12,12 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
 const fs = require('fs');
+const { collectSensitiveTermsFromEnv, sanitizeValue } = require('../security/secretMasking');
 
 function writeJsonReport(filePath, data) {
-  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+  const sensitiveTerms = collectSensitiveTermsFromEnv(process.env);
+  const sanitized = sanitizeValue(data, { sensitiveTerms });
+  fs.writeFileSync(filePath, `${JSON.stringify(sanitized, null, 2)}\n`, 'utf8');
 }
 
 module.exports = {

--- a/src/security/secretMasking.js
+++ b/src/security/secretMasking.js
@@ -14,6 +14,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 const REDACTED_VALUE = '[REDACTED]';
 const SENSITIVE_KEY_PATTERN = /(^|[_-])(password|passwd|pwd|pass|secret|token|api[_-]?key|key|authorization|auth|credential|credentials)$/i;
 const USER_KEY_PATTERN = /^(user|username)$/i;
+const SENSITIVE_ENV_KEYS = Object.freeze([
+  'ZEUS_DB_HOST',
+  'ZEUS_DB_USER',
+  'ZEUS_DB_DEFAULT_LIBRARY',
+  'ZEUS_DB_DEFAULT_SCHEMA',
+  'ZEUS_METADATA_DB_HOST',
+  'ZEUS_METADATA_DB_USER',
+  'ZEUS_METADATA_DB_DEFAULT_LIBRARY',
+  'ZEUS_METADATA_DB_DEFAULT_SCHEMA',
+  'ZEUS_TESTDATA_DB_HOST',
+  'ZEUS_TESTDATA_DB_USER',
+  'ZEUS_TESTDATA_DB_DEFAULT_LIBRARY',
+  'ZEUS_TESTDATA_DB_DEFAULT_SCHEMA',
+  'ZEUS_FETCH_HOST',
+  'ZEUS_FETCH_USER',
+  'ZEUS_FETCH_SOURCE_LIB',
+  'ZEUS_FETCH_SOURCE_LIBRARY',
+]);
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -25,6 +43,64 @@ function shouldMaskKey(key) {
 
 function hasCredentialFields(value) {
   return Object.keys(value || {}).some((entry) => shouldMaskKey(entry));
+}
+
+function escapeRegExp(value) {
+  return String(value || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeSensitiveTerms(input = []) {
+  const terms = Array.isArray(input) ? input : [input];
+  return Array.from(new Set(terms
+    .map((entry) => String(entry || '').trim())
+    .filter((entry) => entry.length > 1)
+    .map((entry) => entry.toUpperCase())))
+    .sort((left, right) => right.length - left.length || left.localeCompare(right));
+}
+
+function parseSensitiveTermsCsv(value) {
+  if (value === undefined || value === null || value === false) {
+    return [];
+  }
+  const raw = Array.isArray(value) ? value.join(',') : String(value);
+  return raw
+    .split(/[,\n;]+/g)
+    .map((entry) => String(entry || '').trim())
+    .filter(Boolean);
+}
+
+function collectSensitiveTermsFromEnv(env = process.env, additionalTerms = []) {
+  const terms = [];
+
+  for (const key of SENSITIVE_ENV_KEYS) {
+    if (env && env[key]) {
+      terms.push(env[key]);
+    }
+  }
+
+  if (env && env.ZEUS_SENSITIVE_TERMS) {
+    terms.push(...parseSensitiveTermsCsv(env.ZEUS_SENSITIVE_TERMS));
+  }
+  if (env && env.ZEUS_MASK_TERMS) {
+    terms.push(...parseSensitiveTermsCsv(env.ZEUS_MASK_TERMS));
+  }
+  terms.push(...parseSensitiveTermsCsv(additionalTerms));
+  return normalizeSensitiveTerms(terms);
+}
+
+function maskSensitiveTermsInText(value, sensitiveTerms = []) {
+  let text = String(value === undefined || value === null ? '' : value);
+  const normalizedTerms = normalizeSensitiveTerms(sensitiveTerms);
+
+  for (const term of normalizedTerms) {
+    const escaped = escapeRegExp(term);
+    text = text.replace(
+      new RegExp(`(^|[^A-Z0-9_#$@])(${escaped})(?=[^A-Z0-9_#$@]|$)`, 'gi'),
+      `$1${REDACTED_VALUE}`,
+    );
+  }
+
+  return text;
 }
 
 function maskSecretsInText(value) {
@@ -51,7 +127,13 @@ function maskSecretsInText(value) {
   return text;
 }
 
-function sanitizeValue(value, key = '') {
+function sanitizeValue(value, keyOrOptions = '', maybeOptions = {}) {
+  const key = typeof keyOrOptions === 'string' ? keyOrOptions : '';
+  const options = typeof keyOrOptions === 'object' && keyOrOptions !== null && !Array.isArray(keyOrOptions)
+    ? keyOrOptions
+    : maybeOptions;
+  const sensitiveTerms = normalizeSensitiveTerms((options && options.sensitiveTerms) || []);
+
   if (value === undefined || value === null) {
     return value;
   }
@@ -61,11 +143,11 @@ function sanitizeValue(value, key = '') {
   }
 
   if (typeof value === 'string') {
-    return maskSecretsInText(value);
+    return maskSensitiveTermsInText(maskSecretsInText(value), sensitiveTerms);
   }
 
   if (Array.isArray(value)) {
-    return value.map((entry) => sanitizeValue(entry));
+    return value.map((entry) => sanitizeValue(entry, options));
   }
 
   if (isPlainObject(value)) {
@@ -76,7 +158,7 @@ function sanitizeValue(value, key = '') {
         sanitized[childKey] = REDACTED_VALUE;
         continue;
       }
-      sanitized[childKey] = sanitizeValue(childValue, childKey);
+      sanitized[childKey] = sanitizeValue(childValue, childKey, options);
     }
     return sanitized;
   }
@@ -86,8 +168,11 @@ function sanitizeValue(value, key = '') {
 
 module.exports = {
   REDACTED_VALUE,
+  collectSensitiveTermsFromEnv,
+  maskSensitiveTermsInText,
   maskSecretsInText,
+  normalizeSensitiveTerms,
+  parseSensitiveTermsCsv,
   sanitizeValue,
   shouldMaskKey,
 };
-

--- a/src/ui/localUiServer.js
+++ b/src/ui/localUiServer.js
@@ -20,8 +20,12 @@ const {
   executeReadRun,
   executeReadRunViews,
 } = require('../core/runExplorerService');
+const { listAnalysisRuns } = require('./localUiDataApi');
 const { renderLocalUiShell } = require('./localUiShell');
 const { createPromptWorkbenchService } = require('./promptWorkbenchService');
+const { collectSensitiveTermsFromEnv, maskSensitiveTermsInText, sanitizeValue } = require('../security/secretMasking');
+const { listWorkspaces, readWorkspaceById, touchWorkspace } = require('../workspace/analysisRegistryService');
+const { readWorkspaceIndex, WORKSPACE_INDEX_FILE } = require('../workspace/workspaceIndexBuilder');
 
 const DEFAULT_UI_HOST = '127.0.0.1';
 const DEFAULT_UI_PORT = 4782;
@@ -49,12 +53,14 @@ function parsePositiveInteger(value, fallback) {
   return parsed;
 }
 
-function sendJson(response, statusCode, payload) {
+function sendJson(response, statusCode, payload, options = {}) {
+  const sensitiveTerms = Array.isArray(options.sensitiveTerms) ? options.sensitiveTerms : [];
+  const sanitizedPayload = sanitizeValue(payload, { sensitiveTerms });
   response.writeHead(statusCode, {
     'Content-Type': 'application/json; charset=utf-8',
     'Cache-Control': 'no-store',
   });
-  response.end(`${JSON.stringify(payload, null, 2)}\n`);
+  response.end(`${JSON.stringify(sanitizedPayload, null, 2)}\n`);
 }
 
 function sendMethodNotAllowed(response, methods) {
@@ -66,12 +72,13 @@ function sendMethodNotAllowed(response, methods) {
   response.end(`${JSON.stringify({ error: 'Method not allowed' }, null, 2)}\n`);
 }
 
-function sendText(response, statusCode, content, contentType = 'text/plain; charset=utf-8') {
+function sendText(response, statusCode, content, contentType = 'text/plain; charset=utf-8', sensitiveTerms = []) {
+  const sanitized = maskSensitiveTermsInText(content, sensitiveTerms);
   response.writeHead(statusCode, {
     'Content-Type': contentType,
     'Cache-Control': 'no-store',
   });
-  response.end(content);
+  response.end(sanitized);
 }
 
 function splitPathname(pathname) {
@@ -123,7 +130,10 @@ async function handlePromptBuilderRequest({
   pathname,
   segments,
   promptWorkbenchService,
+  sensitiveTerms = [],
 }) {
+  const send = (statusCode, payload) => sendJson(response, statusCode, payload, { sensitiveTerms });
+
   if (!pathname.startsWith('/api/prompt-builder')) {
     return false;
   }
@@ -133,7 +143,7 @@ async function handlePromptBuilderRequest({
       sendMethodNotAllowed(response, ['GET']);
       return true;
     }
-    sendJson(response, 200, promptWorkbenchService.getContract());
+    send(200, promptWorkbenchService.getContract());
     return true;
   }
 
@@ -142,7 +152,7 @@ async function handlePromptBuilderRequest({
       sendMethodNotAllowed(response, ['GET']);
       return true;
     }
-    sendJson(response, 200, promptWorkbenchService.listUseCases());
+    send(200, promptWorkbenchService.listUseCases());
     return true;
   }
 
@@ -151,7 +161,7 @@ async function handlePromptBuilderRequest({
       sendMethodNotAllowed(response, ['GET']);
       return true;
     }
-    sendJson(response, 200, promptWorkbenchService.listModules());
+    send(200, promptWorkbenchService.listModules());
     return true;
   }
 
@@ -161,18 +171,18 @@ async function handlePromptBuilderRequest({
       return true;
     }
     const payload = await readJsonBody(request);
-    sendJson(response, 200, promptWorkbenchService.previewPrompt(payload));
+    send(200, promptWorkbenchService.previewPrompt(payload));
     return true;
   }
 
   if (pathname === '/api/prompt-builder/templates') {
     if (request.method === 'GET') {
-      sendJson(response, 200, promptWorkbenchService.listTemplates());
+      send(200, promptWorkbenchService.listTemplates());
       return true;
     }
     if (request.method === 'POST') {
       const payload = await readJsonBody(request);
-      sendJson(response, 201, promptWorkbenchService.createTemplate(payload));
+      send(201, promptWorkbenchService.createTemplate(payload));
       return true;
     }
     sendMethodNotAllowed(response, ['GET', 'POST']);
@@ -182,16 +192,16 @@ async function handlePromptBuilderRequest({
   if (segments[0] === 'api' && segments[1] === 'prompt-builder' && segments[2] === 'templates' && segments.length === 4) {
     const templateId = segments[3];
     if (request.method === 'GET') {
-      sendJson(response, 200, promptWorkbenchService.readTemplate(templateId));
+      send(200, promptWorkbenchService.readTemplate(templateId));
       return true;
     }
     if (request.method === 'PUT') {
       const payload = await readJsonBody(request);
-      sendJson(response, 200, promptWorkbenchService.updateTemplate(templateId, payload));
+      send(200, promptWorkbenchService.updateTemplate(templateId, payload));
       return true;
     }
     if (request.method === 'DELETE') {
-      sendJson(response, 200, promptWorkbenchService.deleteTemplate(templateId));
+      send(200, promptWorkbenchService.deleteTemplate(templateId));
       return true;
     }
     sendMethodNotAllowed(response, ['GET', 'PUT', 'DELETE']);
@@ -203,7 +213,7 @@ async function handlePromptBuilderRequest({
       sendMethodNotAllowed(response, ['GET']);
       return true;
     }
-    sendJson(response, 200, promptWorkbenchService.listContextSources());
+    send(200, promptWorkbenchService.listContextSources());
     return true;
   }
 
@@ -212,7 +222,7 @@ async function handlePromptBuilderRequest({
       sendMethodNotAllowed(response, ['GET']);
       return true;
     }
-    sendJson(response, 200, promptWorkbenchService.listContextSourcePrompts(segments[3]));
+    send(200, promptWorkbenchService.listContextSourcePrompts(segments[3]));
     return true;
   }
 
@@ -222,15 +232,140 @@ async function handlePromptBuilderRequest({
       return true;
     }
     const payload = await readJsonBody(request);
-    sendJson(response, 200, promptWorkbenchService.importContextPrompt(payload));
+    send(200, promptWorkbenchService.importContextPrompt(payload));
     return true;
   }
 
-  sendJson(response, 404, { error: `Route not found: ${pathname}` });
+  send(404, { error: `Route not found: ${pathname}` });
   return true;
 }
 
-function createLocalUiRequestHandler({ outputRoot, promptWorkbenchService }) {
+function buildDefaultAnalysisWorkspace({ outputRoot }) {
+  return {
+    id: 'default',
+    name: 'Current Output Root',
+    description: 'Fallback workspace when no analyses registry is configured.',
+    path: path.resolve(outputRoot),
+    outputDir: '.',
+    sourceDir: '',
+    registeredAt: null,
+    lastAccessedAt: null,
+  };
+}
+
+function listAnalyses(registryPath, outputRoot) {
+  if (!registryPath) {
+    return [buildDefaultAnalysisWorkspace({ outputRoot })];
+  }
+  return listWorkspaces(registryPath);
+}
+
+function resolveAnalysisWorkspace({ registryPath, workspaceId, outputRoot }) {
+  if (workspaceId === 'default') {
+    return buildDefaultAnalysisWorkspace({ outputRoot });
+  }
+  if (!registryPath) {
+    throw new Error(`Workspace not found: ${workspaceId}`);
+  }
+  const workspace = readWorkspaceById(registryPath, workspaceId);
+  if (!workspace) {
+    throw new Error(`Workspace not found: ${workspaceId}`);
+  }
+  return workspace;
+}
+
+function resolveWorkspaceOutputRoot(workspace) {
+  if (workspace.id === 'default') {
+    return path.resolve(workspace.path);
+  }
+  return path.resolve(workspace.path, workspace.outputDir || 'output');
+}
+
+async function handleAnalysesRequest({
+  request,
+  response,
+  pathname,
+  segments,
+  registryPath,
+  outputRoot,
+  sensitiveTerms,
+}) {
+  if (!pathname.startsWith('/api/analyses')) {
+    return false;
+  }
+
+  if (pathname === '/api/analyses') {
+    if (request.method !== 'GET') {
+      sendMethodNotAllowed(response, ['GET']);
+      return true;
+    }
+    sendJson(response, 200, {
+      registryPath: registryPath || null,
+      workspaces: listAnalyses(registryPath, outputRoot),
+    }, { sensitiveTerms });
+    return true;
+  }
+
+  if (segments[0] !== 'api' || segments[1] !== 'analyses' || segments.length < 3) {
+    sendJson(response, 404, { error: `Route not found: ${pathname}` }, { sensitiveTerms });
+    return true;
+  }
+
+  const workspaceId = segments[2];
+  const workspace = resolveAnalysisWorkspace({ registryPath, workspaceId, outputRoot });
+  const workspaceOutputRoot = resolveWorkspaceOutputRoot(workspace);
+
+  if (segments.length === 3) {
+    if (request.method !== 'GET') {
+      sendMethodNotAllowed(response, ['GET']);
+      return true;
+    }
+    sendJson(response, 200, {
+      workspace,
+      outputRoot: workspaceOutputRoot,
+      index: readWorkspaceIndex(workspace.path),
+      runs: listAnalysisRuns(workspaceOutputRoot),
+    }, { sensitiveTerms });
+    return true;
+  }
+
+  if (segments.length === 4 && segments[3] === 'index') {
+    if (request.method !== 'GET') {
+      sendMethodNotAllowed(response, ['GET']);
+      return true;
+    }
+    const index = readWorkspaceIndex(workspace.path);
+    if (!index) {
+      sendJson(response, 404, { error: `${WORKSPACE_INDEX_FILE} not found for workspace ${workspaceId}` }, { sensitiveTerms });
+      return true;
+    }
+    sendJson(response, 200, index, { sensitiveTerms });
+    return true;
+  }
+
+  if (segments.length === 4 && segments[3] === 'touch') {
+    if (request.method !== 'POST') {
+      sendMethodNotAllowed(response, ['POST']);
+      return true;
+    }
+    const touched = registryPath ? touchWorkspace(registryPath, workspaceId) : workspace;
+    sendJson(response, 200, {
+      ok: true,
+      workspace: touched,
+    }, { sensitiveTerms });
+    return true;
+  }
+
+  sendJson(response, 404, { error: `Route not found: ${pathname}` }, { sensitiveTerms });
+  return true;
+}
+
+function createLocalUiRequestHandler({
+  outputRoot,
+  promptWorkbenchService,
+  registryPath = null,
+  sensitiveTerms = [],
+}) {
   const resolvedOutputRoot = path.resolve(outputRoot);
   const service = promptWorkbenchService || createPromptWorkbenchService();
 
@@ -240,12 +375,26 @@ function createLocalUiRequestHandler({ outputRoot, promptWorkbenchService }) {
     const segments = splitPathname(pathname);
 
     try {
+      const analysesHandled = await handleAnalysesRequest({
+        request,
+        response,
+        pathname,
+        segments,
+        registryPath,
+        outputRoot: resolvedOutputRoot,
+        sensitiveTerms,
+      });
+      if (analysesHandled) {
+        return;
+      }
+
       const promptBuilderHandled = await handlePromptBuilderRequest({
         request,
         response,
         pathname,
         segments,
         promptWorkbenchService: service,
+        sensitiveTerms,
       });
       if (promptBuilderHandled) {
         return;
@@ -257,7 +406,7 @@ function createLocalUiRequestHandler({ outputRoot, promptWorkbenchService }) {
       }
 
       if (pathname === '/' || pathname === '/index.html') {
-        sendText(response, 200, renderLocalUiShell(), 'text/html; charset=utf-8');
+        sendText(response, 200, renderLocalUiShell(), 'text/html; charset=utf-8', sensitiveTerms);
         return;
       }
 
@@ -265,14 +414,14 @@ function createLocalUiRequestHandler({ outputRoot, promptWorkbenchService }) {
         sendJson(response, 200, {
           ok: true,
           outputRoot: resolvedOutputRoot,
-        });
+        }, { sensitiveTerms });
         return;
       }
 
       if (pathname === '/api/runs') {
         sendJson(response, 200, executeListRuns({
           sourceOutputRoot: resolvedOutputRoot,
-        }).runs);
+        }).runs, { sensitiveTerms });
         return;
       }
 
@@ -280,7 +429,7 @@ function createLocalUiRequestHandler({ outputRoot, promptWorkbenchService }) {
         sendJson(response, 200, executeReadRun({
           sourceOutputRoot: resolvedOutputRoot,
           program: segments[2],
-        }).run);
+        }).run, { sensitiveTerms });
         return;
       }
 
@@ -288,7 +437,7 @@ function createLocalUiRequestHandler({ outputRoot, promptWorkbenchService }) {
         sendJson(response, 200, executeReadRunViews({
           sourceOutputRoot: resolvedOutputRoot,
           program: segments[2],
-        }).views);
+        }).views, { sensitiveTerms });
         return;
       }
 
@@ -297,7 +446,7 @@ function createLocalUiRequestHandler({ outputRoot, promptWorkbenchService }) {
           sourceOutputRoot: resolvedOutputRoot,
           program: segments[2],
           path: url.searchParams.get('path'),
-        }).artifact);
+        }).artifact, { sensitiveTerms });
         return;
       }
 
@@ -307,15 +456,15 @@ function createLocalUiRequestHandler({ outputRoot, promptWorkbenchService }) {
           program: segments[1],
           path: url.searchParams.get('path'),
         }).artifact;
-        sendText(response, 200, artifact.content, artifact.contentType);
+        sendText(response, 200, artifact.content, artifact.contentType, sensitiveTerms);
         return;
       }
 
-      sendJson(response, 404, { error: `Route not found: ${pathname}` });
+      sendJson(response, 404, { error: `Route not found: ${pathname}` }, { sensitiveTerms });
     } catch (error) {
       sendJson(response, /not found/i.test(error.message) ? 404 : 400, {
         error: error.message,
-      });
+      }, { sensitiveTerms });
     }
   };
 }
@@ -325,6 +474,8 @@ async function startLocalUiServer({
   host = DEFAULT_UI_HOST,
   port = DEFAULT_UI_PORT,
   templateStorePath,
+  registryPath = null,
+  sensitiveTerms = [],
 } = {}) {
   const resolvedHost = normalizeHost(host);
   const resolvedPort = parsePositiveInteger(port, DEFAULT_UI_PORT);
@@ -333,9 +484,12 @@ async function startLocalUiServer({
     templateStorePath,
     outputRoot: resolvedOutputRoot,
   });
+  const resolvedSensitiveTerms = collectSensitiveTermsFromEnv(process.env, sensitiveTerms);
   const server = http.createServer(createLocalUiRequestHandler({
     outputRoot: resolvedOutputRoot,
     promptWorkbenchService,
+    registryPath: registryPath ? path.resolve(registryPath) : null,
+    sensitiveTerms: resolvedSensitiveTerms,
   }));
 
   await new Promise((resolve, reject) => {
@@ -350,6 +504,7 @@ async function startLocalUiServer({
     host: resolvedHost,
     port: actualPort,
     outputRoot: resolvedOutputRoot,
+    registryPath: registryPath ? path.resolve(registryPath) : null,
     url: `http://${resolvedHost === '::1' ? '[::1]' : resolvedHost}:${actualPort}`,
   };
 }

--- a/src/workspace/analysisRegistryService.js
+++ b/src/workspace/analysisRegistryService.js
@@ -1,0 +1,248 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REGISTRY_SCHEMA_VERSION = 1;
+const WORKSPACE_ID_PATTERN = /^[a-z0-9_-]+$/;
+const WORKSPACE_PATH_ENCODING = 'base64utf8';
+
+function normalizeWorkspaceId(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function encodeWorkspacePath(value) {
+  return Buffer.from(String(value || ''), 'utf8').toString('base64');
+}
+
+function decodeWorkspacePath(value, encoding = '') {
+  const raw = String(value || '').trim();
+  if (!raw) {
+    return '';
+  }
+  if (String(encoding || '').trim().toLowerCase() === WORKSPACE_PATH_ENCODING) {
+    return Buffer.from(raw, 'base64').toString('utf8');
+  }
+  return raw;
+}
+
+function deriveWorkspaceId(input) {
+  const normalized = String(input || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (!normalized) {
+    throw new Error('Workspace id cannot be derived from the provided value. Use --id.');
+  }
+  return normalized;
+}
+
+function validateWorkspaceId(value) {
+  const normalized = normalizeWorkspaceId(value);
+  if (!normalized) {
+    throw new Error('Workspace id is required.');
+  }
+  if (!WORKSPACE_ID_PATTERN.test(normalized)) {
+    throw new Error(`Invalid workspace id: ${value}. Allowed pattern: ${WORKSPACE_ID_PATTERN}`);
+  }
+  return normalized;
+}
+
+function resolveRegistryPath(config = {}) {
+  const explicit = config.registryPath || config.registry || config.registryFile;
+  const env = config.env || process.env;
+  const profile = config.profile || null;
+
+  const candidate = explicit
+    || (env && env.ZEUS_ANALYSES_REGISTRY)
+    || (profile && profile.analysesRegistryPath)
+    || path.join(os.homedir(), '.zeus', 'analyses-registry.json');
+
+  return path.resolve(config.cwd || process.cwd(), String(candidate));
+}
+
+function createEmptyRegistry() {
+  return {
+    schemaVersion: REGISTRY_SCHEMA_VERSION,
+    registeredAt: new Date().toISOString(),
+    workspaces: [],
+  };
+}
+
+function normalizeWorkspaceEntry(entry = {}) {
+  const now = new Date().toISOString();
+  const outputDir = String(entry.outputDir || 'output').trim() || 'output';
+  const sourceDir = String(entry.sourceDir || 'rpg_sources').trim() || 'rpg_sources';
+  const decodedPath = decodeWorkspacePath(entry.path, entry.pathEncoding);
+
+  return {
+    id: validateWorkspaceId(entry.id),
+    name: String(entry.name || '').trim() || String(entry.id || '').trim(),
+    description: String(entry.description || '').trim() || '',
+    system: String(entry.system || '').trim() || '',
+    library: String(entry.library || '').trim() || '',
+    profile: String(entry.profile || '').trim() || '',
+    path: path.resolve(String(decodedPath || '')),
+    outputDir,
+    sourceDir,
+    tags: Array.isArray(entry.tags)
+      ? Array.from(new Set(entry.tags.map((tag) => String(tag || '').trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b))
+      : [],
+    registeredAt: String(entry.registeredAt || now),
+    lastAccessedAt: String(entry.lastAccessedAt || now),
+  };
+}
+
+function validateRegistryPath(registryPath) {
+  const resolved = path.resolve(String(registryPath || ''));
+  if (!resolved) {
+    throw new Error('Registry path is required.');
+  }
+  if (path.extname(resolved).toLowerCase() !== '.json') {
+    throw new Error('Registry path must point to a .json file.');
+  }
+  return resolved;
+}
+
+function readRegistry(registryPath) {
+  const resolvedPath = validateRegistryPath(registryPath);
+  if (!fs.existsSync(resolvedPath)) {
+    return createEmptyRegistry();
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+  const workspaces = Array.isArray(parsed.workspaces) ? parsed.workspaces.map((entry) => normalizeWorkspaceEntry(entry)) : [];
+
+  return {
+    schemaVersion: REGISTRY_SCHEMA_VERSION,
+    registeredAt: String(parsed.registeredAt || new Date().toISOString()),
+    workspaces,
+  };
+}
+
+function writeRegistry(registryPath, data) {
+  const resolvedPath = validateRegistryPath(registryPath);
+  const directory = path.dirname(resolvedPath);
+  fs.mkdirSync(directory, { recursive: true });
+
+  const payload = {
+    schemaVersion: REGISTRY_SCHEMA_VERSION,
+    registeredAt: String(data && data.registeredAt ? data.registeredAt : new Date().toISOString()),
+    workspaces: Array.isArray(data && data.workspaces)
+      ? data.workspaces.map((entry) => {
+        const normalized = normalizeWorkspaceEntry(entry);
+        return {
+          ...normalized,
+          path: encodeWorkspacePath(normalized.path),
+          pathEncoding: WORKSPACE_PATH_ENCODING,
+        };
+      })
+      : [],
+  };
+
+  const tempPath = `${resolvedPath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  fs.renameSync(tempPath, resolvedPath);
+  return payload;
+}
+
+function registerWorkspace(registryPath, workspaceEntry) {
+  const registry = readRegistry(registryPath);
+  const normalized = normalizeWorkspaceEntry(workspaceEntry);
+
+  if (!normalized.path || !fs.existsSync(normalized.path) || !fs.statSync(normalized.path).isDirectory()) {
+    throw new Error(`Workspace path not found: ${normalized.path}`);
+  }
+
+  const byIdIndex = registry.workspaces.findIndex((entry) => entry.id === normalized.id);
+  const byPathIndex = registry.workspaces.findIndex((entry) => entry.path === normalized.path);
+  const existingIndex = byIdIndex !== -1 ? byIdIndex : byPathIndex;
+
+  if (existingIndex >= 0) {
+    const existing = registry.workspaces[existingIndex];
+    registry.workspaces[existingIndex] = {
+      ...existing,
+      ...normalized,
+      registeredAt: existing.registeredAt || normalized.registeredAt,
+      lastAccessedAt: new Date().toISOString(),
+    };
+  } else {
+    registry.workspaces.push(normalized);
+  }
+
+  writeRegistry(registryPath, registry);
+  return normalized;
+}
+
+function unregisterWorkspace(registryPath, workspaceId) {
+  const normalizedId = validateWorkspaceId(workspaceId);
+  const registry = readRegistry(registryPath);
+  const previousCount = registry.workspaces.length;
+  registry.workspaces = registry.workspaces.filter((entry) => entry.id !== normalizedId);
+  if (registry.workspaces.length === previousCount) {
+    return false;
+  }
+  writeRegistry(registryPath, registry);
+  return true;
+}
+
+function listWorkspaces(registryPath) {
+  const registry = readRegistry(registryPath);
+  return [...registry.workspaces].sort((left, right) => {
+    const leftTime = Date.parse(left.lastAccessedAt || left.registeredAt || '') || 0;
+    const rightTime = Date.parse(right.lastAccessedAt || right.registeredAt || '') || 0;
+    if (rightTime !== leftTime) {
+      return rightTime - leftTime;
+    }
+    return String(left.id || '').localeCompare(String(right.id || ''));
+  });
+}
+
+function touchWorkspace(registryPath, workspaceId) {
+  const normalizedId = validateWorkspaceId(workspaceId);
+  const registry = readRegistry(registryPath);
+  const workspace = registry.workspaces.find((entry) => entry.id === normalizedId);
+  if (!workspace) {
+    throw new Error(`Workspace not found: ${normalizedId}`);
+  }
+  workspace.lastAccessedAt = new Date().toISOString();
+  writeRegistry(registryPath, registry);
+  return workspace;
+}
+
+function readWorkspaceById(registryPath, workspaceId) {
+  const normalizedId = validateWorkspaceId(workspaceId);
+  return listWorkspaces(registryPath).find((entry) => entry.id === normalizedId) || null;
+}
+
+module.exports = {
+  REGISTRY_SCHEMA_VERSION,
+  WORKSPACE_PATH_ENCODING,
+  WORKSPACE_ID_PATTERN,
+  decodeWorkspacePath,
+  deriveWorkspaceId,
+  encodeWorkspacePath,
+  listWorkspaces,
+  normalizeWorkspaceEntry,
+  readRegistry,
+  readWorkspaceById,
+  registerWorkspace,
+  resolveRegistryPath,
+  touchWorkspace,
+  unregisterWorkspace,
+  validateWorkspaceId,
+  writeRegistry,
+};

--- a/src/workspace/workspaceIndexBuilder.js
+++ b/src/workspace/workspaceIndexBuilder.js
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+
+const { writeJsonReport } = require('../report/jsonReport');
+const { listAnalysisRuns } = require('../ui/localUiDataApi');
+
+const WORKSPACE_INDEX_FILE = 'workspace-index.json';
+
+function normalizePathForJson(filePath) {
+  return String(filePath || '').replace(/\\/g, '/');
+}
+
+function walkFiles(rootDir) {
+  if (!fs.existsSync(rootDir)) {
+    return [];
+  }
+  const discovered = [];
+  const pending = [rootDir];
+
+  while (pending.length > 0) {
+    const current = pending.pop();
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const absolutePath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(absolutePath);
+      } else if (entry.isFile()) {
+        discovered.push(absolutePath);
+      }
+    }
+  }
+
+  return discovered.sort((left, right) => left.localeCompare(right));
+}
+
+function scanSourceDir(sourceDir) {
+  const counts = {};
+  for (const filePath of walkFiles(sourceDir)) {
+    const relative = path.relative(sourceDir, filePath);
+    const segments = relative.split(path.sep).filter(Boolean);
+    const sourceFile = String(segments[0] || '').trim().toUpperCase();
+    if (!sourceFile) {
+      continue;
+    }
+    counts[sourceFile] = (counts[sourceFile] || 0) + 1;
+  }
+  return Object.keys(counts)
+    .sort((left, right) => left.localeCompare(right))
+    .reduce((acc, key) => {
+      acc[key] = counts[key];
+      return acc;
+    }, {});
+}
+
+function findReportFiles(workspacePath, outputDir = 'output') {
+  const resolvedWorkspace = path.resolve(workspacePath);
+  const outputRoot = path.join(resolvedWorkspace, outputDir);
+  const reports = [];
+
+  for (const filePath of walkFiles(outputRoot)) {
+    const relative = normalizePathForJson(path.relative(resolvedWorkspace, filePath));
+    const baseName = path.basename(filePath).toLowerCase();
+    if (!/report/.test(baseName) || !/\.md$/i.test(baseName)) {
+      continue;
+    }
+    const stats = fs.statSync(filePath);
+    reports.push({
+      path: relative,
+      title: path.basename(filePath).replace(/\.md$/i, '').replace(/[_-]+/g, ' ').trim(),
+      generatedAt: stats.mtime.toISOString(),
+    });
+  }
+
+  return reports.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function buildWorkspaceIndex(workspacePath, workspaceEntry = {}) {
+  const resolvedWorkspace = path.resolve(workspacePath);
+  const outputDir = String(workspaceEntry.outputDir || 'output').trim() || 'output';
+  const sourceDir = String(workspaceEntry.sourceDir || 'rpg_sources').trim() || 'rpg_sources';
+  const runs = listAnalysisRuns(path.join(resolvedWorkspace, outputDir));
+
+  return {
+    schemaVersion: 1,
+    id: String(workspaceEntry.id || '').trim() || path.basename(resolvedWorkspace).toLowerCase(),
+    name: String(workspaceEntry.name || '').trim() || path.basename(resolvedWorkspace),
+    system: String(workspaceEntry.system || '').trim() || '',
+    library: String(workspaceEntry.library || '').trim() || '',
+    generatedAt: new Date().toISOString(),
+    programs: runs.map((run) => ({
+      name: run.program,
+      outputDir: normalizePathForJson(path.join(outputDir, run.program)),
+      analyzedAt: run.completedAt,
+      workflowMode: run.workflowMode,
+      artifactCount: run.artifactCount,
+    })),
+    sourceMembers: scanSourceDir(path.join(resolvedWorkspace, sourceDir)),
+    reports: findReportFiles(resolvedWorkspace, outputDir),
+  };
+}
+
+function readWorkspaceIndex(workspacePath) {
+  const resolvedPath = path.join(path.resolve(workspacePath), WORKSPACE_INDEX_FILE);
+  if (!fs.existsSync(resolvedPath)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(resolvedPath, 'utf8'));
+}
+
+function writeWorkspaceIndex(workspacePath, workspaceEntry = {}) {
+  const resolvedWorkspace = path.resolve(workspacePath);
+  fs.mkdirSync(resolvedWorkspace, { recursive: true });
+  const index = buildWorkspaceIndex(resolvedWorkspace, workspaceEntry);
+  const targetPath = path.join(resolvedWorkspace, WORKSPACE_INDEX_FILE);
+  writeJsonReport(targetPath, index);
+  return {
+    path: targetPath,
+    index,
+  };
+}
+
+module.exports = {
+  WORKSPACE_INDEX_FILE,
+  buildWorkspaceIndex,
+  findReportFiles,
+  readWorkspaceIndex,
+  scanSourceDir,
+  writeWorkspaceIndex,
+};

--- a/tests/analysis-registry-service.test.js
+++ b/tests/analysis-registry-service.test.js
@@ -1,0 +1,73 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  listWorkspaces,
+  readWorkspaceById,
+  registerWorkspace,
+  resolveRegistryPath,
+  touchWorkspace,
+  unregisterWorkspace,
+} = require('../src/workspace/analysisRegistryService');
+
+test('resolveRegistryPath respects precedence explicit > env > profile > default', () => {
+  const explicit = resolveRegistryPath({
+    registryPath: './tmp/custom.json',
+    cwd: '/tmp',
+    env: { ZEUS_ANALYSES_REGISTRY: '/tmp/env.json' },
+    profile: { analysesRegistryPath: '/tmp/profile.json' },
+  });
+  assert.equal(explicit, path.resolve('/tmp', './tmp/custom.json'));
+
+  const fromEnv = resolveRegistryPath({
+    cwd: '/tmp',
+    env: { ZEUS_ANALYSES_REGISTRY: '/tmp/env.json' },
+    profile: { analysesRegistryPath: '/tmp/profile.json' },
+  });
+  assert.equal(fromEnv, path.resolve('/tmp/env.json'));
+
+  const fromProfile = resolveRegistryPath({
+    cwd: '/tmp',
+    env: {},
+    profile: { analysesRegistryPath: '/tmp/profile.json' },
+  });
+  assert.equal(fromProfile, path.resolve('/tmp/profile.json'));
+});
+
+test('register/list/touch/unregister workspace lifecycle works with persisted registry', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-registry-'));
+  const workspacePath = path.join(tempRoot, 'workspace-a');
+  fs.mkdirSync(workspacePath, { recursive: true });
+
+  const registryPath = path.join(tempRoot, '_registry.json');
+
+  registerWorkspace(registryPath, {
+    id: 'workspace_a',
+    name: 'Workspace A',
+    path: workspacePath,
+    outputDir: 'output',
+    sourceDir: 'rpg_sources',
+  });
+
+  const listed = listWorkspaces(registryPath);
+  assert.equal(listed.length, 1);
+  assert.equal(listed[0].id, 'workspace_a');
+  assert.equal(path.resolve(listed[0].path), path.resolve(workspacePath));
+
+  const beforeTouch = listed[0].lastAccessedAt;
+  const touched = touchWorkspace(registryPath, 'workspace_a');
+  assert.equal(touched.id, 'workspace_a');
+  assert.ok(Date.parse(touched.lastAccessedAt) >= Date.parse(beforeTouch));
+
+  const found = readWorkspaceById(registryPath, 'workspace_a');
+  assert.equal(found.id, 'workspace_a');
+  const rawRegistryJson = fs.readFileSync(registryPath, 'utf8');
+  assert.doesNotMatch(rawRegistryJson, new RegExp(workspacePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+
+  assert.equal(unregisterWorkspace(registryPath, 'workspace_a'), true);
+  assert.equal(unregisterWorkspace(registryPath, 'workspace_a'), false);
+  assert.equal(listWorkspaces(registryPath).length, 0);
+});

--- a/tests/doctor-command.test.js
+++ b/tests/doctor-command.test.js
@@ -17,6 +17,7 @@ test('buildEnvironmentChecks flags missing env vars with concrete set hints', ()
   assert.ok(checks.some((entry) => entry.name === 'ZEUS_DB_HOST' && entry.status === 'FAIL' && /set ZEUS_DB_HOST=mein-ibmi-host/.test(entry.details)));
   assert.ok(checks.some((entry) => entry.name === 'ZEUS_FETCH_OUT' && entry.status === 'FAIL' && /set ZEUS_FETCH_OUT=C:\/Projekte\/ticket\/zeus-fetch/.test(entry.details)));
   assert.ok(checks.some((entry) => entry.name === 'ZEUS_OUTPUT_ROOT' && entry.status === 'WARN'));
+  assert.ok(checks.some((entry) => entry.name === 'ZEUS_ANALYSES_REGISTRY' && entry.status === 'WARN'));
 });
 
 test('buildEnvironmentChecks downgrades to warnings when the profile already provides literal fallbacks', () => {

--- a/tests/local-ui-server.test.js
+++ b/tests/local-ui-server.test.js
@@ -135,6 +135,11 @@ test('local UI server exposes run explorer data and Prompt Workbench routes thro
     const health = await fetch(`${started.url}/api/health`).then((response) => response.json());
     assert.equal(health.ok, true);
 
+    const analyses = await fetch(`${started.url}/api/analyses`).then((response) => response.json());
+    assert.equal(Array.isArray(analyses.workspaces), true);
+    assert.equal(analyses.workspaces.length, 1);
+    assert.equal(analyses.workspaces[0].id, 'default');
+
     const runs = await fetch(`${started.url}/api/runs`).then((response) => response.json());
     assert.equal(runs.length, 1);
     assert.equal(runs[0].program, 'ORDERPGM');

--- a/tests/secret-masking.test.js
+++ b/tests/secret-masking.test.js
@@ -3,6 +3,8 @@ const assert = require('node:assert/strict');
 
 const {
   REDACTED_VALUE,
+  collectSensitiveTermsFromEnv,
+  maskSensitiveTermsInText,
   maskSecretsInText,
   sanitizeValue,
 } = require('../src/security/secretMasking');
@@ -48,3 +50,38 @@ test('maskSecretsInText redacts credential fields and jdbc query credentials', (
   assert.doesNotMatch(output, /\btop-secret\b/);
 });
 
+test('collectSensitiveTermsFromEnv includes configured system/library/user values', () => {
+  const terms = collectSensitiveTermsFromEnv({
+    ZEUS_DB_HOST: 'DERSMT1',
+    ZEUS_FETCH_SOURCE_LIB: 'WPT',
+    ZEUS_FETCH_USER: 'MYUSER',
+    ZEUS_SENSITIVE_TERMS: 'alpha,beta',
+  });
+
+  assert.ok(terms.includes('DERSMT1'));
+  assert.ok(terms.includes('WPT'));
+  assert.ok(terms.includes('MYUSER'));
+  assert.ok(terms.includes('ALPHA'));
+  assert.ok(terms.includes('BETA'));
+});
+
+test('maskSensitiveTermsInText redacts configured names in plain text', () => {
+  const output = maskSensitiveTermsInText('System DERSMT1 library WPT owner MYUSER', ['DERSMT1', 'WPT', 'MYUSER']);
+  assert.doesNotMatch(output, /\bDERSMT1\b/);
+  assert.doesNotMatch(output, /\bWPT\b/);
+  assert.doesNotMatch(output, /\bMYUSER\b/);
+  assert.match(output, /\[REDACTED\]/);
+});
+
+test('sanitizeValue applies sensitive term masking recursively', () => {
+  const sanitized = sanitizeValue({
+    system: 'DERSMT1',
+    nested: {
+      text: 'Library WPT, Owner MYUSER',
+    },
+  }, { sensitiveTerms: ['DERSMT1', 'WPT', 'MYUSER'] });
+
+  assert.equal(sanitized.system, REDACTED_VALUE);
+  assert.doesNotMatch(sanitized.nested.text, /\bWPT\b/);
+  assert.doesNotMatch(sanitized.nested.text, /\bMYUSER\b/);
+});

--- a/tests/workspace-index-builder.test.js
+++ b/tests/workspace-index-builder.test.js
@@ -1,0 +1,77 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { buildWorkspaceIndex, writeWorkspaceIndex } = require('../src/workspace/workspaceIndexBuilder');
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+test('buildWorkspaceIndex aggregates runs, source members, and reports', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-workspace-index-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  const outputDir = path.join(workspacePath, 'output');
+  const programDir = path.join(outputDir, 'ORDERPGM');
+  const sourceDir = path.join(workspacePath, 'rpg_sources');
+
+  fs.mkdirSync(programDir, { recursive: true });
+  writeJson(path.join(programDir, 'analyze-run-manifest.json'), {
+    schemaVersion: 1,
+    run: {
+      status: 'succeeded',
+      completedAt: '2026-05-18T09:00:00.000Z',
+    },
+    inputs: {
+      sourceRoot: 'C:/src',
+      options: {
+        guidedMode: {
+          name: 'documentation',
+        },
+      },
+    },
+  });
+  fs.writeFileSync(path.join(programDir, 'report.md'), '# Report\n', 'utf8');
+  fs.writeFileSync(path.join(programDir, 'context.json'), '{"ok":true}\n', 'utf8');
+  fs.writeFileSync(path.join(programDir, 'architecture-report.md'), '# Architecture Report\n', 'utf8');
+
+  fs.mkdirSync(path.join(sourceDir, 'QRPGLESRC'), { recursive: true });
+  fs.mkdirSync(path.join(sourceDir, 'QCLLESRC'), { recursive: true });
+  fs.writeFileSync(path.join(sourceDir, 'QRPGLESRC', 'ORDERPGM.rpgle'), 'dcl-proc X;\n', 'utf8');
+  fs.writeFileSync(path.join(sourceDir, 'QRPGLESRC', 'ORDERSRV.rpgle'), 'dcl-proc Y;\n', 'utf8');
+  fs.writeFileSync(path.join(sourceDir, 'QCLLESRC', 'ORDERCL.clle'), 'PGM\n', 'utf8');
+
+  const index = buildWorkspaceIndex(workspacePath, {
+    id: 'workspace-a',
+    name: 'Workspace A',
+    outputDir: 'output',
+    sourceDir: 'rpg_sources',
+  });
+
+  assert.equal(index.id, 'workspace-a');
+  assert.equal(index.programs.length, 1);
+  assert.equal(index.programs[0].name, 'ORDERPGM');
+  assert.equal(index.programs[0].workflowMode, 'documentation');
+  assert.equal(index.sourceMembers.QRPGLESRC, 2);
+  assert.equal(index.sourceMembers.QCLLESRC, 1);
+  assert.ok(index.reports.some((entry) => /architecture-report\.md$/i.test(entry.path)));
+});
+
+test('writeWorkspaceIndex persists workspace-index.json', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-workspace-index-write-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  fs.mkdirSync(path.join(workspacePath, 'output'), { recursive: true });
+
+  const result = writeWorkspaceIndex(workspacePath, {
+    id: 'workspace-b',
+    name: 'Workspace B',
+  });
+
+  assert.equal(path.basename(result.path), 'workspace-index.json');
+  assert.equal(fs.existsSync(result.path), true);
+  const saved = JSON.parse(fs.readFileSync(result.path, 'utf8'));
+  assert.equal(saved.id, 'workspace-b');
+});


### PR DESCRIPTION
## Summary
- add `zeus analyses` command family (`list/register/index/open/show/unregister`)
- introduce registry and workspace index services for multi-workspace analysis management
- extend local UI API with `/api/analyses*` endpoints
- support optional `--registry-path` in `serve` while keeping fallback compatibility
- add generic sensitive-term masking for JSON and UI/API outputs
- harden local commit safety with `.gitignore` entries for local analyses registry/workspaces

## Validation
- `node --test tests/secret-masking.test.js tests/analysis-registry-service.test.js tests/workspace-index-builder.test.js tests/doctor-command.test.js tests/local-ui-server.test.js`
- `node --test tests/table-name-resolution-service.test.js`
