### PR TITLE
Add safe Local UI action for analyzing existing workspaces

### DIFF
--- a/docs/viewer/local-ui-shell.md
+++ b/docs/viewer/local-ui-shell.md
@@ -1,12 +1,12 @@
 ---
 Title: Local UI Shell
 Description: Dokumentation zur lokalen Viewer- und UI-Shell fuer erzeugte Analyseartefakte.
-Last Updated: 2026-05-17
+Last Updated: 2026-06-02
 ---
 
 # Local UI Shell
 
-The local UI keeps the run explorer read-only while also exposing local-only Prompt Workbench actions such as preview generation, template persistence, and prompt-seed import. It still avoids introducing a separate parsing layer in the browser.
+The local UI keeps the run explorer mostly read-only while also exposing a small allowlisted local action surface: Doctor readiness checks, Analyze Workspace for existing local source trees, and Prompt Workbench actions such as preview generation, template persistence, and prompt-seed import. It still avoids introducing a separate parsing layer in the browser.
 
 ## Command
 
@@ -18,7 +18,8 @@ Behavior:
 
 - binds to loopback only (`127.0.0.1` by default)
 - serves a local HTML shell plus local-only JSON routes
-- reads existing analyze output directories; it does not run analysis itself
+- reads existing analyze output directories
+- can trigger allowlisted local analysis for an already configured workspace source root
 - reuses the current manifest and artifact contracts instead of introducing a parallel storage model
 
 ## API endpoints
@@ -26,6 +27,7 @@ Behavior:
 - `GET /api/health`
 - `GET /api/ui-metadata`
 - `POST /api/ui-actions/doctor`
+- `POST /api/ui-actions/analyze-existing-workspace`
 - `GET /api/runs`
 - `GET /api/runs/:program`
 - `GET /api/runs/:program/views`
@@ -83,14 +85,27 @@ The local UI action surface is intentionally explicit and small:
 Current supported action:
 
 - `doctor` readiness check via `POST /api/ui-actions/doctor`
+- `analyze-existing-workspace` via `POST /api/ui-actions/analyze-existing-workspace`
 
 Security behavior:
 
 - request and response format is JSON only
 - server-side validation blocks unsafe profile values
+- `analyze-existing-workspace` accepts only `profile`, `program`, `member`, and `safeSharing`
+- browser payloads do not provide `sourceRoot`; the action always uses the selected profile's configured local source root
+- browser payloads cannot provide arbitrary shell commands, absolute paths, or traversal-style filesystem input
 - responses keep diagnostics structured and do not expose resolved secret values or raw env values
 - runtime guardrail conflicts between profile DB targets and env overrides are surfaced as warnings, not automatic aborts
 - conflict diagnostics remain allowlisted and redacted; the UI never exposes passwords or full credential-bearing JDBC URLs
+
+Analyze Workspace behavior:
+
+- runs the existing local `analyze` core against an already available local workspace/source root
+- does not fetch remote sources
+- does not connect to IBM i, DB2, SFTP, or other remote systems
+- returns structured status values such as `completed`, `warning`, and `failed`
+- can link back to the generated run summary and `report.md` when that artifact exists
+- keeps raw action details collapsed in the browser by default
 
 ## Doctor readiness diagnostics
 
@@ -115,4 +130,4 @@ Example meaning:
 - environment override: `ZEUS_DB_HOST`
 - effective target: `secondary-system`
 
-The Local UI still does not execute arbitrary browser commands. It only invokes the allowlisted `doctor` readiness action and renders the resulting diagnostics as escaped text.
+The Local UI still does not execute arbitrary browser commands. It only invokes the allowlisted `doctor` and `analyze-existing-workspace` actions and renders the resulting diagnostics as escaped text.

--- a/src/ui/localUiActionService.js
+++ b/src/ui/localUiActionService.js
@@ -11,15 +11,26 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 */
+const path = require('path');
 const { runDoctorChecks } = require('../cli/commands/doctorCommand');
+const { executeAnalyze } = require('../core/analyzeService');
+const { resolveAnalyzeConfig } = require('../config/runtimeConfig');
+const { ANALYZE_RUN_MANIFEST_FILE } = require('../analyze/analyzeRunManifest');
 const {
   buildEnvProfileConflictMessage,
   summarizeTargetValue,
 } = require('../cli/helpers/runtimeConfigWarnings');
 
 const ALLOWED_DOCTOR_KEYS = new Set(['profile', 'showResolved']);
+const ALLOWED_ANALYZE_WORKSPACE_KEYS = new Set(['profile', 'program', 'member', 'safeSharing']);
 const PROFILE_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+const OBJECT_NAME_PATTERN = /^[A-Za-z0-9_]{1,64}$/;
 const SECRET_LIKE_PATTERN = /(PASS|PASSWORD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|CREDENTIAL|PWD)/i;
