### PR TITLE
Document internal knowledge lab boundary

### DIFF
--- a/docs/internal/knowledge-lab.md
+++ b/docs/internal/knowledge-lab.md
@@ -1,0 +1,64 @@
+---
+Title: Internal Knowledge Lab Boundary
+Description: Internal-only boundary for local knowledge-lab experiments and strict separation from product/runtime surfaces.
+Last Updated: 2026-05-25
+---
+
+# Internal Knowledge Lab Boundary
+
+This document defines a hard boundary:
+
+- local knowledge-lab experiments are allowed
+- product/runtime exposure is not
+
+Expected local lab workspace:
+
+```text
+.local/internal-tools/knowledge-lab/
+```
+
+This location is local-only and should remain ignored/disposable.
+
+## Core Rule
+
+Internal knowledge-lab tools may inspect raw project evidence locally, but they must never produce, expose, commit, or promote project-derived raw/intermediate data as reusable toolkit knowledge.
+
+Only privacy-passed final catalog objects may ever cross into public runtime surfaces.
+
+## Boundary Model
+
+```text
+.local/internal-tools/knowledge-lab/
+  = internal-only local workshop (raw evidence, classifier experiments, prompts, scratch output)
+
+src/knowledge/
+  = product boundary (contracts, privacy gates, final-safe catalog shapes, synthetic tests)
+```
+
+## Allowed vs Forbidden
+
+| Area | Allowed | Forbidden |
+|---|---|---|
+| Local experimentation | local classifier/prompts over raw evidence, local taxonomy/normalization experiments, disposable candidate generation | auto-promoting local output into runtime/public docs |
+| Synthetic data | create synthetic DDS/PUI/RPG examples for privacy-gate tests | commit real project-derived examples |
+| Pattern candidates | propose generic candidates like `ui.grid`, `ui.button`, `workflow.prompt-confirm-action` | persist real field/program/library/table names as toolkit knowledge |
+| Privacy hardening | improve rejection rules using synthetic cases | bypass privacy gate for runtime exposure |
+| Local AI usage | local prompt/classification assistance as suggestion source | treating local AI output as final knowledge |
+| Training/fine-tuning | synthetic-only experimentation | training/fine-tuning on real customer/project sources |
+| Commit behavior | commit policy/docs/tests that are synthetic and boundary-safe | commit raw evidence, raw prompts/responses from real sources, model artifacts from project data |
+| Runtime surfaces | keep CLI/MCP/API knowledge exposure disabled until privacy-passed final catalog exists | expose lab output in CLI, MCP, API, or analyze auto-load |
+
+## Additional Non-Negotiables
+
+- No migration from old `.zeus/knowledge` or legacy DDDL/template catalogs.
+- DDDL remains raw local interchange only, never reusable toolkit knowledge.
+- Sanitized candidates are still not automatically safe.
+- Public docs and tests must remain synthetic and reproducible.
+
+## Practical Checklist Before Any Promotion
+
+1. Data is synthetic or privacy-passed final catalog only.
+2. Schema validation passes (`src/knowledge/final` contract).
+3. Privacy gate passes (`src/knowledge/privacy`).
+4. No runtime auto-load path added in analyze.
+5. No MCP/API/CLI exposure added without explicit safety review.

--- a/docs/knowledgebase/README.md
+++ b/docs/knowledgebase/README.md
@@ -30,3 +30,12 @@ Local risk handling:
 - `.local` audit/session-note files that preserve removed knowledge paths are local risk artifacts and should be purged unless proven synthetic
 - raw exports outside `.zeus/knowledge` (for example old `output/pui-dddl/*`) must be treated as unsafe local evidence, not reusable knowledge
 - DDDL is local raw interchange only and must not be promoted to final project-neutral knowledge
+
+Internal knowledge-lab note:
+
+- internal lab tooling may exist locally under `.local/internal-tools/knowledge-lab/`
+- this lab is local-only and not a CLI/MCP/API product feature
+- raw/intermediate lab outputs are sensitive and disposable
+- lab outputs must not be treated as final project-neutral knowledge
+- only privacy-passed final catalog objects may cross into runtime surfaces
+- policy reference: `docs/internal/knowledge-lab.md`

