### PR TITLE
Add local workspace policy and knowledge claim guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,7 @@ Die Tests decken unter anderem Scanner, Analyseverträge, Runtime-Konfiguration,
 - KI-Antworten immer gegen `canonical-analysis.json`, Reports und DB2-Metadaten prüfen.
 - MCP-Tools nur minimal allowlisten.
 - Audit-Dateien und generierte Artefakte als potenziell sensibel behandeln.
+- Lokale Arbeitsdaten unter `.local/`, `output/` oder `.zeus/` sind keine Knowledgebase. Sie können sensible Analyse-, Audit- oder Scratch-Daten enthalten. Siehe `docs/safety/local-workspace-policy.md`.
 - Für externe Weitergabe `--safe-sharing` nutzen.
 
 ---
@@ -1250,6 +1251,7 @@ The test suite covers scanners, analysis contracts, runtime configuration, profi
 - Validate AI answers against `canonical-analysis.json`, reports and DB2 metadata.
 - Allowlist only the minimum MCP tools required for the task.
 - Treat audit files and generated artifacts as potentially sensitive.
+- Local workspace data under `.local/`, `output/` or `.zeus/` is not a knowledgebase. It may contain sensitive analysis, audit or scratch data. See `docs/safety/local-workspace-policy.md`.
 - Use `--safe-sharing` for external review.
 
 ---

--- a/docs/safety/local-workspace-policy.md
+++ b/docs/safety/local-workspace-policy.md
@@ -1,0 +1,53 @@
+---
+Title: Local Workspace Policy
+Description: Rules for local workspace data, sensitive artifacts, and public-safe documentation boundaries.
+Last Updated: 2026-05-24
+---
+
+# Local Workspace Policy
+
+This policy is blunt on purpose: local workspace data is useful for operators, but it is not reusable toolkit knowledge.
+
+## Scope
+
+These locations are local-workshop surfaces and may be sensitive:
+
+- `.local/`
+- `output/`
+- `.zeus/`
+
+## What These Locations Are
+
+- `.local/` may contain operator notes, MCP audit traces, session notes, scratch files, and debugging output.
+- `output/` may contain generated analysis artifacts for review and troubleshooting.
+- `.zeus/` may contain local runtime/experimental data.
+
+## What These Locations Are Not
+
+- not a project-neutral knowledgebase
+- not a public fixture source by default
+- not a safe MCP/API knowledge source
+- not a source-code-generation input
+- not a replacement for `src/knowledge/final` contracts
+
+## Hard Rules
+
+- Treat `.local/`, `output/`, and `.zeus/` content as potentially sensitive unless proven synthetic.
+- Do not migrate local audit/session notes into `src/knowledge/final`.
+- Do not promote local DDDL/template artifacts into reusable toolkit knowledge.
+- Do not copy local examples into public docs/tests unless content is intentionally synthetic and reviewed.
+- Purge old knowledge-transfer notes, old `zeus.knowledge` traces, and old DDDL/template artifacts unless clearly synthetic and still needed.
+
+## DDDL Rule
+
+DDDL remains local raw interchange only. It is not a final-safe or reusable project-neutral knowledgebase.
+
+## MCP/API Rule
+
+Knowledge exposure via CLI/MCP/API stays disabled until a final project-neutral catalog has passed privacy validation.
+
+## Public Docs and Tests Rule
+
+- Public docs and tests must use synthetic examples only.
+- If a local artifact is useful, rewrite it as synthetic before promoting it to repository content.
+- Historical references to removed paths are acceptable only in dedicated reset/architecture documents, not as active behavior claims.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "doctor": "node ./cli/zeus.js doctor",
     "build": "echo \"No build step required for this CLI project\"",
     "lint": "echo \"No linter configured; skipping lint\"",
+    "check:public-knowledge-claims": "node scripts/check-public-knowledge-claims.js",
     "test": "npm run test:ci && npm run test:unit",
     "test:ci": "npm run test:contract && npm run test:smoke",
     "test:unit": "npm run test:corpus && node --test tests/analyze-stages.test.js tests/analyze-stage-registry.test.js tests/architecture-viewer.test.js tests/local-ui-server.test.js tests/source-scan-cache.test.js tests/analyze-runtime-contract.test.js tests/analyze-governance-config.test.js tests/binding-semantics.test.js tests/source-normalization.test.js tests/source-integrity.test.js tests/source-type-scanners.test.js tests/db2-catalog-intelligence.test.js tests/impact-ambiguity.test.js tests/investigation-workflows.test.js tests/runtime-config.test.js tests/runtime-config-boundary.test.js tests/source-catalog.test.js tests/profile-selection.test.js tests/secret-masking.test.js tests/ai-context-service.test.js tests/db2-config.test.js tests/query-service.test.js tests/write-sql-command.test.js tests/search-source-command.test.js tests/pui-edit-command.test.js tests/pui-dddl.test.js tests/pui-dddl-export-service.test.js tests/knowledge-safety-reset.test.js tests/knowledge-privacy-gate.test.js tests/zeus-api.test.js tests/joblog-command.test.js tests/table-name-resolution-service.test.js tests/mcp-server.test.js tests/mcp-stdio-transport.test.js",