+const KNOWN_ANALYZE_FAILURE_CODES = new Set([
+  'PROGRAM_REQUIRED',
+  'SOURCE_REQUIRED',
+  'SOURCE_ROOT_MISSING',
+]);
 
 class UiActionError extends Error {
   constructor(message, statusCode = 400) {
@@ -47,6 +58,17 @@ function validateProfileName(profileName) {
   return value;
 }
 
+function validateObjectName(value, fieldName) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (!OBJECT_NAME_PATTERN.test(trimmed)) {
+    throw new UiActionError(`Invalid payload: ${fieldName} contains unsupported characters`, 400);
+  }
+  return trimmed.toUpperCase();
+}
+
 function normalizeDoctorPayload(rawPayload) {
   if (!isPlainObject(rawPayload)) {
     throw new UiActionError('Invalid payload: expected JSON object', 400);
@@ -62,6 +84,31 @@ function normalizeDoctorPayload(rawPayload) {
   return {
     profile,
     showResolved,
+  };
+}
+
+function normalizeAnalyzeExistingWorkspacePayload(rawPayload) {
+  if (!isPlainObject(rawPayload)) {
+    throw new UiActionError('Invalid payload: expected JSON object', 400);
+  }
+
+  const unknownKeys = Object.keys(rawPayload).filter((key) => !ALLOWED_ANALYZE_WORKSPACE_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    throw new UiActionError(`Invalid payload: unsupported key(s): ${unknownKeys.join(', ')}`, 400);
+  }
+
+  const profile = validateProfileName(rawPayload.profile);
+  const program = validateObjectName(rawPayload.program, 'program');
+  const member = validateObjectName(rawPayload.member, 'member');
+  if (!program && !member) {
+    throw new UiActionError('Invalid payload: program or member is required', 400);
+  }
+
+  return {
+    profile,
+    program: program || null,
+    member: member || null,
+    safeSharing: rawPayload.safeSharing === undefined ? true : Boolean(rawPayload.safeSharing),
   };
 }
 
@@ -161,10 +208,124 @@ function defaultDoctorExecutor(args, runtime) {
   return runDoctorChecks(args, runtime);
 }
 
+function defaultAnalyzeExecutor(args, runtime) {
+  return executeAnalyze(args, runtime);
+}
+
+function defaultAnalyzeConfigResolver(args, runtime) {
+  return resolveAnalyzeConfig(args, runtime);
+}
+
+function sanitizeWorkspacePathForUi(value, cwd) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (!path.isAbsolute(trimmed)) {
+    return trimmed.replace(/\\/g, '/');
+  }
+
+  const relative = path.relative(cwd, trimmed);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return '(configured outside project root)';
+  }
+
+  const normalized = relative.split(path.sep).join('/');
+  return normalized.startsWith('.') ? normalized : `./${normalized}`;
+}
+
+function isExpectedAnalyzeFailure(error) {
+  const code = String(error && error.code || '').trim().toUpperCase();
+  if (KNOWN_ANALYZE_FAILURE_CODES.has(code)) {
+    return true;
+  }
+
+  const message = String(error && error.message || '');
+  return /failed to load profiles|profile ".*" not found|missing required option|source directory not found|member ".*" not found|ambiguous/i.test(message);
+}
+
+function summarizeAnalyzeFailure(error) {
+  const code = String(error && error.code || '').trim().toUpperCase();
+  const message = String(error && error.message || '').trim();
+  if (/source directory not found/i.test(message)) {
+    return 'The selected profile source root was not found locally.';
+  }
+  if (code === 'PROGRAM_REQUIRED') {
+    return 'The selected profile requires a program name or a member that resolves to a program.';
+  }
+  if (code === 'SOURCE_REQUIRED' || code === 'SOURCE_ROOT_MISSING') {
+    return 'The selected profile does not resolve to a usable local source root for analysis.';
+  }
+  if (/member ".*" not found/i.test(message)) {
+    return message.replace(/ under .*/i, ' under the configured local source root.');
+  }
+  if (/ambiguous/i.test(message)) {
+    return message.replace(/ under .*/i, '.');
+  }
+  if (/failed to load profiles/i.test(message) || /profile ".*" not found/i.test(message)) {
+    return message;
+  }
+  return 'Analyze Workspace failed for the selected input.';
+}
+
+function summarizeAnalyzeDiagnostics(manifest) {
+  const summary = manifest && manifest.summary && typeof manifest.summary === 'object'
+    ? manifest.summary
+    : {};
+  const warningCount = Number(summary.warningCount || 0);
+  const errorCount = Number(summary.errorCount || 0);
+  if (warningCount <= 0 && errorCount <= 0) {
+    return [];
+  }
+
+  return [{
+    code: errorCount > 0 ? 'ANALYZE_ERRORS' : 'ANALYZE_WARNINGS',
+    severity: errorCount > 0 ? 'ERROR' : 'WARN',
+    message: errorCount > 0
+      ? `Analysis completed with ${errorCount} error(s) and ${warningCount} warning(s).`
+      : `Analysis completed with ${warningCount} warning(s).`,
+    errorCount,
+    warningCount,
+  }];
+}
+
+function buildAnalyzeWorkspaceOutput(program, manifest) {
+  const artifacts = Array.isArray(manifest && manifest.artifacts) ? manifest.artifacts : [];
+  const reportArtifact = artifacts.find((artifact) => artifact && artifact.path === 'report.md');
+  const manifestPath = `${program}/${ANALYZE_RUN_MANIFEST_FILE}`;
+  const reportArtifactPath = reportArtifact ? `${program}/report.md` : null;
+
+  return {
+    runId: program,
+    program,
+    manifestPath,
+    runApiPath: `/api/runs/${encodeURIComponent(program)}`,
+    viewsApiPath: `/api/runs/${encodeURIComponent(program)}/views`,
+    reportArtifactPath,
+    reportUrl: reportArtifact
+      ? `/runs/${encodeURIComponent(program)}/artifacts/raw?path=${encodeURIComponent('report.md')}`
+      : null,
+  };
+}
+
+function buildAnalyzeWorkspaceContext(payload, config, cwd) {
+  const safeSourceRoot = sanitizeWorkspacePathForUi(config && config.sourceRoot, cwd);
+  const safeOutputRoot = sanitizeWorkspacePathForUi(config && config.outputRoot, cwd);
+  return {
+    profile: payload.profile,
+    sourceRoot: safeSourceRoot,
+    outputRoot: safeOutputRoot,
+    sourceRootOrigin: 'profile',
+  };
+}
+
 function createLocalUiActionService({
   cwd = process.cwd(),
   env = process.env,
   doctorExecutor = defaultDoctorExecutor,
+  analyzeExecutor = defaultAnalyzeExecutor,
+  analyzeConfigResolver = defaultAnalyzeConfigResolver,
 } = {}) {
   async function runDoctorAction(rawPayload) {
     const startedAt = new Date();
@@ -209,6 +370,117 @@ function createLocalUiActionService({
     };
   }
 
+  async function runAnalyzeExistingWorkspaceAction(rawPayload) {
+    const startedAt = new Date();
+    const payload = normalizeAnalyzeExistingWorkspacePayload(rawPayload || {});
+    const analyzeArgs = {
+      profile: payload.profile,
+      program: payload.program || undefined,
+      member: payload.member || undefined,
+      'safe-sharing': payload.safeSharing,
+    };
+
+    let analyzeConfig = null;
+    try {
+      analyzeConfig = analyzeConfigResolver({ profile: payload.profile }, { cwd, env });
+    } catch (error) {
+      if (!isExpectedAnalyzeFailure(error)) {
+        throw error;
+      }
+      const finishedAt = new Date();
+      return {
+        action: 'analyze-existing-workspace',
+        status: 'failed',
+        startedAt: startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        durationMs: finishedAt.getTime() - startedAt.getTime(),
+        input: payload,
+        workspace: buildAnalyzeWorkspaceContext(payload, null, cwd),
+        diagnostics: [{
+          code: 'ANALYZE_FAILED',
+          severity: 'ERROR',
+          message: summarizeAnalyzeFailure(error),
+        }],
+        result: {
+          code: String(error.code || '').trim() || 'ANALYZE_FAILED',
+          message: summarizeAnalyzeFailure(error),
+        },
+        notes: ['Analyze Workspace uses the configured local profile source root and does not accept browser-provided filesystem paths.'],
+      };
+    }
+
+    try {
+      const execution = await Promise.resolve(analyzeExecutor(analyzeArgs, { cwd, env }));
+      const manifest = execution && execution.analyzeManifest ? execution.analyzeManifest : null;
+      const diagnostics = summarizeAnalyzeDiagnostics(manifest);
+      const finishedAt = new Date();
+      const status = diagnostics.some((entry) => String(entry.severity || '').toUpperCase() === 'ERROR')
+        ? 'failed'
+        : diagnostics.length > 0
+          ? 'warning'
+          : 'completed';
+
+      return {
+        action: 'analyze-existing-workspace',
+        status,
+        startedAt: startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        durationMs: finishedAt.getTime() - startedAt.getTime(),
+        input: payload,
+        workspace: buildAnalyzeWorkspaceContext(payload, analyzeConfig, cwd),
+        diagnostics,
+        output: buildAnalyzeWorkspaceOutput(execution.program, manifest),
+        result: {
+          program: execution.program,
+          member: payload.member,
+          summary: manifest && manifest.summary ? {
+            stageCount: Number(manifest.summary.stageCount || 0),
+            diagnosticCount: Number(manifest.summary.diagnosticCount || 0),
+            warningCount: Number(manifest.summary.warningCount || 0),
+            errorCount: Number(manifest.summary.errorCount || 0),
+            generatedArtifactCount: Number(manifest.summary.generatedArtifactCount || 0),
+            sourceFileCount: Number(manifest.summary.sourceFileCount || 0),
+          } : null,
+          manifestStatus: manifest && manifest.run ? manifest.run.status || null : null,
+        },
+        notes: [
+          'Analyze Workspace reuses the existing local analyze pipeline and does not fetch remote sources.',
+          payload.safeSharing ? 'Safe-sharing artifacts were generated for this run.' : null,
+          payload.member && !payload.program ? 'Program resolution was derived from the selected member within the configured source root.' : null,
+        ].filter(Boolean),
+      };
+    } catch (error) {
+      if (!isExpectedAnalyzeFailure(error)) {
+        throw error;
+      }
+      const finishedAt = new Date();
+      return {
+        action: 'analyze-existing-workspace',
+        status: 'failed',
+        startedAt: startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        durationMs: finishedAt.getTime() - startedAt.getTime(),
+        input: payload,
+        workspace: buildAnalyzeWorkspaceContext(payload, analyzeConfig, cwd),
+        diagnostics: [{
+          code: 'ANALYZE_FAILED',
+          severity: 'ERROR',
+          message: summarizeAnalyzeFailure(error),
+        }],
+        result: {
+          code: String(error.code || '').trim() || 'ANALYZE_FAILED',
+          message: summarizeAnalyzeFailure(error),
+          manifestStatus: error && error.analyzeManifest && error.analyzeManifest.run
+            ? error.analyzeManifest.run.status || null
+            : null,
+        },
+        notes: [
+          'Analyze Workspace uses the configured local profile source root and does not accept browser-provided filesystem paths.',
+        ],
+      };
+    }
+  }
+
   async function executeAction(actionName, payload) {
     const normalizedAction = String(actionName || '').trim().toLowerCase();
     if (!normalizedAction) {
@@ -218,21 +490,28 @@ function createLocalUiActionService({
     if (normalizedAction === 'doctor') {
       return runDoctorAction(payload);
     }
+    if (normalizedAction === 'analyze-existing-workspace') {
+      return runAnalyzeExistingWorkspaceAction(payload);
+    }
 
     throw new UiActionError(`Unknown action: ${normalizedAction}`, 404);
   }
 
   return {
     executeAction,
+    normalizeAnalyzeExistingWorkspacePayload,
     normalizeDoctorPayload,
     validateProfileName,
+    validateObjectName,
   };
 }
 
 module.exports = {
   UiActionError,
   createLocalUiActionService,
+  normalizeAnalyzeExistingWorkspacePayload,
   normalizeDoctorPayload,
   normalizeDoctorDiagnostics,
   validateProfileName,
+  validateObjectName,
 };

--- a/src/ui/localUiServer.js
+++ b/src/ui/localUiServer.js
@@ -559,6 +559,8 @@ async function startLocalUiServer({
     cwd: actionServiceOptions.cwd || process.cwd(),
     env: actionServiceOptions.env || process.env,
     doctorExecutor: actionServiceOptions.doctorExecutor,
+    analyzeExecutor: actionServiceOptions.analyzeExecutor,
+    analyzeConfigResolver: actionServiceOptions.analyzeConfigResolver,
   });
   const resolvedSensitiveTerms = collectSensitiveTermsFromEnv(process.env, sensitiveTerms);
   const server = http.createServer(createLocalUiRequestHandler({

--- a/src/ui/localUiShell.js
+++ b/src/ui/localUiShell.js
@@ -533,7 +533,7 @@ input[type="search"]{
 
 <script>
 const s={
-  runs:[],detail:null,program:null,tab:'home',artifact:null,node:null,table:null,left:null,right:null,cache:new Map(),
+  runs:[],detail:null,program:null,tab:'home',homePanel:'guide',artifact:null,node:null,table:null,left:null,right:null,cache:new Map(),
   uiMetadata:{
     loading:false,
     error:null,
@@ -543,6 +543,15 @@ const s={
   uiActions:{
     doctor:{
       profile:'dev',
+      running:false,
+      error:null,
+      result:null
+    },
+    analyze:{
+      profile:'dev',
+      program:'',
+      member:'',
+      safeSharing:true,
       running:false,
       error:null,
       result:null
@@ -726,7 +735,7 @@ function fallbackWorkflowCards(){
   return [
     { id:'configure', title:'Configure', description:'Review profile and environment metadata.', badge:'configure', status:'Not checked yet', primaryActionLabel:'Open Configure', recommendedNext:'doctor' },
     { id:'fetch-sources', title:'Fetch Sources', description:'Prepare source evidence from IBM i.', badge:'fetch', status:'Not checked yet', primaryActionLabel:'Prepare Fetch', recommendedNext:'copy-to-workspace' },
-    { id:'analyze-workspace', title:'Analyze Workspace', description:'Run analysis and generate artifacts.', badge:'analyze', status:'Not checked yet', primaryActionLabel:'Review Analyze', recommendedNext:'serve' },
+    { id:'analyze-workspace', title:'Analyze Workspace', description:'Run analysis and generate artifacts.', badge:'analyze', status:'Not checked yet', primaryActionLabel:'Analyze Workspace', recommendedNext:'serve' },
     { id:'query-db2', title:'Query DB2', description:'Run read-only DB2 query workflows.', badge:'query', status:'Not checked yet', primaryActionLabel:'Review Queries', recommendedNext:'query-table' },
     { id:'review-reports', title:'Review Reports', description:'Inspect report and artifact output.', badge:'review', status:'Not checked yet', primaryActionLabel:'Open Artifacts', recommendedNext:'bundle' },
     { id:'generate-ai-context', title:'Generate AI Context', description:'Bundle and refine AI context artifacts.', badge:'context', status:'Not checked yet', primaryActionLabel:'Open Workbench', recommendedNext:'bundle' }
@@ -759,7 +768,7 @@ function defaultConfigSection(){
 function cardToHomeTarget(cardId){
   if(cardId==='configure') return 'configure';
   if(cardId==='fetch-sources') return 'configure';
-  if(cardId==='analyze-workspace') return 'refresh';
+  if(cardId==='analyze-workspace') return 'analyze-workspace';
   if(cardId==='query-db2') return 'db2';
   if(cardId==='review-reports') return 'artifacts';
   if(cardId==='generate-ai-context') return 'workbench';
@@ -800,6 +809,29 @@ async function runDoctorReadinessAction(){
   }
 }
 
+async function runAnalyzeExistingWorkspaceAction(){
+  const profile=String(s.uiActions.analyze.profile||'dev').trim()||'dev';
+  const program=String(s.uiActions.analyze.program||'').trim();
+  const member=String(s.uiActions.analyze.member||'').trim();
+  s.uiActions.analyze.running=true;
+  s.uiActions.analyze.error=null;
+  try{
+    const payload={profile,safeSharing:s.uiActions.analyze.safeSharing!==false};
+    if(program) payload.program=program;
+    if(member) payload.member=member;
+    const result=await sendJson('POST','/api/ui-actions/analyze-existing-workspace',payload);
+    s.uiActions.analyze.result=result;
+    if(result&&result.output&&result.output.program&&(result.status==='completed'||result.status==='warning')){
+      await refreshRuns(result.output.program);
+    }
+  }catch(error){
+    s.uiActions.analyze.error=error.message||String(error);
+    s.uiActions.analyze.result=null;
+  }finally{
+    s.uiActions.analyze.running=false;
+  }
+}
+
 function normalizeDoctorDiagnostics(result){
   const diagnostics=result&&Array.isArray(result.diagnostics)?result.diagnostics:[];
   return diagnostics.filter((entry)=>entry&&typeof entry==='object');
@@ -827,8 +859,73 @@ function renderDoctorDiagnostics(result){
   if(errorCount>0) summaryParts.push('error '+String(errorCount));
   return '<div class="hint-list"><div class="hint-item"><strong>'+esc(heading)+'</strong><p>'+(warningCount>0?'These warnings explain why the selected profile and the active environment may point to different DB targets.':'Doctor returned structured diagnostics for review.')+'</p>'+(summaryParts.length?'<p class="small">'+esc(summaryParts.join(' • '))+'</p>':'')+'</div>'+diagnostics.map((entry)=>renderDoctorDiagnosticEntry(entry)).join('')+'</div>';
 }
-async function refreshRuns(){
-  const currentProgram=s.program;
+
+function normalizeAnalyzeActionDiagnostics(result){
+  const diagnostics=result&&Array.isArray(result.diagnostics)?result.diagnostics:[];
+  return diagnostics.filter((entry)=>entry&&typeof entry==='object');
+}
+
+function isSafeLocalUiReportUrl(value){
+  const normalized=String(value||'').trim();
+  return normalized.startsWith('/runs/')
+    && normalized.includes('/artifacts/raw?path=')
+    && !/[<>"'\\s]/.test(normalized);
+}
+
+function renderAnalyzeActionDiagnostics(result){
+  const diagnostics=normalizeAnalyzeActionDiagnostics(result);
+  if(!diagnostics.length) return '';
+  return '<div class="hint-list">'+diagnostics.map((entry)=>{
+    const severity=String(entry.severity||'').trim().toUpperCase()||'INFO';
+    return '<div class="hint-item"><strong>'+esc(String(entry.code||'ANALYZE_DIAGNOSTIC'))+'</strong><div class="tokens"><div class="token '+esc(statusToneClass(severity))+'">'+esc(severity)+'</div></div><p>'+(entry.message?esc(String(entry.message)):'No additional details.')+'</p></div>';
+  }).join('')+'</div>';
+}
+
+function renderAnalyzeWorkspacePanel(){
+  const analyzeState=s.uiActions.analyze||{};
+  const analyzeResult=analyzeState.result;
+  const analyzeSummary=analyzeResult&&analyzeResult.result&&analyzeResult.result.summary;
+  const analyzeStatus=analyzeResult&&analyzeResult.status
+    ? String(analyzeResult.status)
+    : (analyzeState.running?'running':analyzeState.error?'error':'not-run');
+  const analyzeTone=statusToneClass(analyzeStatus);
+  const analyzeStatusLabel=analyzeState.running
+    ? 'running'
+    : (analyzeState.error?'error':(analyzeResult&&analyzeResult.status?analyzeResult.status:'not-run'));
+  const analyzeHint=analyzeState.error
+    ? analyzeState.error
+    : (analyzeResult
+      ? ('last run: '+String(fmt(analyzeResult.finishedAt||analyzeResult.startedAt||'')))
+      : 'Uses the selected profile source root. Browser-provided filesystem paths are not accepted.');
+  const workspace=analyzeResult&&analyzeResult.workspace?analyzeResult.workspace:null;
+  const sourceRoot=workspace&&workspace.sourceRoot?String(workspace.sourceRoot):'profile-defined';
+  const outputRoot=workspace&&workspace.outputRoot?String(workspace.outputRoot):'profile-defined';
+  const safeReportUrl=analyzeResult&&analyzeResult.output&&isSafeLocalUiReportUrl(analyzeResult.output.reportUrl)
+    ? String(analyzeResult.output.reportUrl)
+    : '';
+  const rawResult=analyzeResult
+    ? JSON.stringify({
+      output:analyzeResult.output||null,
+      result:analyzeResult.result||null,
+      diagnostics:analyzeResult.diagnostics||[],
+      notes:analyzeResult.notes||[],
+    },null,2)
+    : '';
+
+  return '<div class="sub"><h2>Analyze Workspace</h2><p>Run the existing local analyze pipeline against the selected profile workspace. This action stays local-only: no remote fetch, no DB2 query execution, and no browser-provided commands.</p><div class="tokens"><div class="token '+esc(analyzeTone)+'">Analyze: '+esc(analyzeStatusLabel)+'</div><div class="token">source root: '+esc(sourceRoot)+'</div><div class="token">output: '+esc(outputRoot)+'</div>'+(analyzeResult?'<div class="token">duration: '+esc(String(analyzeResult.durationMs||0))+' ms</div>':'')+'</div><div class="field-grid"><label>Profile Name<input id="analyzeProfile" value="'+escAttr(analyzeState.profile||'dev')+'" placeholder="dev"></label><label>Program Name<input id="analyzeProgram" value="'+escAttr(analyzeState.program||'')+'" placeholder="ORDERPGM"></label><label>Member Name<input id="analyzeMember" value="'+escAttr(analyzeState.member||'')+'" placeholder="ORDERPGM"></label></div><div class="actions"><button class="btn primary" data-analyze-run="1">'+esc(analyzeState.running?'Analyzing...':'Analyze Workspace')+'</button><button class="btn" data-analyze-toggle-safe-sharing="1">Safe Sharing: '+esc(analyzeState.safeSharing===false?'off':'on')+'</button><button class="btn" data-home-target="guide">Back To Guidance</button></div><div class="hint-list"><div class="hint-item"><strong>Input rules</strong><p>Provide a safe profile name plus either a program or a member. The source root comes from the selected profile.</p><p class="small">'+esc(analyzeHint)+'</p></div>'+(analyzeResult&&analyzeResult.notes&&analyzeResult.notes.length?'<div class="hint-item"><strong>Notes</strong><p>'+esc(analyzeResult.notes.join(' '))+'</p></div>':'')+'</div>'+
+    (analyzeSummary?'<div class="hint-list"><div class="hint-item"><strong>Summary</strong><p>stages '+esc(String(analyzeSummary.stageCount||0))+' • source files '+esc(String(analyzeSummary.sourceFileCount||0))+' • artifacts '+esc(String(analyzeSummary.generatedArtifactCount||0))+' • warnings '+esc(String(analyzeSummary.warningCount||0))+' • errors '+esc(String(analyzeSummary.errorCount||0))+'</p></div></div>':'')+
+    renderAnalyzeActionDiagnostics(analyzeResult)+
+    ((safeReportUrl||(analyzeResult&&analyzeResult.output&&analyzeResult.output.program))?'<div class="actions">'+(safeReportUrl?'<a class="btn" href="'+escAttr(safeReportUrl)+'" target="_blank" rel="noopener noreferrer">Open analysis report</a>':'')+((analyzeResult&&analyzeResult.output&&analyzeResult.output.program)?'<button class="btn" data-analyze-open-artifacts="'+esc(String(analyzeResult.output.program))+'">Open In Artifacts</button>':'')+'</div>':'')+
+    (rawResult?'<details><summary>Show raw result</summary><div class="preview"><pre>'+esc(rawResult)+'</pre></div></details>':'')+
+    '</div>';
+}
+
+function renderHomeGuidePanel(){
+  return '<div class="sub"><h2>Workflow Guidance</h2><p>Only allowlisted local UI actions are executable here. Configure and Analyze Workspace are wired into the shell; fetch, DB2, and arbitrary commands remain outside the browser.</p><div class="hint-list"><div class="hint-item"><strong>Recommended sequence</strong><p>Configure -> doctor -> analyze -> review -> bundle/context.</p></div><div class="hint-item"><strong>Analyze starter</strong><p>Use the Analyze Workspace card to run the local analyzer against the selected profile source root.</p></div><div class="hint-item"><strong>Workflow starter</strong><p>Prompt Workbench remains available immediately, even before your first analysis run is generated.</p></div></div><h3>Prompt Workbench Choices</h3>'+promptWorkbenchHighlights()+'</div>';
+}
+
+async function refreshRuns(preferredProgram){
+  const currentProgram=preferredProgram||s.program;
   s.runs=await getJson('/api/runs');
   renderRuns();
 
@@ -857,6 +954,20 @@ async function openHomeTarget(target,options){
   const opts=options||{};
   if(target==='refresh'){
     await refreshRuns();
+    return;
+  }
+
+  if(target==='guide'){
+    s.tab='home';
+    s.homePanel='guide';
+    await render();
+    return;
+  }
+
+  if(target==='analyze-workspace'){
+    s.tab='home';
+    s.homePanel='analyze-workspace';
+    await render();
     return;
   }
 
@@ -941,21 +1052,73 @@ function renderHome(){
   const summary=hasRun?s.detail.summary:null;
   const nextHint=summary
     ? 'Selected run: '+summary.program+' ('+String(summary.workflowPreset||summary.workflowMode||'standard')+').'
-    : 'No run selected yet. Start with Configure, then run doctor/fetch/analyze from CLI.';
+    : 'No run selected yet. Start with Configure, then use Analyze Workspace or refresh existing runs.';
 
   root.innerHTML='<div class="sub"><div class="home-callout"><h2>Workflow Shell</h2><p>A calmer entry point: pick one workflow card, then move to the next recommended step.</p><div class="tokens"><div class="token">Cards: '+esc(String(cards.length))+'</div><div class="token">Metadata: '+esc(s.uiMetadata.error?'degraded fallback':'live API')+'</div><div class="token">'+esc(nextHint)+'</div></div></div><h3>Workflow Cards</h3>'+
     (s.uiMetadata.loading
       ? '<div class="empty">Loading UI metadata...</div>'
       : '<div class="workflow-grid">'+cards.map((card)=>'<div class="workflow-card"><h4>'+esc(card.title)+'</h4><p>'+esc(card.description||'')+'</p><div class="workflow-meta"><div class="token">'+esc(card.badge||card.category||'workflow')+'</div><div class="token">'+esc(card.status||'Not checked yet')+'</div><div class="token">Commands: '+esc(String(card.commandCount||0))+'</div></div><p><strong>Next:</strong> '+esc(card.recommendedNext||'TBD')+'</p><div class="actions"><button class="btn primary" data-home-target="'+esc(cardToHomeTarget(card.id))+'">'+esc(card.primaryActionLabel||'Open')+'</button></div></div>').join('')+'</div>'
     )+
-    '<div class="actions"><button class="btn" data-home-target="configure">Open Configure</button><button class="btn" data-home-target="refresh">Refresh Runs</button><button class="btn" data-home-target="workbench">Open Prompt Workbench</button></div></div>'+
-    '<div class="sub"><h2>Command Guidance</h2><p>The shell remains read-only for configuration values. Use CLI commands for execution until explicit safe execution wiring is added.</p><div class="hint-list"><div class="hint-item"><strong>Recommended sequence</strong><p>Configure -> doctor -> fetch -> analyze -> review -> bundle/context.</p></div><div class="hint-item"><strong>Analyze starter</strong><p>Run <code>zeus analyze --source ./src --program ORDERPGM --out ./output</code>, then click Refresh Runs.</p></div><div class="hint-item"><strong>Workflow starter</strong><p>Run <code>zeus workflow --preset modernization-review --source ./src --program ORDERPGM --out ./output</code> for richer prompt packs.</p></div></div><h3>Prompt Workbench Choices</h3>'+promptWorkbenchHighlights()+'</div>';
+    '<div class="actions"><button class="btn" data-home-target="configure">Open Configure</button><button class="btn" data-home-target="analyze-workspace">Open Analyze Workspace</button><button class="btn" data-home-target="refresh">Refresh Runs</button><button class="btn" data-home-target="workbench">Open Prompt Workbench</button></div></div>'+
+    (s.homePanel==='analyze-workspace'?renderAnalyzeWorkspacePanel():renderHomeGuidePanel());
 
   for(const b of root.querySelectorAll('[data-home-target]')){
     b.onclick=()=>openHomeTarget(b.dataset.homeTarget);
   }
   for(const b of root.querySelectorAll('[data-home-workbench]')){
     b.onclick=()=>openHomeTarget('workbench',{useCaseId:b.dataset.homeWorkbench});
+  }
+  const analyzeProfileInput=root.querySelector('#analyzeProfile');
+  if(analyzeProfileInput){
+    analyzeProfileInput.oninput=(event)=>{
+      s.uiActions.analyze.profile=String(event.target.value||'').trim();
+    };
+  }
+  const analyzeProgramInput=root.querySelector('#analyzeProgram');
+  if(analyzeProgramInput){
+    analyzeProgramInput.oninput=(event)=>{
+      s.uiActions.analyze.program=String(event.target.value||'').trim();
+    };
+  }
+  const analyzeMemberInput=root.querySelector('#analyzeMember');
+  if(analyzeMemberInput){
+    analyzeMemberInput.oninput=(event)=>{
+      s.uiActions.analyze.member=String(event.target.value||'').trim();
+    };
+  }
+  const analyzeRunButton=root.querySelector('[data-analyze-run]');
+  if(analyzeRunButton){
+    analyzeRunButton.onclick=async ()=>{
+      const profileInput=q('analyzeProfile');
+      const programInput=q('analyzeProgram');
+      const memberInput=q('analyzeMember');
+      if(profileInput){
+        s.uiActions.analyze.profile=String(profileInput.value||'').trim()||'dev';
+      }
+      if(programInput){
+        s.uiActions.analyze.program=String(programInput.value||'').trim();
+      }
+      if(memberInput){
+        s.uiActions.analyze.member=String(memberInput.value||'').trim();
+      }
+      renderHome();
+      await runAnalyzeExistingWorkspaceAction();
+      renderHome();
+    };
+  }
+  const analyzeToggleButton=root.querySelector('[data-analyze-toggle-safe-sharing]');
+  if(analyzeToggleButton){
+    analyzeToggleButton.onclick=()=>{
+      s.uiActions.analyze.safeSharing=s.uiActions.analyze.safeSharing===false;
+      renderHome();
+    };
+  }
+  for(const b of root.querySelectorAll('[data-analyze-open-artifacts]')){
+    b.onclick=async ()=>{
+      await selectRun(b.dataset.analyzeOpenArtifacts);
+      s.tab='artifacts';
+      await render();
+    };
   }
 }
 

--- a/src/ui/uiMetadataService.js
+++ b/src/ui/uiMetadataService.js
@@ -44,7 +44,7 @@ const WORKFLOW_CARD_DEFINITIONS = Object.freeze([
     title: 'Analyze Workspace',
     description: 'Run analysis and generate evidence artifacts for graph, DB2, and prompts.',
     category: 'analyze',
-    primaryActionLabel: 'Review Analyze Commands',
+    primaryActionLabel: 'Analyze Workspace',
   }),
   Object.freeze({
     id: 'query-db2',

--- a/tests/local-ui-action-service.test.js
+++ b/tests/local-ui-action-service.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert/strict');
 const {
   UiActionError,
   createLocalUiActionService,
+  normalizeAnalyzeExistingWorkspacePayload,
   normalizeDoctorDiagnostics,
   normalizeDoctorPayload,
   validateProfileName,
@@ -140,4 +141,147 @@ test('normalizeDoctorDiagnostics redacts secret-like values and summarizes jdbc 
   assert.equal(diagnostics[0].message.includes('<script>'), false);
   assert.equal(diagnostics[1].profileValue, '(redacted)');
   assert.equal(diagnostics[1].effectiveValue, '(redacted)');
+});
+
+test('analyze-existing-workspace action accepts valid payload, applies safe defaults, and returns safe links', async () => {
+  let receivedArgs = null;
+  const service = createLocalUiActionService({
+    cwd: '/workspace/project',
+    analyzeConfigResolver: () => ({
+      sourceRoot: './workspace',
+      outputRoot: './output',
+    }),
+    analyzeExecutor: (args) => {
+      receivedArgs = args;
+      return {
+        program: 'ORDERPGM',
+        analyzeManifest: {
+          run: {
+            status: 'succeeded',
+          },
+          summary: {
+            stageCount: 8,
+            diagnosticCount: 0,
+            warningCount: 0,
+            errorCount: 0,
+            generatedArtifactCount: 4,
+            sourceFileCount: 2,
+          },
+          artifacts: [
+            { path: 'report.md' },
+            { path: 'context.json' },
+          ],
+        },
+      };
+    },
+  });
+
+  const result = await service.executeAction('analyze-existing-workspace', {
+    profile: 'dev',
+    member: 'orderpgm',
+  });
+
+  assert.deepEqual(receivedArgs, {
+    profile: 'dev',
+    program: undefined,
+    member: 'ORDERPGM',
+    'safe-sharing': true,
+  });
+  assert.equal(result.action, 'analyze-existing-workspace');
+  assert.equal(result.status, 'completed');
+  assert.equal(result.input.member, 'ORDERPGM');
+  assert.equal(result.input.safeSharing, true);
+  assert.equal(result.workspace.sourceRoot, './workspace');
+  assert.equal(result.workspace.outputRoot, './output');
+  assert.equal(result.output.runId, 'ORDERPGM');
+  assert.equal(result.output.manifestPath, 'ORDERPGM/analyze-run-manifest.json');
+  assert.equal(result.output.reportArtifactPath, 'ORDERPGM/report.md');
+  assert.match(result.output.reportUrl, /^\/runs\/ORDERPGM\/artifacts\/raw\?path=report\.md$/);
+  assert.ok(result.notes.some((entry) => /does not fetch remote sources/i.test(entry)));
+});
+
+test('analyze-existing-workspace rejects unknown payload keys and raw command strings', () => {
+  assert.throws(
+    () => normalizeAnalyzeExistingWorkspacePayload({
+      profile: 'dev',
+      program: 'ORDERPGM',
+      command: 'rm -rf /',
+    }),
+    /unsupported key/i,
+  );
+});
+
+test('analyze-existing-workspace rejects unsafe profile, program, and member names', async () => {
+  const service = createLocalUiActionService({
+    analyzeConfigResolver: () => ({
+      sourceRoot: './workspace',
+      outputRoot: './output',
+    }),
+    analyzeExecutor: () => ({
+      program: 'ORDERPGM',
+      analyzeManifest: {
+        run: { status: 'succeeded' },
+        summary: {},
+        artifacts: [],
+      },
+    }),
+  });
+
+  for (const profile of ['../development', 'development test', 'development;rm -rf', '"development"']) {
+    await assert.rejects(
+      () => service.executeAction('analyze-existing-workspace', {
+        profile,
+        program: 'ORDERPGM',
+      }),
+      /invalid payload/i,
+    );
+  }
+
+  for (const program of ['../ORDERPGM', 'ORDER PGM', 'ORDERPGM;rm -rf', '"ORDERPGM"']) {
+    await assert.rejects(
+      () => service.executeAction('analyze-existing-workspace', {
+        profile: 'dev',
+        program,
+      }),
+      /invalid payload/i,
+    );
+  }
+
+  for (const member of ['../ORDERPGM', 'ORDER PGM', 'ORDERPGM;rm -rf', '"ORDERPGM"']) {
+    await assert.rejects(
+      () => service.executeAction('analyze-existing-workspace', {
+        profile: 'dev',
+        member,
+      }),
+      /invalid payload/i,
+    );
+  }
+});
+
+test('analyze-existing-workspace returns structured failed status for expected analyze failures without leaking private paths', async () => {
+  const service = createLocalUiActionService({
+    cwd: '/workspace/project',
+    analyzeConfigResolver: () => ({
+      sourceRoot: '/private/source/root',
+      outputRoot: './output',
+    }),
+    analyzeExecutor: () => {
+      const error = new Error('Source directory not found: /private/source/root. Provide a valid --source path.');
+      error.code = 'SOURCE_ROOT_MISSING';
+      throw error;
+    },
+  });
+
+  const result = await service.executeAction('analyze-existing-workspace', {
+    profile: 'dev',
+    program: 'ORDERPGM',
+    safeSharing: false,
+  });
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.input.safeSharing, false);
+  assert.equal(result.workspace.sourceRoot, '(configured outside project root)');
+  assert.equal(result.diagnostics.length, 1);
+  assert.match(result.diagnostics[0].message, /not found locally/i);
+  assert.equal(JSON.stringify(result).includes('/private/source/root'), false);
 });

--- a/tests/local-ui-server.test.js
+++ b/tests/local-ui-server.test.js
@@ -155,6 +155,35 @@ test('local UI server exposes run explorer data and Prompt Workbench routes thro
             ],
           };
         },
+        analyzeConfigResolver: () => ({
+          sourceRoot: './workspace',
+          outputRoot: './output',
+        }),
+        analyzeExecutor: (args) => {
+          if (args.profile === 'explode-analyze') {
+            throw new Error('unexpected analyze failure');
+          }
+          return {
+            program: args.program || args.member || 'ORDERPGM',
+            analyzeManifest: {
+              run: {
+                status: 'succeeded',
+              },
+              summary: {
+                stageCount: 8,
+                diagnosticCount: 0,
+                warningCount: 0,
+                errorCount: 0,
+                generatedArtifactCount: 3,
+                sourceFileCount: 2,
+              },
+              artifacts: [
+                { path: 'report.md' },
+                { path: 'context.json' },
+              ],
+            },
+          };
+        },
       },
     });
 
@@ -234,6 +263,50 @@ test('local UI server exposes run explorer data and Prompt Workbench routes thro
     });
     assert.equal(unknownAction.status, 404);
 
+    const analyzeResponse = await fetch(`${started.url}/api/ui-actions/analyze-existing-workspace`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        profile: 'dev',
+        member: 'orderpgm',
+      }),
+    });
+    assert.equal(analyzeResponse.status, 200);
+    const analyzePayload = await analyzeResponse.json();
+    assert.equal(analyzePayload.action, 'analyze-existing-workspace');
+    assert.equal(analyzePayload.status, 'completed');
+    assert.equal(analyzePayload.input.member, 'ORDERPGM');
+    assert.equal(analyzePayload.input.safeSharing, true);
+    assert.equal(analyzePayload.workspace.sourceRoot, './workspace');
+    assert.match(analyzePayload.output.reportUrl, /^\/runs\/ORDERPGM\/artifacts\/raw\?path=report\.md$/);
+
+    const analyzeInvalidPayload = await fetch(`${started.url}/api/ui-actions/analyze-existing-workspace`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        profile: 'dev',
+        member: 'ORDERPGM',
+        command: 'rm -rf /',
+      }),
+    });
+    assert.equal(analyzeInvalidPayload.status, 400);
+
+    const analyzeUnsafePayload = await fetch(`${started.url}/api/ui-actions/analyze-existing-workspace`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        profile: 'dev',
+        member: '../ORDERPGM',
+      }),
+    });
+    assert.equal(analyzeUnsafePayload.status, 400);
+
     const nonJsonAction = await fetch(`${started.url}/api/ui-actions/doctor`, {
       method: 'POST',
       headers: {
@@ -255,6 +328,20 @@ test('local UI server exposes run explorer data and Prompt Workbench routes thro
     assert.equal(unexpectedFailure.status, 500);
     const unexpectedFailurePayload = await unexpectedFailure.json();
     assert.equal(unexpectedFailurePayload.error, 'Internal server error');
+
+    const unexpectedAnalyzeFailure = await fetch(`${started.url}/api/ui-actions/analyze-existing-workspace`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        profile: 'explode-analyze',
+        program: 'ORDERPGM',
+      }),
+    });
+    assert.equal(unexpectedAnalyzeFailure.status, 500);
+    const unexpectedAnalyzeFailurePayload = await unexpectedAnalyzeFailure.json();
+    assert.equal(unexpectedAnalyzeFailurePayload.error, 'Internal server error');
 
     const analyses = await fetch(`${started.url}/api/analyses`).then((response) => response.json());
     assert.equal(Array.isArray(analyses.workspaces), true);
@@ -300,6 +387,10 @@ test('local UI server exposes run explorer data and Prompt Workbench routes thro
     assert.match(shellHtml, /Workflow Shell/);
     assert.match(shellHtml, /Workflow Cards/);
     assert.match(shellHtml, /Check Readiness/);
+    assert.match(shellHtml, /Analyze Workspace/);
+    assert.match(shellHtml, /Open analysis report/);
+    assert.match(shellHtml, /Show raw result/);
+    assert.match(shellHtml, /\/api\/ui-actions\/analyze-existing-workspace/);
     assert.match(shellHtml, /Configuration warnings/);
     assert.match(shellHtml, /Selected profile and environment point to different DB targets/);
     assert.match(shellHtml, /Graph Explorer|Graph/);


### PR DESCRIPTION
This PR adds the next allowlisted Local UI action for analyzing existing local workspaces. It follows the same safety model as the Doctor action: strict payload validation, no arbitrary browser-triggered command execution, no remote fetch, no DB query execution, and safe structured responses for the UI.