--- a/docs/safety/local-workspace-policy.md
+++ b/docs/safety/local-workspace-policy.md
@@ -21,6 +21,7 @@ These locations are local-workshop surfaces and may be sensitive:
 - `.local/` may contain operator notes, MCP audit traces, session notes, scratch files, and debugging output.
 - `output/` may contain generated analysis artifacts for review and troubleshooting.
 - `.zeus/` may contain local runtime/experimental data.
+- `.local/internal-tools/knowledge-lab/` is an internal-only experiment space and not a product/runtime surface.
 
 ## What These Locations Are Not
 
@@ -35,6 +36,8 @@ These locations are local-workshop surfaces and may be sensitive:
 - Treat `.local/`, `output/`, and `.zeus/` content as potentially sensitive unless proven synthetic.
 - Do not migrate local audit/session notes into `src/knowledge/final`.
 - Do not promote local DDDL/template artifacts into reusable toolkit knowledge.
+- Do not treat local AI classifier/prompt output as final knowledge.
+- Do not train or fine-tune models on real customer/project source evidence.
 - Do not copy local examples into public docs/tests unless content is intentionally synthetic and reviewed.
 - Purge old knowledge-transfer notes, old `zeus.knowledge` traces, and old DDDL/template artifacts unless clearly synthetic and still needed.
 

--- a/scripts/check-public-knowledge-claims.js
+++ b/scripts/check-public-knowledge-claims.js
@@ -10,9 +10,10 @@ const ALLOWLISTED_DOCS = new Set([
   normalizePath('docs/knowledgebase/project-neutral-knowledgebase-architecture.md'),
   normalizePath('docs/knowledgebase/README.md'),
   normalizePath('docs/safety/local-workspace-policy.md'),
+  normalizePath('docs/internal/knowledge-lab.md'),
 ]);
 