--- a/scripts/check-public-knowledge-claims.js
+++ b/scripts/check-public-knowledge-claims.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+
+const ALLOWLISTED_DOCS = new Set([
+  normalizePath('docs/knowledgebase/project-neutral-knowledgebase-architecture.md'),
+  normalizePath('docs/knowledgebase/README.md'),
+  normalizePath('docs/safety/local-workspace-policy.md'),
+]);
+
+const HARD_BLOCKED_TERMS = [
+  '.zeus/knowledge',
+  'puiDddlKnowledgeBase',
+  'aiKnowledgePatternLibrary',
+  'knowledgeBaseService',
+  'puiPatternRegistry',
+  'puiPatternImport',
+  'build-pui-knowledgebase',
+  'build-pui-catalog',
+  'promote-pui-dddl-kb',
+  'DDDL knowledgebase',
+  'template knowledgebase',
+  'reusable DDDL templates',
+  'persistent PUI pattern catalog',
+  'local pattern registry',
+];
+
+const ZEUS_KNOWLEDGE_PATTERN = /\bzeus\.knowledge\b/i;
+const ZEUS_KNOWLEDGE_NEGATIVE_CONTEXT = /\b(not part|is not part|not available|disabled|removed|reset|no longer|nicht teil|ist nicht teil|nicht verfuegbar|nicht verfügbar|deaktiviert|entfernt|zurueckgesetzt|zurückgesetzt|nicht mehr)\b/i;
+
+function normalizePath(value) {
+  return String(value || '').replace(/\\/g, '/');
+}
+
+function listMarkdownFiles(dirPath, bucket = []) {
+  if (!fs.existsSync(dirPath)) {
+    return bucket;
+  }
+
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      listMarkdownFiles(fullPath, bucket);
+      continue;
+    }
+    if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+      bucket.push(fullPath);
+    }
+  }
+  return bucket;
+}
+
+function isPublicDoc(relativePath) {
+  const normalized = normalizePath(relativePath);
+  if (normalized === 'README.md') {
+    return true;
+  }
+  if (!normalized.startsWith('docs/')) {
+    return false;
+  }
+  if (normalized.startsWith('docs/internal/')) {
+    return false;
+  }
+  return true;
+}
+
+function shouldSkipFile(relativePath) {
+  const normalized = normalizePath(relativePath);
+  return ALLOWLISTED_DOCS.has(normalized);
+}
+
+function findTermIssues(lines, filePath) {
+  const issues = [];
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1;
+
+    HARD_BLOCKED_TERMS.forEach((term) => {
+      const termRegex = new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+      if (!termRegex.test(line)) {
+        return;
+      }
+      issues.push({
+        filePath,
+        lineNumber,
+        term,
+        line,
+        message: `legacy knowledge-path claim detected: "${term}"`,
+      });
+    });
+
+    if (ZEUS_KNOWLEDGE_PATTERN.test(line) && !ZEUS_KNOWLEDGE_NEGATIVE_CONTEXT.test(line)) {
+      issues.push({
+        filePath,
+        lineNumber,
+        term: 'zeus.knowledge',
+        line,
+        message: 'zeus.knowledge appears without explicit removed/disabled context',
+      });
+    }
+  });
+  return issues;
+}
+
+function collectTargetFiles() {
+  const files = [];
+  const readmePath = path.resolve(ROOT, 'README.md');
+  if (fs.existsSync(readmePath)) {
+    files.push(readmePath);
+  }
+
+  const docsRoot = path.resolve(ROOT, 'docs');
+  files.push(...listMarkdownFiles(docsRoot));
+
+  const unique = new Set(files.map((entry) => path.resolve(entry)));
+  return [...unique];
+}
+
+function main() {
+  const targets = collectTargetFiles();
+  const issues = [];
+
+  targets.forEach((absolutePath) => {
+    const relativePath = normalizePath(path.relative(ROOT, absolutePath));
+    if (!isPublicDoc(relativePath)) {
+      return;
+    }
+    if (shouldSkipFile(relativePath)) {
+      return;
+    }
+
+    const content = fs.readFileSync(absolutePath, 'utf8');
+    const lines = content.split(/\r?\n/);
+    issues.push(...findTermIssues(lines, relativePath));
+  });
+
+  if (issues.length > 0) {
+    console.error('Public knowledge-claims guard failed.');
+    console.error('The following public docs contain legacy/unsafe knowledgebase claims:');
+    issues.forEach((issue) => {
+      console.error(`- ${issue.filePath}:${issue.lineNumber} [${issue.term}] ${issue.message}`);
+    });
+    process.exit(1);
+  }
+
+  console.log('Public knowledge-claims guard passed.');
+}
+
+main();


### PR DESCRIPTION
## Summary

- documents how `.local/`, `output/` and `.zeus/` should be treated as local/sensitive/disposable workspace data
- clarifies that local workspace data is not reusable toolkit knowledge
- adds a lightweight guard against reintroducing obsolete knowledgebase claims in public docs
- keeps DDDL framed as raw local interchange only
- keeps MCP/API knowledge exposure disabled

## Tests

- `npm test`
- `npm run check:public-knowledge-claims`
- `node --test tests/knowledge-privacy-gate.test.js`