-const HARD_BLOCKED_TERMS = [
+const DOC_BLOCKED_TERMS = [
   '.zeus/knowledge',
   'puiDddlKnowledgeBase',
   'aiKnowledgePatternLibrary',
@@ -27,6 +28,26 @@ const HARD_BLOCKED_TERMS = [
   'reusable DDDL templates',
   'persistent PUI pattern catalog',
   'local pattern registry',
+];
+
+const RUNTIME_BLOCKED_TERMS = [
+  'zeus.knowledge',
+  '.zeus/knowledge',
+  'DDDL knowledgebase',
+  'template knowledgebase',
+  'persistent PUI pattern catalog',
+  'local pattern registry',
+  'buildKnowledgebase',
+  'promoteKnowledge',
+  'trainFromSources',
+  'rawEvidenceExport',
+  'knowledge-lab',
+  'internal-knowledge-lab',
+  'local-ai-classifier',
+  'train-from-projects',
+  'train from sources',
+  'fine-tune on project sources',
+  'fine tune on project sources',
 ];
 
 const ZEUS_KNOWLEDGE_PATTERN = /\bzeus\.knowledge\b/i;
@@ -74,13 +95,17 @@ function shouldSkipFile(relativePath) {
   return ALLOWLISTED_DOCS.has(normalized);
 }
 
-function findTermIssues(lines, filePath) {
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function findDocIssues(lines, filePath) {
   const issues = [];
   lines.forEach((line, index) => {
     const lineNumber = index + 1;
 
-    HARD_BLOCKED_TERMS.forEach((term) => {
-      const termRegex = new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+    DOC_BLOCKED_TERMS.forEach((term) => {
+      const termRegex = new RegExp(escapeRegex(term), 'i');
       if (!termRegex.test(line)) {
         return;
       }
@@ -106,7 +131,27 @@ function findTermIssues(lines, filePath) {
   return issues;
 }
 
-function collectTargetFiles() {
+function findRuntimeIssues(lines, filePath) {
+  const issues = [];
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1;
+    RUNTIME_BLOCKED_TERMS.forEach((term) => {
+      const termRegex = new RegExp(escapeRegex(term), 'i');
+      if (!termRegex.test(line)) {
+        return;
+      }
+      issues.push({
+        filePath,
+        lineNumber,
+        term,
+        message: `runtime/public surface references blocked term: "${term}"`,
+      });
+    });
+  });
+  return issues;
+}
+
+function collectDocTargets() {
   const files = [];
   const readmePath = path.resolve(ROOT, 'README.md');
   if (fs.existsSync(readmePath)) {
@@ -120,11 +165,42 @@ function collectTargetFiles() {
   return [...unique];
 }
 
+function listFilesRecursive(rootDir, bucket = []) {
+  if (!fs.existsSync(rootDir)) {
+    return bucket;
+  }
+  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      listFilesRecursive(fullPath, bucket);
+      continue;
+    }
+    if (entry.isFile()) {
+      bucket.push(fullPath);
+    }
+  }
+  return bucket;
+}
+
+function collectRuntimeTargets() {
+  const roots = [
+    path.resolve(ROOT, 'src', 'mcp'),
+    path.resolve(ROOT, 'src', 'api'),
+    path.resolve(ROOT, 'cli'),
+  ];
+  const files = [];
+  roots.forEach((rootDir) => listFilesRecursive(rootDir, files));
+  const unique = new Set(files.map((entry) => path.resolve(entry)));
+  return [...unique];
+}
+
 function main() {
-  const targets = collectTargetFiles();
+  const docTargets = collectDocTargets();
+  const runtimeTargets = collectRuntimeTargets();
   const issues = [];
 
-  targets.forEach((absolutePath) => {
+  docTargets.forEach((absolutePath) => {
     const relativePath = normalizePath(path.relative(ROOT, absolutePath));
     if (!isPublicDoc(relativePath)) {
       return;
@@ -135,12 +211,19 @@ function main() {
 
     const content = fs.readFileSync(absolutePath, 'utf8');
     const lines = content.split(/\r?\n/);
-    issues.push(...findTermIssues(lines, relativePath));
+    issues.push(...findDocIssues(lines, relativePath));
+  });
+
+  runtimeTargets.forEach((absolutePath) => {
+    const relativePath = normalizePath(path.relative(ROOT, absolutePath));
+    const content = fs.readFileSync(absolutePath, 'utf8');
+    const lines = content.split(/\r?\n/);
+    issues.push(...findRuntimeIssues(lines, relativePath));
   });
 
   if (issues.length > 0) {
     console.error('Public knowledge-claims guard failed.');
-    console.error('The following public docs contain legacy/unsafe knowledgebase claims:');
+    console.error('The following files contain blocked legacy/internal knowledge exposure terms:');
     issues.forEach((issue) => {
       console.error(`- ${issue.filePath}:${issue.lineNumber} [${issue.term}] ${issue.message}`);
     });

--- a/tests/knowledge-lab-boundary.test.js
+++ b/tests/knowledge-lab-boundary.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const { spawnSync } = require('node:child_process');
+
+const { listMcpTools } = require('../src/mcp/mcpTools');
+const zeusApi = require('../src/api/zeusApi');
+
+test('mcp tool surface does not expose knowledge-lab or legacy knowledge tools', () => {
+  const tools = listMcpTools();
+  const names = tools.map((tool) => String(tool && tool.name ? tool.name : ''));
+
+  assert.equal(names.includes('zeus.knowledge'), false);
+  assert.equal(names.some((name) => /knowledge-lab|local-ai-classifier/i.test(name)), false);
+});
+
+test('zeus api exports no internal knowledge-lab runtime surface', () => {
+  const exportNames = Object.keys(zeusApi);
+  assert.equal(exportNames.some((name) => /knowledge-lab|local-ai-classifier/i.test(name)), false);
+});
+
+test('public knowledge-claims guard passes', () => {
+  const scriptPath = path.resolve(__dirname, '..', 'scripts', 'check-public-knowledge-claims.js');
+  const result = spawnSync(process.execPath, [scriptPath], {
+    cwd: path.resolve(__dirname, '..'),
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr || result.stdout || 'guard script failed');
+});


### PR DESCRIPTION
## Summary

- documents the internal-only knowledge lab boundary
- clarifies that local AI / extraction experiments are not product features
- keeps raw/intermediate lab outputs local, ignored and disposable
- prevents local lab output from becoming reusable toolkit knowledge
- updates public knowledge docs with the internal-lab safety boundary
- adds/updates a guard against accidental public exposure of removed or internal knowledge paths

## Safety

- no `.local`, `.zeus` or `output` data was migrated
- no real project-derived fixtures or examples were added
- no CLI/MCP/API knowledge exposure was added
- DDDL remains raw local interchange only
- final knowledge still requires privacy-gate validation

## Tests

- `npm test`
- `npm run check:public-knowledge-claims`
