### PR TITLE
Add Local UI AI Session Starter

### DIFF
--- a/docs/ai/session-prompt.md
+++ b/docs/ai/session-prompt.md
@@ -15,7 +15,7 @@ Related:
 
 ## Session Start Prompt (Copy/Paste)
 
-```text
+````text
 You are a senior IBM i / RPG engineering assistant working with Zeus RPG PromptKit.
 
 Core operating model:
@@ -113,7 +113,7 @@ node cli/zeus.js analyze --profile <profile> --program <PROGRAM> --verbose
 
 Now proceed with this session goal:
 [INSERT USER GOAL HERE]
-```
+````
 
 ## Usage Notes
 

--- a/docs/viewer/local-ui-shell.md
+++ b/docs/viewer/local-ui-shell.md
@@ -1,7 +1,7 @@
 ---
 Title: Local UI Shell
 Description: Dokumentation zur lokalen Viewer- und UI-Shell fuer erzeugte Analyseartefakte.
-Last Updated: 2026-06-18
+Last Updated: 2026-06-19
 ---
 
 # Local UI Shell
@@ -27,6 +27,7 @@ Behavior:
 - `GET /api/health`
 - `GET /api/ui-metadata`
 - `POST /api/ui-actions/doctor`
+- `POST /api/ui-actions/generate-ai-session-prompt`
 - `POST /api/ui-actions/analyze-existing-workspace`
 - `GET /api/runs`
 - `GET /api/runs/:program`
@@ -52,6 +53,7 @@ The browser shell consumes only those endpoints. It does not parse output direct
   - env/profile precedence explanation
   - safe config metadata overview
   - Doctor readiness checks
+  - AI Session Starter prompt generation from `docs/ai/session-prompt.md`
   - runtime guardrail conflict warnings
   - clear recommended next steps
 - the local-only profile wizard remains available inside Setup, but behind an expandable details area so onboarding does not start with a dense editing surface
@@ -118,15 +120,18 @@ The local UI action surface is intentionally explicit and small:
 Current supported action:
 
 - `doctor` readiness check via `POST /api/ui-actions/doctor`
+- `generate-ai-session-prompt` via `POST /api/ui-actions/generate-ai-session-prompt`
 - `analyze-existing-workspace` via `POST /api/ui-actions/analyze-existing-workspace`
 
 Security behavior:
 
 - request and response format is JSON only
 - server-side validation blocks unsafe profile values
+- `generate-ai-session-prompt` accepts only `profile`, optional `environment`, `goal`, `includeDoctorSummary`, and optional compact `doctorSummary`
 - `analyze-existing-workspace` accepts only `profile`, `program`, `member`, and `safeSharing`
 - browser payloads do not provide `sourceRoot`; the action always uses the selected profile's configured local source root
 - browser payloads cannot provide arbitrary shell commands, absolute paths, or traversal-style filesystem input
+- browser payloads cannot provide env dumps, raw secrets, or credential-bearing JDBC text for AI session generation
 - responses keep diagnostics structured and do not expose resolved secret values or raw env values
 - runtime guardrail conflicts between profile DB targets and env overrides are surfaced as warnings, not automatic aborts
 - conflict diagnostics remain allowlisted and redacted; the UI never exposes passwords or full credential-bearing JDBC URLs
@@ -152,6 +157,24 @@ The Setup tab explains precedence in simple terms:
 - env vars are powerful and can change the effective target
 - Doctor checks the effective configuration after those rules are applied
 - secret values are never shown
+
+Setup now also includes `Start AI Session`:
+
+- it generates a guided assistant prompt from `docs/ai/session-prompt.md`
+- it keeps prompt generation server-side so the browser only submits validated JSON
+- it can include a compact Doctor summary, but it still instructs the assistant to run Doctor first
+- it reminds the user that env loading is shell/process scoped
+- it shows helper commands for `config/load-env.ps1` and `config/load-env.sh`
+- it does not inject env vars into the user's already-open terminal
+- it does not expose credentials, resolved env values, or full connection strings
+- it treats `docs/tool-catalog.md` as the authoritative CLI/MCP command reference
+
+AI Session Starter guidance:
+
+- use it after Setup understanding and preferably after `Check Readiness`
+- keep credentials in env or other local-only mechanisms, not in the goal text
+- generated prompts can mention allowlisted Zeus MCP tools if available, but they must not invent unsupported MCP capabilities
+- risky CLI or MCP operations still require explicit approval according to the tool catalog safety levels
 
 Env vars are shown as metadata only, for example:
 

--- a/src/cli/commands/analysesCommand.js
+++ b/src/cli/commands/analysesCommand.js
@@ -28,7 +28,8 @@ const {
   readWorkspaceIndex,
   writeWorkspaceIndex,
 } = require('../../workspace/workspaceIndexBuilder');
-const { startLocalUiServer, DEFAULT_UI_HOST, DEFAULT_UI_PORT } = require('../../ui/localUiServer');
+const { startLocalUiServer } = require('../../ui/localUiServer');
+const { DEFAULT_UI_HOST, DEFAULT_UI_PORT } = require('../../ui/localUiDefaults');
 
 function parsePort(value, fallback) {
   if (value === undefined || value === null || value === true) {

--- a/src/cli/commands/serveCommand.js
+++ b/src/cli/commands/serveCommand.js
@@ -15,7 +15,8 @@ const path = require('path');
 
 const { loadProfiles, resolveBundleConfig, resolveProfile } = require('../../config/runtimeConfig');
 const { resolveRegistryPath } = require('../../workspace/analysisRegistryService');
-const { startLocalUiServer, DEFAULT_UI_HOST, DEFAULT_UI_PORT } = require('../../ui/localUiServer');
+const { startLocalUiServer } = require('../../ui/localUiServer');
+const { DEFAULT_UI_HOST, DEFAULT_UI_PORT } = require('../../ui/localUiDefaults');
 
 function parsePort(value, fallback) {
   if (value === undefined || value === null || value === true) {

--- a/src/mcp/mcpTools.js
+++ b/src/mcp/mcpTools.js
@@ -72,7 +72,7 @@ const { assessCanonicalModel } = require('../impact/riskAssessmentAnalyzer');
 const { WORKFLOW_RUN_MANIFEST_FILE } = require('../workflow/workflowRunManifest');
 const { searchLocalSources } = require('../investigation/fieldXrefService');
 const { listAnalysisRuns } = require('../ui/localUiDataApi');
-const { DEFAULT_UI_HOST, DEFAULT_UI_PORT } = require('../ui/localUiServer');
+const { DEFAULT_UI_HOST, DEFAULT_UI_PORT } = require('../ui/localUiDefaults');
 const {
   buildWorkCopyTargetName,
   discoverFetchedSources,

--- a/src/ui/aiSessionPromptService.js
+++ b/src/ui/aiSessionPromptService.js
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+const fs = require('fs');
+const path = require('path');
+
+const { sanitizeValue } = require('../security/secretMasking');
+
+const AI_SESSION_PROMPT_TEMPLATE_PATH = 'docs/ai/session-prompt.md';
+const AI_SESSION_PROMPT_PLACEHOLDER = '[INSERT USER GOAL HERE]';
+const AI_SESSION_GOAL_MAX_LENGTH = 4000;
+class AiSessionPromptError extends Error {
+  constructor(message, statusCode = 500) {
+    super(message);
+    this.name = 'AiSessionPromptError';
+    this.statusCode = statusCode;
+  }
+}
+
+function defaultTemplateLoader(templatePath = AI_SESSION_PROMPT_TEMPLATE_PATH) {
+  const absolutePath = path.resolve(__dirname, '..', '..', templatePath);
+  if (!fs.existsSync(absolutePath)) {
+    throw new AiSessionPromptError(`AI session prompt template is unavailable: ${templatePath}`, 500);
+  }
+  return fs.readFileSync(absolutePath, 'utf8');
+}
+
+function extractSessionPromptTemplate(markdown) {
+  const source = String(markdown || '');
+  const sectionMatch = source.match(/##\s+Session Start Prompt[^\n]*/m);
+  if (!sectionMatch || typeof sectionMatch.index !== 'number') {
+    throw new AiSessionPromptError('AI session prompt template is missing the Session Start Prompt text block.', 500);
+  }
+
+  const sectionStart = sectionMatch.index;
+  const fenceMatch = /```text\r?\n/g;
+  fenceMatch.lastIndex = sectionStart;
+  const openingFenceMatch = fenceMatch.exec(source);
+  if (!openingFenceMatch) {
+    throw new AiSessionPromptError('AI session prompt template is missing the Session Start Prompt text block.', 500);
+  }
+
+  const promptStart = openingFenceMatch.index + openingFenceMatch[0].length;
+  const nextHeadingIndex = source.indexOf('\n## ', promptStart);
+  const sectionEnd = nextHeadingIndex >= 0 ? nextHeadingIndex : source.length;
+  const closingFenceIndex = source.lastIndexOf('\n```', sectionEnd);
+  if (closingFenceIndex < promptStart) {
+    throw new AiSessionPromptError('AI session prompt template is missing the Session Start Prompt closing fence.', 500);
+  }
+
+  const promptTemplate = source.slice(promptStart, closingFenceIndex);
+  if (!promptTemplate.includes(AI_SESSION_PROMPT_PLACEHOLDER)) {
+    throw new AiSessionPromptError('AI session prompt template is missing the session goal placeholder.', 500);
+  }
+  return promptTemplate;
+}
+
+function formatDoctorSummary(doctorSummary) {
+  if (!doctorSummary || typeof doctorSummary !== 'object') {
+    return null;
+  }
+
+  const summary = doctorSummary.summary && typeof doctorSummary.summary === 'object'
+    ? doctorSummary.summary
+    : null;
+  const counts = [];
+  if (summary) {
+    for (const key of ['pass', 'warn', 'fail', 'info', 'skip']) {
+      if (Number.isFinite(summary[key])) {
+        counts.push(`${key}=${Number(summary[key])}`);
+      }
+    }
+  }
+
+  const details = [
+    `status=${String(doctorSummary.status || 'unknown').trim() || 'unknown'}`,
+    counts.length > 0 ? counts.join(', ') : null,
+    doctorSummary.finishedAt ? `finishedAt=${String(doctorSummary.finishedAt).trim()}` : null,
+  ].filter(Boolean);
+
+  return details.length > 0 ? details.join(' | ') : null;
+}
+
+function buildSessionGoalBlock({
+  profile,
+  environment,
+  includeDoctorSummary = false,
+  doctorSummary = null,
+}) {
+  const lines = [
+    'Session context from Local UI Setup (safe metadata only):',
+    `- Profile: ${profile}`,
+    environment ? `- Environment hint: ${environment}` : null,
+    '- Env loading is shell-scoped. The Local UI cannot inject env vars into the user\'s already-open terminal session.',
+    '- The Local UI server only sees env vars that were present when it started.',
+    includeDoctorSummary && formatDoctorSummary(doctorSummary)
+      ? `- Doctor summary: ${formatDoctorSummary(doctorSummary)}`
+      : '- Doctor summary: not included; run `doctor` first in this session before deeper work.',
+    '- Treat `docs/tool-catalog.md` as the authoritative command and safety reference.',
+    '- Use allowlisted Zeus CLI and Zeus MCP tools if available. Do not invent tools or assume unsupported capabilities.',
+    '- Never request, paste, echo, or persist credentials, env dumps, or credential-bearing JDBC URLs.',
+    '',
+    'User goal:',
+  ].filter(Boolean);
+
+  return `${lines.join('\n')}\n`;
+}
+
+function createAiSessionPromptService({
+  templateLoader = defaultTemplateLoader,
+  templatePath = AI_SESSION_PROMPT_TEMPLATE_PATH,
+} = {}) {
+  function generatePrompt({
+    profile,
+    environment = '',
+    goal,
+    includeDoctorSummary = false,
+    doctorSummary = null,
+  }) {
+    const markdown = templateLoader(templatePath);
+    const promptTemplate = extractSessionPromptTemplate(markdown);
+    const sessionGoalPrefix = buildSessionGoalBlock({
+      profile: sanitizeValue(profile),
+      environment: environment ? sanitizeValue(environment) : '',
+      includeDoctorSummary,
+      doctorSummary,
+    });
+    const sanitizedGoal = sanitizeValue(String(goal || '').trim());
+    const prompt = promptTemplate.replace(
+      AI_SESSION_PROMPT_PLACEHOLDER,
+      `${sessionGoalPrefix}${sanitizedGoal}`,
+    );
+    const warnings = [
+      includeDoctorSummary
+        ? 'Doctor summary was included as a compact status hint only. The assistant should still run doctor first.'
+        : 'No doctor summary was included. The assistant should still run doctor first.',
+      'Do not paste credentials or env secret values into the session goal.',
+      'Use docs/tool-catalog.md as the authoritative Zeus command reference.',
+    ];
+
+    return {
+      prompt,
+      warnings,
+      metadata: {
+        profile: sanitizeValue(profile),
+        environment: environment ? sanitizeValue(environment) : null,
+        includedDoctorSummary: Boolean(includeDoctorSummary && formatDoctorSummary(doctorSummary)),
+        templateSource: templatePath,
+      },
+    };
+  }
+
+  return {
+    generatePrompt,
+    extractSessionPromptTemplate,
+  };
+}
+
+module.exports = {
+  AI_SESSION_GOAL_MAX_LENGTH,
+  AI_SESSION_PROMPT_PLACEHOLDER,
+  AI_SESSION_PROMPT_TEMPLATE_PATH,
+  AiSessionPromptError,
+  buildSessionGoalBlock,
+  createAiSessionPromptService,
+  defaultTemplateLoader,
+  extractSessionPromptTemplate,
+};

--- a/src/ui/aiSessionPromptService.js
+++ b/src/ui/aiSessionPromptService.js
@@ -43,7 +43,7 @@ function extractSessionPromptTemplate(markdown) {
   }
 
   const sectionStart = sectionMatch.index;
-  const fenceMatch = /```text\r?\n/g;
+  const fenceMatch = /^(`{3,})text\r?\n/gm;
   fenceMatch.lastIndex = sectionStart;
   const openingFenceMatch = fenceMatch.exec(source);
   if (!openingFenceMatch) {
@@ -51,9 +51,7 @@ function extractSessionPromptTemplate(markdown) {
   }
 
   const promptStart = openingFenceMatch.index + openingFenceMatch[0].length;
-  const nextHeadingIndex = source.indexOf('\n## ', promptStart);
-  const sectionEnd = nextHeadingIndex >= 0 ? nextHeadingIndex : source.length;
-  const closingFenceIndex = source.lastIndexOf('\n```', sectionEnd);
+  const closingFenceIndex = source.indexOf(`\n${openingFenceMatch[1]}`, promptStart);
   if (closingFenceIndex < promptStart) {
     throw new AiSessionPromptError('AI session prompt template is missing the Session Start Prompt closing fence.', 500);
   }

--- a/src/ui/localUiActionService.js
+++ b/src/ui/localUiActionService.js
@@ -27,11 +27,18 @@ const {
   buildEnvProfileConflictMessage,
   summarizeTargetValue,
 } = require('../cli/helpers/runtimeConfigWarnings');
+const { maskSecretsInText } = require('../security/secretMasking');
+const {
+  AI_SESSION_GOAL_MAX_LENGTH,
+  AiSessionPromptError,
+  createAiSessionPromptService,
+} = require('./aiSessionPromptService');
 const { buildDiscoveryActionPreview, getGuidedDiscoveryAction } = require('./guidedConfigWizardModel');
 
 const ALLOWED_DOCTOR_KEYS = new Set(['profile', 'showResolved']);
 const ALLOWED_ANALYZE_WORKSPACE_KEYS = new Set(['profile', 'program', 'member', 'safeSharing']);
 const ALLOWED_DISCOVERY_PREVIEW_KEYS = new Set(['profile', 'actionId']);
+const ALLOWED_AI_SESSION_PROMPT_KEYS = new Set(['profile', 'environment', 'goal', 'includeDoctorSummary', 'doctorSummary']);
 const FETCH_CONFIG_DERIVED_DISCOVERY_ACTIONS = new Set([
   'discover-source-libraries',
   'discover-source-physical-files',
@@ -45,12 +52,16 @@ const OBJECT_CONFIG_DERIVED_DISCOVERY_ACTIONS = new Set([
 ]);
 const PROFILE_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
 const OBJECT_NAME_PATTERN = /^[A-Za-z0-9_]{1,64}$/;
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/u;
 const SECRET_LIKE_PATTERN = /(PASS|PASSWORD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|CREDENTIAL|PWD)/i;
+const JDBC_CREDENTIAL_PATTERN = /\bjdbc:[a-z0-9]+:\/\/[^:\s/;,@]+:[^@\s/;]+@/i;
 const KNOWN_ANALYZE_FAILURE_CODES = new Set([
   'PROGRAM_REQUIRED',
   'SOURCE_REQUIRED',
   'SOURCE_ROOT_MISSING',
 ]);
+const ALLOWED_DOCTOR_SUMMARY_KEYS = new Set(['status', 'summary', 'finishedAt']);
+const ALLOWED_DOCTOR_SUMMARY_COUNT_KEYS = new Set(['total', 'pass', 'fail', 'warn', 'info', 'skip']);
 
 class UiActionError extends Error {
   constructor(message, statusCode = 400) {
@@ -87,6 +98,95 @@ function validateObjectName(value, fieldName) {
     throw new UiActionError(`Invalid payload: ${fieldName} contains unsupported characters`, 400);
   }
   return trimmed.toUpperCase();
+}
+
+function validateOptionalSimpleName(value, fieldName) {
+  const trimmed = String(value || '').trim();
+  if (!trimmed) {
+    return '';
+  }
+  if (trimmed.includes('..')) {
+    throw new UiActionError(`Invalid payload: ${fieldName} must not contain ".."`, 400);
+  }
+  if (!PROFILE_NAME_PATTERN.test(trimmed)) {
+    throw new UiActionError(`Invalid payload: ${fieldName} contains unsupported characters`, 400);
+  }
+  return trimmed;
+}
+
+function normalizeGoal(goal) {
+  const trimmed = String(goal || '').replace(/\r\n/g, '\n').trim();
+  if (!trimmed) {
+    throw new UiActionError('Invalid payload: goal is required', 400);
+  }
+  if (trimmed.length > AI_SESSION_GOAL_MAX_LENGTH) {
+    throw new UiActionError(`Invalid payload: goal exceeds ${AI_SESSION_GOAL_MAX_LENGTH} characters`, 400);
+  }
+  if (CONTROL_CHARACTER_PATTERN.test(trimmed)) {
+    throw new UiActionError('Invalid payload: goal contains unsupported control characters', 400);
+  }
+  if (JDBC_CREDENTIAL_PATTERN.test(trimmed) || maskSecretsInText(trimmed) !== trimmed) {
+    throw new UiActionError('Invalid payload: goal appears to contain secrets or credential-bearing connection text', 400);
+  }
+  return trimmed;
+}
+
+function normalizeDoctorSummary(rawDoctorSummary) {
+  if (rawDoctorSummary === undefined) {
+    return null;
+  }
+  if (!isPlainObject(rawDoctorSummary)) {
+    throw new UiActionError('Invalid payload: doctorSummary must be an object', 400);
+  }
+
+  const unknownKeys = Object.keys(rawDoctorSummary).filter((key) => !ALLOWED_DOCTOR_SUMMARY_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    throw new UiActionError(`Invalid payload: unsupported doctorSummary key(s): ${unknownKeys.join(', ')}`, 400);
+  }
+
+  const status = String(rawDoctorSummary.status || '').trim().toLowerCase();
+  if (!status) {
+    throw new UiActionError('Invalid payload: doctorSummary.status is required when doctorSummary is provided', 400);
+  }
+
+  let summary = null;
+  if (rawDoctorSummary.summary !== undefined) {
+    if (!isPlainObject(rawDoctorSummary.summary)) {
+      throw new UiActionError('Invalid payload: doctorSummary.summary must be an object', 400);
+    }
+    const unknownSummaryKeys = Object.keys(rawDoctorSummary.summary)
+      .filter((key) => !ALLOWED_DOCTOR_SUMMARY_COUNT_KEYS.has(key));
+    if (unknownSummaryKeys.length > 0) {
+      throw new UiActionError(`Invalid payload: unsupported doctorSummary.summary key(s): ${unknownSummaryKeys.join(', ')}`, 400);
+    }
+    summary = {};
+    for (const key of ALLOWED_DOCTOR_SUMMARY_COUNT_KEYS) {
+      if (rawDoctorSummary.summary[key] === undefined) {
+        continue;
+      }
+      const numericValue = Number(rawDoctorSummary.summary[key]);
+      if (!Number.isInteger(numericValue) || numericValue < 0) {
+        throw new UiActionError(`Invalid payload: doctorSummary.summary.${key} must be a non-negative integer`, 400);
+      }
+      summary[key] = numericValue;
+    }
+  }
+
+  const finishedAt = rawDoctorSummary.finishedAt === undefined
+    ? null
+    : String(rawDoctorSummary.finishedAt).trim();
+  if (finishedAt) {
+    const timestamp = new Date(finishedAt);
+    if (Number.isNaN(timestamp.getTime())) {
+      throw new UiActionError('Invalid payload: doctorSummary.finishedAt must be an ISO timestamp', 400);
+    }
+  }
+
+  return {
+    status,
+    summary,
+    finishedAt: finishedAt || null,
+  };
 }
 
 function normalizeDoctorPayload(rawPayload) {
@@ -154,6 +254,33 @@ function normalizeDiscoveryPreviewPayload(rawPayload) {
   return {
     profile,
     actionId,
+  };
+}
+
+function normalizeAiSessionPromptPayload(rawPayload) {
+  if (!isPlainObject(rawPayload)) {
+    throw new UiActionError('Invalid payload: expected JSON object', 400);
+  }
+
+  const unknownKeys = Object.keys(rawPayload).filter((key) => !ALLOWED_AI_SESSION_PROMPT_KEYS.has(key));
+  if (unknownKeys.length > 0) {
+    throw new UiActionError(`Invalid payload: unsupported key(s): ${unknownKeys.join(', ')}`, 400);
+  }
+
+  const profile = validateProfileName(rawPayload.profile);
+  const environment = validateOptionalSimpleName(rawPayload.environment, 'environment');
+  const goal = normalizeGoal(rawPayload.goal);
+  const doctorSummary = normalizeDoctorSummary(rawPayload.doctorSummary);
+  const includeDoctorSummary = rawPayload.includeDoctorSummary === undefined
+    ? Boolean(doctorSummary)
+    : Boolean(rawPayload.includeDoctorSummary);
+
+  return {
+    profile,
+    environment: environment || null,
+    goal,
+    includeDoctorSummary,
+    doctorSummary,
   };
 }
 
@@ -499,6 +626,7 @@ function createLocalUiActionService({
   analyzeConfigResolver = defaultAnalyzeConfigResolver,
   fetchConfigResolver = defaultFetchConfigResolver,
   workflowConfigResolver = defaultWorkflowConfigResolver,
+  aiSessionPromptService = createAiSessionPromptService(),
 } = {}) {
   async function runDoctorAction(rawPayload) {
     const startedAt = new Date();
@@ -741,6 +869,46 @@ function createLocalUiActionService({
     };
   }
 
+  async function runGenerateAiSessionPromptAction(rawPayload) {
+    const startedAt = new Date();
+    const payload = normalizeAiSessionPromptPayload(rawPayload || {});
+
+    try {
+      const promptResult = await Promise.resolve(aiSessionPromptService.generatePrompt(payload));
+      const finishedAt = new Date();
+
+      return {
+        action: 'generate-ai-session-prompt',
+        status: 'completed',
+        startedAt: startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        durationMs: finishedAt.getTime() - startedAt.getTime(),
+        input: {
+          profile: payload.profile,
+          environment: payload.environment,
+          goal: payload.goal,
+          includeDoctorSummary: payload.includeDoctorSummary,
+          doctorSummary: payload.includeDoctorSummary ? payload.doctorSummary : null,
+        },
+        prompt: promptResult.prompt,
+        warnings: Array.isArray(promptResult.warnings) ? promptResult.warnings : [],
+        metadata: promptResult.metadata && typeof promptResult.metadata === 'object'
+          ? promptResult.metadata
+          : {
+            profile: payload.profile,
+            environment: payload.environment,
+            includedDoctorSummary: Boolean(payload.includeDoctorSummary && payload.doctorSummary),
+            templateSource: null,
+          },
+      };
+    } catch (error) {
+      if (!(error instanceof AiSessionPromptError)) {
+        throw error;
+      }
+      throw new UiActionError(error.message, error.statusCode);
+    }
+  }
+
   async function executeAction(actionName, payload) {
     const normalizedAction = String(actionName || '').trim().toLowerCase();
     if (!normalizedAction) {
@@ -756,6 +924,9 @@ function createLocalUiActionService({
     if (normalizedAction === 'discovery-preview') {
       return runDiscoveryPreviewAction(payload);
     }
+    if (normalizedAction === 'generate-ai-session-prompt') {
+      return runGenerateAiSessionPromptAction(payload);
+    }
 
     throw new UiActionError(`Unknown action: ${normalizedAction}`, 404);
   }
@@ -763,6 +934,7 @@ function createLocalUiActionService({
   return {
     executeAction,
     normalizeAnalyzeExistingWorkspacePayload,
+    normalizeAiSessionPromptPayload,
     normalizeDiscoveryPreviewPayload,
     normalizeDoctorPayload,
     buildDiscoveryConfigContext,
@@ -780,9 +952,11 @@ module.exports = {
   buildDb2DiscoveryConfigContext,
   buildObjectDiscoveryConfigContext,
   normalizeAnalyzeExistingWorkspacePayload,
+  normalizeAiSessionPromptPayload,
   normalizeDiscoveryPreviewPayload,
   normalizeDoctorPayload,
   normalizeDoctorDiagnostics,
   validateProfileName,
+  validateOptionalSimpleName,
   validateObjectName,
 };

--- a/src/ui/localUiDefaults.js
+++ b/src/ui/localUiDefaults.js
@@ -1,0 +1,21 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+const DEFAULT_UI_HOST = '127.0.0.1';
+const DEFAULT_UI_PORT = 4782;
+
+module.exports = {
+  DEFAULT_UI_HOST,
+  DEFAULT_UI_PORT,
+};

--- a/src/ui/localUiServer.js
+++ b/src/ui/localUiServer.js
@@ -29,9 +29,7 @@ const { createPromptWorkbenchService } = require('./promptWorkbenchService');
 const { collectSensitiveTermsFromEnv, maskSensitiveTermsInText, sanitizeValue } = require('../security/secretMasking');
 const { listWorkspaces, readWorkspaceById, touchWorkspace } = require('../workspace/analysisRegistryService');
 const { readWorkspaceIndex, WORKSPACE_INDEX_FILE } = require('../workspace/workspaceIndexBuilder');
-
-const DEFAULT_UI_HOST = '127.0.0.1';
-const DEFAULT_UI_PORT = 4782;
+const { DEFAULT_UI_HOST, DEFAULT_UI_PORT } = require('./localUiDefaults');
 const MAX_JSON_BODY_BYTES = 512 * 1024;
 
 function normalizeHost(host) {

--- a/src/ui/localUiShell.js
+++ b/src/ui/localUiShell.js
@@ -860,6 +860,38 @@ function renderCommandBlock(lines){
   return '<div class="command-block"><pre>'+esc((Array.isArray(lines)?lines:[String(lines||'')]).join('\\n'))+'</pre></div>';
 }
 
+function renderTokenRow(items,className){
+  const safeItems=Array.isArray(items)?items:[];
+  const tokens=safeItems.map((entry)=>{
+    if(entry===null||entry===undefined||entry===false) return '';
+    if(typeof entry==='object'){
+      const text=entry.text===undefined||entry.text===null?'':String(entry.text);
+      if(!text) return '';
+      const toneClass=entry.tone?statusToneClass(entry.tone):'';
+      return '<div class="token'+(toneClass?' '+escAttr(toneClass):'')+'">'+esc(text)+'</div>';
+    }
+    const text=String(entry);
+    return text?'<div class="token">'+esc(text)+'</div>':'';
+  }).filter(Boolean).join('');
+  if(!tokens) return '';
+  return '<div class="'+escAttr(className||'tokens')+'">'+tokens+'</div>';
+}
+
+function renderHintList(items){
+  const safeItems=Array.isArray(items)?items:[];
+  const content=safeItems.map((entry)=>{
+    if(!entry||typeof entry!=='object') return '';
+    const title=entry.title?'<strong>'+esc(String(entry.title))+'</strong>':'';
+    const tokens=renderTokenRow(entry.tokens,'tokens');
+    const body=entry.body?'<p>'+esc(String(entry.body))+'</p>':'';
+    const bodyHtml=entry.bodyHtml?'<p>'+String(entry.bodyHtml)+'</p>':'';
+    const small=entry.small?'<p class="small">'+esc(String(entry.small))+'</p>':'';
+    const smallHtml=entry.smallHtml?'<p class="small">'+String(entry.smallHtml)+'</p>':'';
+    return '<div class="hint-item">'+title+tokens+body+bodyHtml+small+smallHtml+'</div>';
+  }).filter(Boolean).join('');
+  return content?'<div class="hint-list">'+content+'</div>':'';
+}
+
 function promptWorkbenchHighlights(){
   const useCases=(s.promptBuilder.useCases||[]).slice(0,3);
   if(s.promptBuilder.loading){
@@ -1622,14 +1654,35 @@ function renderConfigureStartPanel(options){
   }else if(signals.canPreview){
     recommendedNext='Run Preview Draft next, then save locally before Check Readiness.';
   }
-  return '<div class="sub"><h2>'+esc(String(setupMeta.title||'Setup'))+'</h2><p>Use Setup as a simple 3-step path: choose or create a profile, preview and save it locally, then run Zeus Doctor.</p><div class="hint-list"><div class="hint-item"><strong>Browser safety</strong><p>'+esc(boundaryNotes.join(' '))+'</p></div><div class="hint-item"><strong>Resolution order</strong><p>'+esc(precedenceRules.length?precedenceRules.join(' '):precedenceSummary)+' Doctor checks the effective configuration after those rules are applied.</p></div></div><div class="field-list">'+
-    '<div class="field-item"><strong>Recommended Next Step</strong><p>'+esc(recommendedNext)+'</p><div class="workflow-meta">'+recommendedNextTokens.map((token)=>'<div class="token">'+esc(String(token))+'</div>').join('')+'</div></div>'+
-    '<div class="field-item"><strong>1. Choose Or Create A Profile</strong><p>'+esc(stepOneStatus)+'</p><div class="workflow-meta"><div class="token">known profiles: '+esc(String(profiles.length))+'</div><div class="token">local-only: '+esc(String(localOnlyProfiles.length))+'</div><div class="token">managed envs: '+esc(String(managedSystems.length))+'</div></div><p class="small">Selected profile source and local-only overlays are shown here, but secret values are never displayed.</p><div class="actions"><button class="btn" data-pw-refresh="1">Reload Wizard State</button><button class="btn primary" data-pw-new="1">New Local Draft</button><button class="btn" data-pw-load="1">Load Selected Profile</button></div></div>'+
-    '<div class="field-item"><strong>Environment Override Explanation</strong><p>Environment variables can change the effective target even when the saved profile looks correct.</p><div class="workflow-meta">'+routingTokens.map(([label,value])=>'<div class="token">'+esc(label+': '+value)+'</div>').join('')+'</div><p class="small">Examples: <code>ZEUS_DB_HOST</code> can override <code>db.host</code>. Secret env vars may exist, but their values are never shown here.</p></div>'+
-    '<div class="field-item"><strong>Config Metadata Overview</strong><p>'+esc(String(configSectionCount))+' setup sections and '+esc(String(configFields.length))+' documented fields are available in this UI payload.</p><div class="workflow-meta"><div class="token">sensitive fields: '+esc(String(configSensitiveCount))+'</div><div class="token">read-only metadata</div><div class="token">no resolved values</div></div><p class="small">Use the metadata section below to understand which fields can be set by profile or env without exposing runtime secrets.</p></div>'+
-    '<div class="field-item"><strong>2. Preview And Save Locally</strong><p>'+esc(stepTwoStatus)+'</p><div class="workflow-meta"><div class="token '+esc(statusToneClass(previewStatus))+'">'+esc(previewStatus)+'</div>'+(draftProfileName?'<div class="token">draft: '+esc(draftProfileName)+'</div>':'<div class="token">draft name missing</div>')+(selectedProfileSummary?'<div class="token">loaded source: '+esc(String(selectedProfileSummary.sourceKind||'shared'))+'</div>':'')+'</div><div class="actions"><button class="btn" data-pw-preview="1">Preview Draft</button><button class="btn primary" data-pw-save="1">Save Local-only</button></div></div>'+
-    '<div class="field-item"><strong>3. Run Zeus Doctor</strong><p>'+esc(doctorStatus)+'</p><div class="workflow-meta"><div class="token">doctor target: '+esc(doctorProfile)+'</div>'+(doctorProfileSummary?'<div class="token">source: '+esc(String(doctorProfileSummary.sourceKind||'shared'))+'</div>':'<div class="token">save required</div>')+(doctorState&&doctorState.result?'<div class="token">result available</div>':'')+'</div><p class="small">'+esc(doctorHint)+'</p><div class="actions"><button class="btn primary" data-config-doctor="1">'+esc(doctorActionLabel)+'</button><button class="btn" data-config-refresh="1">Refresh Metadata</button></div></div>'+
-  '</div></div>';
+  return '<div class="sub"><h2>'+esc(String(setupMeta.title||'Setup'))+'</h2><p>Use Setup as a simple 3-step path: choose or create a profile, preview and save it locally, then run Zeus Doctor.</p>'+
+    renderHintList([
+      { title:'Browser safety', body:boundaryNotes.join(' ') },
+      { title:'Resolution order', body:(precedenceRules.length?precedenceRules.join(' '):precedenceSummary)+' Doctor checks the effective configuration after those rules are applied.' }
+    ])+
+    '<div class="field-list">'+
+      '<div class="field-item"><strong>Recommended Next Step</strong><p>'+esc(recommendedNext)+'</p>'+renderTokenRow(recommendedNextTokens,'workflow-meta')+'</div>'+
+      '<div class="field-item"><strong>1. Choose Or Create A Profile</strong><p>'+esc(stepOneStatus)+'</p>'+renderTokenRow([
+        'known profiles: '+String(profiles.length),
+        'local-only: '+String(localOnlyProfiles.length),
+        'managed envs: '+String(managedSystems.length)
+      ],'workflow-meta')+'<p class="small">Selected profile source and local-only overlays are shown here, but secret values are never displayed.</p><div class="actions"><button class="btn" data-pw-refresh="1">Reload Wizard State</button><button class="btn primary" data-pw-new="1">New Local Draft</button><button class="btn" data-pw-load="1">Load Selected Profile</button></div></div>'+
+      '<div class="field-item"><strong>Environment Override Explanation</strong><p>Environment variables can change the effective target even when the saved profile looks correct.</p>'+renderTokenRow(routingTokens.map(([label,value])=>label+': '+value),'workflow-meta')+'<p class="small">Examples: <code>ZEUS_DB_HOST</code> can override <code>db.host</code>. Secret env vars may exist, but their values are never shown here.</p></div>'+
+      '<div class="field-item"><strong>Config Metadata Overview</strong><p>'+esc(String(configSectionCount))+' setup sections and '+esc(String(configFields.length))+' documented fields are available in this UI payload.</p>'+renderTokenRow([
+        'sensitive fields: '+String(configSensitiveCount),
+        'read-only metadata',
+        'no resolved values'
+      ],'workflow-meta')+'<p class="small">Use the metadata section below to understand which fields can be set by profile or env without exposing runtime secrets.</p></div>'+
+      '<div class="field-item"><strong>2. Preview And Save Locally</strong><p>'+esc(stepTwoStatus)+'</p>'+renderTokenRow([
+        { text:previewStatus, tone:previewStatus },
+        draftProfileName?'draft: '+draftProfileName:'draft name missing',
+        selectedProfileSummary?'loaded source: '+String(selectedProfileSummary.sourceKind||'shared'):null
+      ],'workflow-meta')+'<div class="actions"><button class="btn" data-pw-preview="1">Preview Draft</button><button class="btn primary" data-pw-save="1">Save Local-only</button></div></div>'+
+      '<div class="field-item"><strong>3. Run Zeus Doctor</strong><p>'+esc(doctorStatus)+'</p>'+renderTokenRow([
+        'doctor target: '+doctorProfile,
+        doctorProfileSummary?'source: '+String(doctorProfileSummary.sourceKind||'shared'):'save required',
+        doctorState&&doctorState.result?'result available':null
+      ],'workflow-meta')+'<p class="small">'+esc(doctorHint)+'</p><div class="actions"><button class="btn primary" data-config-doctor="1">'+esc(doctorActionLabel)+'</button><button class="btn" data-config-refresh="1">Refresh Metadata</button></div></div>'+
+    '</div></div>';
 }
 
 function buildAiSessionDoctorSummaryPayload(doctorResult){
@@ -1685,7 +1738,22 @@ function renderAiSessionStarterPanel(options){
   const doctorStatusText=doctorAvailable
     ? 'Doctor result available. The generated prompt can include a compact summary, but the assistant should still run doctor first.'
     : 'No doctor result is available yet. Run Check Readiness first for a better session handoff.';
-  return '<div class="sub"><details'+(starterOpen?' open':'')+' id="aiSessionStarterDetails"><summary>Start AI Session</summary><p class="small">Use this after checking readiness. It creates a safe prompt for an AI assistant and stays local-only.</p><div class="hint-list"><div class="hint-item"><strong>Boundary</strong><p>The Local UI cannot load env vars into your already-open terminal. Use the helper commands below, then validate with Doctor.</p></div><div class="hint-item"><strong>Safety</strong><p>Do not paste credentials into the goal. The prompt reminds the assistant to run Doctor first and follow <code>'+esc(String(metadata.authoritativeCatalogPath||'docs/tool-catalog.md'))+'</code>.</p></div></div><div class="field-grid"><label>Profile Name<input id="aiSessionProfile" value="'+escAttr(String(state.profile||safeOptions.profile||'dev'))+'" placeholder="dev"></label><label>Environment Name (optional)<input id="aiSessionEnvironment" value="'+escAttr(String(state.environment||''))+'" placeholder="development"></label><label>Session Goal<textarea id="aiSessionGoal" placeholder="Analyze program ORDERPGM and summarize dependencies." maxlength="'+escAttr(String(goalMaxLength))+'">'+esc(String(state.goal||''))+'</textarea></label></div><div class="tokens"><div class="token">goal max: '+esc(String(goalMaxLength))+'</div><div class="token">template: '+esc(String(metadata.templateSource||'docs/ai/session-prompt.md'))+'</div>'+(mcpSummary?'<div class="token">MCP tools: '+esc(String(mcpSummary.toolCount||0))+'</div>':'')+'</div><div class="field-list"><div class="field-item"><strong>Env Loading Helper</strong><p>Choose the command for your shell. Loading env is process-scoped, so existing terminal sessions do not update automatically.</p><div class="preview"><pre>'+esc(powerShellCommand)+'\\n'+esc(bashCommand)+'</pre></div><p class="small">The Local UI server only sees env vars that were present when it started.</p></div><div class="field-item"><strong>Doctor Reminder</strong><p>'+esc(doctorStatusText)+'</p><div class="actions"><label><input id="aiSessionIncludeDoctorSummary" type="checkbox"'+(includeDoctorSummary?' checked':'')+(doctorAvailable?'':' disabled')+'> Include compact Doctor summary</label></div></div><div class="field-item"><strong>Capability Guidance</strong><p>Treat the tool catalog as authoritative and prefer evidence-first, read-only work before any higher-risk action.</p><div class="workflow-meta">'+starterCommands.map((command)=>'<div class="token">'+esc(command)+'</div>').join('')+'</div>'+(approvalRequiredCommands.length?'<p class="small">Approval required before: '+esc(approvalRequiredCommands.join(', '))+'.</p>':'')+(mcpSummary&&Array.isArray(mcpSummary.starterTools)&&mcpSummary.starterTools.length?'<p class="small">If MCP is available in the AI client, allowlisted Zeus tools may include: '+esc(mcpSummary.starterTools.join(', '))+'.</p>':'')+'</div></div><div class="actions"><button class="btn primary" data-ai-session-generate="1">'+esc(state.running?'Generating...':'Generate Session Prompt')+'</button><button class="btn" data-ai-session-copy="1">Copy Prompt</button></div>'+(state.error?'<div class="hint-list"><div class="hint-item"><strong>Prompt generation error</strong><p>'+esc(state.error)+'</p></div></div>':'')+(warnings.length?'<div class="hint-list">'+warnings.map((entry)=>'<div class="hint-item"><p>'+esc(String(entry))+'</p></div>').join('')+'</div>':'')+(state.copyStatus?'<div class="small '+esc(statusToneClass(state.copyStatus))+'">'+esc(state.copyStatus)+'</div>':'')+'<div class="preview">'+(promptText?'<textarea id="aiSessionPromptOutput" style="min-height:360px" readonly>'+esc(promptText)+'</textarea>':'<div class="empty">Generate a session prompt here after Setup and Doctor are ready.</div>')+'</div></details></div>';
+  return '<div class="sub"><details'+(starterOpen?' open':'')+' id="aiSessionStarterDetails"><summary>Start AI Session</summary><p class="small">Use this after checking readiness. It creates a safe prompt for an AI assistant and stays local-only.</p>'+
+    renderHintList([
+      { title:'Boundary', body:'The Local UI cannot load env vars into your already-open terminal. Use the helper commands below, then validate with Doctor.' },
+      { title:'Safety', bodyHtml:'Do not paste credentials into the goal. The prompt reminds the assistant to run Doctor first and follow <code>'+esc(String(metadata.authoritativeCatalogPath||'docs/tool-catalog.md'))+'</code>.' }
+    ])+
+    '<div class="field-grid"><label>Profile Name<input id="aiSessionProfile" value="'+escAttr(String(state.profile||safeOptions.profile||'dev'))+'" placeholder="dev"></label><label>Environment Name (optional)<input id="aiSessionEnvironment" value="'+escAttr(String(state.environment||''))+'" placeholder="development"></label><label>Session Goal<textarea id="aiSessionGoal" placeholder="Analyze program ORDERPGM and summarize dependencies." maxlength="'+escAttr(String(goalMaxLength))+'">'+esc(String(state.goal||''))+'</textarea></label></div>'+
+    renderTokenRow([
+      'goal max: '+String(goalMaxLength),
+      'template: '+String(metadata.templateSource||'docs/ai/session-prompt.md'),
+      mcpSummary?'MCP tools: '+String(mcpSummary.toolCount||0):null
+    ],'tokens')+
+    '<div class="field-list"><div class="field-item"><strong>Env Loading Helper</strong><p>Choose the command for your shell. Loading env is process-scoped, so existing terminal sessions do not update automatically.</p><div class="preview"><pre>'+esc(powerShellCommand)+'\\n'+esc(bashCommand)+'</pre></div><p class="small">The Local UI server only sees env vars that were present when it started.</p></div><div class="field-item"><strong>Doctor Reminder</strong><p>'+esc(doctorStatusText)+'</p><div class="actions"><label><input id="aiSessionIncludeDoctorSummary" type="checkbox"'+(includeDoctorSummary?' checked':'')+(doctorAvailable?'':' disabled')+'> Include compact Doctor summary</label></div></div><div class="field-item"><strong>Capability Guidance</strong><p>Treat the tool catalog as authoritative and prefer evidence-first, read-only work before any higher-risk action.</p>'+renderTokenRow(starterCommands,'workflow-meta')+(approvalRequiredCommands.length?'<p class="small">Approval required before: '+esc(approvalRequiredCommands.join(', '))+'.</p>':'')+(mcpSummary&&Array.isArray(mcpSummary.starterTools)&&mcpSummary.starterTools.length?'<p class="small">If MCP is available in the AI client, allowlisted Zeus tools may include: '+esc(mcpSummary.starterTools.join(', '))+'.</p>':'')+'</div></div><div class="actions"><button class="btn primary" data-ai-session-generate="1">'+esc(state.running?'Generating...':'Generate Session Prompt')+'</button><button class="btn" data-ai-session-copy="1">Copy Prompt</button></div>'+
+    (state.error?renderHintList([{ title:'Prompt generation error', body:String(state.error) }]):'')+
+    (warnings.length?renderHintList(warnings.map((entry)=>({ body:String(entry) }))):'')+
+    (state.copyStatus?'<div class="small '+esc(statusToneClass(state.copyStatus))+'">'+esc(state.copyStatus)+'</div>':'')+
+    '<div class="preview">'+(promptText?'<textarea id="aiSessionPromptOutput" style="min-height:360px" readonly>'+esc(promptText)+'</textarea>':'<div class="empty">Generate a session prompt here after Setup and Doctor are ready.</div>')+'</div></details></div>';
 }
 
 function renderProfileWizardPanel(){

--- a/src/ui/localUiShell.js
+++ b/src/ui/localUiShell.js
@@ -903,6 +903,13 @@ function metadataFields(){
   return fields.length>0?fields:[];
 }
 
+function setupMetadata(){
+  const payload=s.uiMetadata&&s.uiMetadata.payload;
+  return payload&&payload.setup&&typeof payload.setup==='object'
+    ? payload.setup
+    : null;
+}
+
 function guidedConfiguration(){
   const payload=s.uiMetadata&&s.uiMetadata.payload;
   return payload&&payload.guidedConfiguration&&typeof payload.guidedConfiguration==='object'
@@ -1528,6 +1535,7 @@ function preferredProfileWizardDoctorProfile(){
 
 function renderConfigureStartPanel(options){
   const safeOptions=options&&typeof options==='object'?options:{};
+  const setupMeta=setupMetadata()||{};
   const draft=safeOptions.draft&&typeof safeOptions.draft==='object'?safeOptions.draft:ensureProfileWizardDraft();
   const signals=safeOptions.signals&&typeof safeOptions.signals==='object'?safeOptions.signals:evaluateProfileWizardDraft();
   const previewFreshness=safeOptions.previewFreshness&&typeof safeOptions.previewFreshness==='object'
@@ -1582,29 +1590,45 @@ function renderConfigureStartPanel(options){
     : (draftSavedSummary
       ? 'This draft name matches an existing saved profile, but no profile is currently loaded for doctor yet.'
       : 'The browser edits local-only config only. It does not apply unsaved drafts to doctor.');
+  const precedenceRules=Array.isArray(setupMeta.precedenceRules)&&setupMeta.precedenceRules.length
+    ? setupMeta.precedenceRules
+    : ['CLI overrides env.','Env overrides profile.','Profile overrides defaults.'];
+  const precedenceSummary='CLI overrides env. Env overrides profile. Profile overrides defaults.';
+  const boundaryNotes=Array.isArray(setupMeta.boundaryNotes)&&setupMeta.boundaryNotes.length
+    ? setupMeta.boundaryNotes
+    : ['This screen only edits local-only config and placeholder-based environment routing.','It does not expose secrets and it does not connect to IBM i or DB2 here.'];
+  const recommendedNextTokens=Array.isArray(setupMeta.recommendedNextTokens)&&setupMeta.recommendedNextTokens.length
+    ? setupMeta.recommendedNextTokens
+    : ['setup focus','doctor uses effective config','warnings do not auto-abort'];
+  const doctorStatusGuidance=setupMeta.doctorStatusGuidance&&typeof setupMeta.doctorStatusGuidance==='object'
+    ? setupMeta.doctorStatusGuidance
+    : {};
+  const doctorActionLabel=setupMeta.primaryAction&&setupMeta.primaryAction.label
+    ? String(setupMeta.primaryAction.label)
+    : 'Check Readiness';
   let recommendedNext='Choose or load a profile and fill the required path fields first.';
   if(doctorState.running){
-    recommendedNext='Wait for Check Readiness to finish.';
+    recommendedNext=String(doctorStatusGuidance.running||'Wait for Check Readiness to finish.');
   }else if(doctorState.error){
-    recommendedNext='Review the readiness error, then try Check Readiness again.';
+    recommendedNext=String(doctorStatusGuidance.error||'Review the readiness error, then try Check Readiness again.');
   }else if(doctorResult&&doctorResult.status==='ready'){
-    recommendedNext='Setup looks ready. Continue to Reports when output exists, or use Advanced / Tools if you need local-only analysis or prompt work.';
+    recommendedNext=String(doctorStatusGuidance.ready||'Setup looks ready. Continue to Reports when output exists, or use Advanced / Tools if you need local-only analysis or prompt work.');
   }else if(doctorResult&&doctorResult.status==='warning'){
-    recommendedNext='Review the warning cards below. Env vars may be changing the effective target even when the saved profile looks correct.';
+    recommendedNext=String(doctorStatusGuidance.warning||'Review the warning cards below. Env vars may be changing the effective target even when the saved profile looks correct.');
   }else if(doctorResult&&doctorResult.status==='failed'){
-    recommendedNext='Resolve the failed doctor checks before moving on.';
+    recommendedNext=String(doctorStatusGuidance.failed||'Resolve the failed doctor checks before moving on.');
   }else if(signals.canSave){
     recommendedNext='Save the current draft if needed, then run Check Readiness.';
   }else if(signals.canPreview){
     recommendedNext='Run Preview Draft next, then save locally before Check Readiness.';
   }
-  return '<div class="sub"><h2>Setup</h2><p>Use Setup as a simple 3-step path: choose or create a profile, preview and save it locally, then run Zeus Doctor.</p><div class="hint-list"><div class="hint-item"><strong>Browser safety</strong><p>This screen only edits local-only config and placeholder-based environment routing. It does not expose secrets and it does not connect to IBM i or DB2 here.</p></div><div class="hint-item"><strong>Resolution order</strong><p>CLI overrides env. Env overrides profile. Profile overrides defaults. Doctor checks the effective configuration after those rules are applied.</p></div></div><div class="field-list">'+
-    '<div class="field-item"><strong>Recommended Next Step</strong><p>'+esc(recommendedNext)+'</p><div class="workflow-meta"><div class="token">setup focus</div><div class="token">doctor uses effective config</div><div class="token">warnings do not auto-abort</div></div></div>'+
+  return '<div class="sub"><h2>'+esc(String(setupMeta.title||'Setup'))+'</h2><p>Use Setup as a simple 3-step path: choose or create a profile, preview and save it locally, then run Zeus Doctor.</p><div class="hint-list"><div class="hint-item"><strong>Browser safety</strong><p>'+esc(boundaryNotes.join(' '))+'</p></div><div class="hint-item"><strong>Resolution order</strong><p>'+esc(precedenceRules.length?precedenceRules.join(' '):precedenceSummary)+' Doctor checks the effective configuration after those rules are applied.</p></div></div><div class="field-list">'+
+    '<div class="field-item"><strong>Recommended Next Step</strong><p>'+esc(recommendedNext)+'</p><div class="workflow-meta">'+recommendedNextTokens.map((token)=>'<div class="token">'+esc(String(token))+'</div>').join('')+'</div></div>'+
     '<div class="field-item"><strong>1. Choose Or Create A Profile</strong><p>'+esc(stepOneStatus)+'</p><div class="workflow-meta"><div class="token">known profiles: '+esc(String(profiles.length))+'</div><div class="token">local-only: '+esc(String(localOnlyProfiles.length))+'</div><div class="token">managed envs: '+esc(String(managedSystems.length))+'</div></div><p class="small">Selected profile source and local-only overlays are shown here, but secret values are never displayed.</p><div class="actions"><button class="btn" data-pw-refresh="1">Reload Wizard State</button><button class="btn primary" data-pw-new="1">New Local Draft</button><button class="btn" data-pw-load="1">Load Selected Profile</button></div></div>'+
     '<div class="field-item"><strong>Environment Override Explanation</strong><p>Environment variables can change the effective target even when the saved profile looks correct.</p><div class="workflow-meta">'+routingTokens.map(([label,value])=>'<div class="token">'+esc(label+': '+value)+'</div>').join('')+'</div><p class="small">Examples: <code>ZEUS_DB_HOST</code> can override <code>db.host</code>. Secret env vars may exist, but their values are never shown here.</p></div>'+
     '<div class="field-item"><strong>Config Metadata Overview</strong><p>'+esc(String(configSectionCount))+' setup sections and '+esc(String(configFields.length))+' documented fields are available in this UI payload.</p><div class="workflow-meta"><div class="token">sensitive fields: '+esc(String(configSensitiveCount))+'</div><div class="token">read-only metadata</div><div class="token">no resolved values</div></div><p class="small">Use the metadata section below to understand which fields can be set by profile or env without exposing runtime secrets.</p></div>'+
     '<div class="field-item"><strong>2. Preview And Save Locally</strong><p>'+esc(stepTwoStatus)+'</p><div class="workflow-meta"><div class="token '+esc(statusToneClass(previewStatus))+'">'+esc(previewStatus)+'</div>'+(draftProfileName?'<div class="token">draft: '+esc(draftProfileName)+'</div>':'<div class="token">draft name missing</div>')+(selectedProfileSummary?'<div class="token">loaded source: '+esc(String(selectedProfileSummary.sourceKind||'shared'))+'</div>':'')+'</div><div class="actions"><button class="btn" data-pw-preview="1">Preview Draft</button><button class="btn primary" data-pw-save="1">Save Local-only</button></div></div>'+
-    '<div class="field-item"><strong>3. Run Zeus Doctor</strong><p>'+esc(doctorStatus)+'</p><div class="workflow-meta"><div class="token">doctor target: '+esc(doctorProfile)+'</div>'+(doctorProfileSummary?'<div class="token">source: '+esc(String(doctorProfileSummary.sourceKind||'shared'))+'</div>':'<div class="token">save required</div>')+(doctorState&&doctorState.result?'<div class="token">result available</div>':'')+'</div><p class="small">'+esc(doctorHint)+'</p><div class="actions"><button class="btn primary" data-config-doctor="1">Check Readiness</button><button class="btn" data-config-refresh="1">Refresh Metadata</button></div></div>'+
+    '<div class="field-item"><strong>3. Run Zeus Doctor</strong><p>'+esc(doctorStatus)+'</p><div class="workflow-meta"><div class="token">doctor target: '+esc(doctorProfile)+'</div>'+(doctorProfileSummary?'<div class="token">source: '+esc(String(doctorProfileSummary.sourceKind||'shared'))+'</div>':'<div class="token">save required</div>')+(doctorState&&doctorState.result?'<div class="token">result available</div>':'')+'</div><p class="small">'+esc(doctorHint)+'</p><div class="actions"><button class="btn primary" data-config-doctor="1">'+esc(doctorActionLabel)+'</button><button class="btn" data-config-refresh="1">Refresh Metadata</button></div></div>'+
   '</div></div>';
 }
 

--- a/src/ui/localUiShell.js
+++ b/src/ui/localUiShell.js
@@ -580,6 +580,17 @@ const s={
       running:false,
       error:null,
       result:null
+    },
+    aiSession:{
+      profile:'dev',
+      environment:'',
+      goal:'',
+      includeDoctorSummary:false,
+      running:false,
+      error:null,
+      result:null,
+      copyStatus:'',
+      expanded:false
     }
   },
   profileWizard:{
@@ -923,6 +934,13 @@ function profileWizardMetadata(){
   const payload=s.uiMetadata&&s.uiMetadata.payload;
   return payload&&payload.profileWizard&&typeof payload.profileWizard==='object'
     ? payload.profileWizard
+    : null;
+}
+
+function aiSessionStarterMetadata(){
+  const payload=s.uiMetadata&&s.uiMetadata.payload;
+  return payload&&payload.aiSessionStarter&&typeof payload.aiSessionStarter==='object'
+    ? payload.aiSessionStarter
     : null;
 }
 
@@ -1590,6 +1608,62 @@ function renderConfigureStartPanel(options){
   '</div></div>';
 }
 
+function buildAiSessionDoctorSummaryPayload(doctorResult){
+  if(!doctorResult||typeof doctorResult!=='object') return null;
+  const summary=doctorResult.result&&doctorResult.result.summary&&typeof doctorResult.result.summary==='object'
+    ? doctorResult.result.summary
+    : null;
+  return {
+    status:String(doctorResult.status||'').trim()||'unknown',
+    summary:summary?{
+      total:Number(summary.total||0),
+      pass:Number(summary.pass||0),
+      fail:Number(summary.fail||0),
+      warn:Number(summary.warn||0),
+      info:Number(summary.info||0),
+      skip:Number(summary.skip||0)
+    }:null,
+    finishedAt:doctorResult.finishedAt||null
+  };
+}
+
+function renderAiSessionStarterPanel(options){
+  const safeOptions=options&&typeof options==='object'?options:{};
+  const metadata=safeOptions.metadata&&typeof safeOptions.metadata==='object'
+    ? safeOptions.metadata
+    : (aiSessionStarterMetadata()||{});
+  const state=safeOptions.state&&typeof safeOptions.state==='object'?safeOptions.state:(s.uiActions.aiSession||{});
+  const doctorResult=safeOptions.doctorResult&&typeof safeOptions.doctorResult==='object'?safeOptions.doctorResult:null;
+  const doctorAvailable=Boolean(doctorResult);
+  const includeDoctorSummary=doctorAvailable
+    ? state.includeDoctorSummary!==false
+    : false;
+  const starterOpen=Boolean(state.expanded||state.running||state.error||(state.result&&state.result.prompt));
+  const goalMaxLength=Number(metadata.goalMaxLength||4000);
+  const promptText=state.result&&state.result.prompt?String(state.result.prompt):'';
+  const warnings=state.result&&Array.isArray(state.result.warnings)?state.result.warnings:[];
+  const envLoading=metadata.envLoading&&typeof metadata.envLoading==='object'?metadata.envLoading:{};
+  const powerShellCommand=envLoading.powerShell&&envLoading.powerShell.command
+    ? String(envLoading.powerShell.command)
+    : '. .\\config\\load-env.ps1 -Environment <environment>';
+  const bashCommand=envLoading.bash&&envLoading.bash.command
+    ? String(envLoading.bash.command)
+    : 'source ./config/load-env.sh <environment>';
+  const mcpSummary=metadata.capabilityGuidance&&metadata.capabilityGuidance.mcp&&typeof metadata.capabilityGuidance.mcp==='object'
+    ? metadata.capabilityGuidance.mcp
+    : null;
+  const starterCommands=metadata.capabilityGuidance&&Array.isArray(metadata.capabilityGuidance.starterCommands)
+    ? metadata.capabilityGuidance.starterCommands
+    : [];
+  const approvalRequiredCommands=metadata.capabilityGuidance&&Array.isArray(metadata.capabilityGuidance.approvalRequiredCommands)
+    ? metadata.capabilityGuidance.approvalRequiredCommands
+    : [];
+  const doctorStatusText=doctorAvailable
+    ? 'Doctor result available. The generated prompt can include a compact summary, but the assistant should still run doctor first.'
+    : 'No doctor result is available yet. Run Check Readiness first for a better session handoff.';
+  return '<div class="sub"><details'+(starterOpen?' open':'')+' id="aiSessionStarterDetails"><summary>Start AI Session</summary><p class="small">Use this after checking readiness. It creates a safe prompt for an AI assistant and stays local-only.</p><div class="hint-list"><div class="hint-item"><strong>Boundary</strong><p>The Local UI cannot load env vars into your already-open terminal. Use the helper commands below, then validate with Doctor.</p></div><div class="hint-item"><strong>Safety</strong><p>Do not paste credentials into the goal. The prompt reminds the assistant to run Doctor first and follow <code>'+esc(String(metadata.authoritativeCatalogPath||'docs/tool-catalog.md'))+'</code>.</p></div></div><div class="field-grid"><label>Profile Name<input id="aiSessionProfile" value="'+escAttr(String(state.profile||safeOptions.profile||'dev'))+'" placeholder="dev"></label><label>Environment Name (optional)<input id="aiSessionEnvironment" value="'+escAttr(String(state.environment||''))+'" placeholder="development"></label><label>Session Goal<textarea id="aiSessionGoal" placeholder="Analyze program ORDERPGM and summarize dependencies." maxlength="'+escAttr(String(goalMaxLength))+'">'+esc(String(state.goal||''))+'</textarea></label></div><div class="tokens"><div class="token">goal max: '+esc(String(goalMaxLength))+'</div><div class="token">template: '+esc(String(metadata.templateSource||'docs/ai/session-prompt.md'))+'</div>'+(mcpSummary?'<div class="token">MCP tools: '+esc(String(mcpSummary.toolCount||0))+'</div>':'')+'</div><div class="field-list"><div class="field-item"><strong>Env Loading Helper</strong><p>Choose the command for your shell. Loading env is process-scoped, so existing terminal sessions do not update automatically.</p><div class="preview"><pre>'+esc(powerShellCommand)+'\\n'+esc(bashCommand)+'</pre></div><p class="small">The Local UI server only sees env vars that were present when it started.</p></div><div class="field-item"><strong>Doctor Reminder</strong><p>'+esc(doctorStatusText)+'</p><div class="actions"><label><input id="aiSessionIncludeDoctorSummary" type="checkbox"'+(includeDoctorSummary?' checked':'')+(doctorAvailable?'':' disabled')+'> Include compact Doctor summary</label></div></div><div class="field-item"><strong>Capability Guidance</strong><p>Treat the tool catalog as authoritative and prefer evidence-first, read-only work before any higher-risk action.</p><div class="workflow-meta">'+starterCommands.map((command)=>'<div class="token">'+esc(command)+'</div>').join('')+'</div>'+(approvalRequiredCommands.length?'<p class="small">Approval required before: '+esc(approvalRequiredCommands.join(', '))+'.</p>':'')+(mcpSummary&&Array.isArray(mcpSummary.starterTools)&&mcpSummary.starterTools.length?'<p class="small">If MCP is available in the AI client, allowlisted Zeus tools may include: '+esc(mcpSummary.starterTools.join(', '))+'.</p>':'')+'</div></div><div class="actions"><button class="btn primary" data-ai-session-generate="1">'+esc(state.running?'Generating...':'Generate Session Prompt')+'</button><button class="btn" data-ai-session-copy="1">Copy Prompt</button></div>'+(state.error?'<div class="hint-list"><div class="hint-item"><strong>Prompt generation error</strong><p>'+esc(state.error)+'</p></div></div>':'')+(warnings.length?'<div class="hint-list">'+warnings.map((entry)=>'<div class="hint-item"><p>'+esc(String(entry))+'</p></div>').join('')+'</div>':'')+(state.copyStatus?'<div class="small '+esc(statusToneClass(state.copyStatus))+'">'+esc(state.copyStatus)+'</div>':'')+'<div class="preview">'+(promptText?'<textarea id="aiSessionPromptOutput" style="min-height:360px" readonly>'+esc(promptText)+'</textarea>':'<div class="empty">Generate a session prompt here after Setup and Doctor are ready.</div>')+'</div></details></div>';
+}
+
 function renderProfileWizardPanel(){
   const state=profileWizardState();
   const draft=ensureProfileWizardDraft();
@@ -2139,10 +2213,19 @@ function renderConfigure(){
       .join('\\n')
     : '';
   const doctorDiagnosticsPanel=renderDoctorDiagnostics(doctorResult);
+  const aiSessionState=s.uiActions.aiSession||{};
   const discoveryState=s.uiActions.discovery||{};
   const discoveryResult=discoveryState.result;
   const selectedDiscoveryActionId=String(discoveryState.actionId||((discoveryActions[0]&&discoveryActions[0].id)||'discover-source-libraries'));
   const profileForWizard=String(doctorState.profile||discoveryState.profile||preferredProfileWizardDoctorProfile()).trim()||'dev';
+  if(!String(aiSessionState.profile||'').trim()){
+    aiSessionState.profile=profileForWizard;
+  }
+  if(!doctorResult){
+    aiSessionState.includeDoctorSummary=false;
+  }else if(aiSessionState.result===null&&aiSessionState.error===null&&String(aiSessionState.goal||'').trim()===''){
+    aiSessionState.includeDoctorSummary=true;
+  }
   const wizardDetailsOpen=Boolean(
     s.profileWizard.loading
     || s.profileWizard.previewing
@@ -2172,6 +2255,12 @@ function renderConfigure(){
     doctorDiagnosticsPanel+
     (doctorDetails?'<details><summary>Show checks</summary><div class="preview"><pre>'+esc(doctorDetails)+'</pre></div></details>':'')+
     '</div>'+
+    renderAiSessionStarterPanel({
+      metadata:aiSessionStarterMetadata(),
+      state:aiSessionState,
+      profile:profileForWizard,
+      doctorResult
+    })+
     '<div class="sub"><details'+(wizardDetailsOpen?' open':'')+'><summary>Local-only Profile Wizard</summary><p class="small">Use this only when you need to create or adjust the local-only profile overlay that Setup and Doctor rely on.</p>'+renderProfileWizardPanel()+'</details></div>'+
     '<div class="sub"><h2>Advanced Setup Details</h2><p class="small">These sections explain the metadata-driven wizard model and read-only preview stubs. They are optional once the main setup flow is clear.</p><details'+(discoveryResult||discoveryState.error?' open':'')+'><summary>Read-only Discovery Actions</summary><div class="stack"><div class="field-list">'+(discoveryActions.length?discoveryActions.map((action)=>'<div class="field-item"><strong>'+esc(action.title)+'</strong><p>'+esc(action.description||'')+'</p><div class="workflow-meta"><div class="token">safety: '+esc(action.safetyLevel||'S2')+'</div><div class="token">'+esc(action.status||'stubbed-preview-only')+'</div><div class="token">'+esc(action.expensive?'preview first':'read-only')+'</div></div><div class="actions"><button class="btn" data-discovery-preview="'+esc(action.id)+'">'+esc(String(action.status||'').indexOf('config-preview-ready')===0?'Preview':'Preview Stub')+'</button></div></div>').join(''):'<div class="empty">No discovery actions available.</div>')+'</div>'+(discoveryState.error?'<div class="hint-list"><div class="hint-item"><strong>Discovery preview error</strong><p>'+esc(discoveryState.error)+'</p></div></div>':'')+renderGuidedDiscoveryPreview(discoveryResult)+'</div></details><details><summary>Safe CLI Preview</summary><p class="small">Generated from the selected intent. Secrets are never included.</p><div class="field-grid"><label>Analysis Intent<select id="guidedIntentSelect">'+intents.map((intent)=>'<option value="'+escAttr(intent.id)+'"'+(selectedIntent&&intent.id===selectedIntent.id?' selected':'')+'>'+esc(intent.title)+'</option>').join('')+'</select></label></div>'+renderGuidedCliPreview(selectedIntent,profileForWizard)+'</details><details><summary>Guided Wizard Metadata</summary><div class="tokens"><div class="token">'+esc(statusLine)+'</div><div class="token">Wizard steps: '+esc(String(steps.length||0))+'</div><div class="token">Intents: '+esc(String(intents.length||0))+'</div><div class="token">Purpose labels: '+esc(String(guided&&guided.purposeLabels&&guided.purposeLabels.length||0))+'</div></div><div class="section-list">'+steps.map((step)=>'<button class="btn section-btn'+(selectedStep&&step.id===selectedStep.id?' active':'')+'" data-guided-step="'+esc(step.id)+'">'+esc(step.shortTitle||step.title)+'</button>').join('')+'</div><div class="configure-layout"><div class="section-list">'+
       sections.map((section)=>'<button class="btn section-btn'+(section.id===s.uiMetadata.selectedConfigSection?' active':'')+'" data-config-section="'+esc(section.id)+'">'+esc(section.label||section.id)+'</button>').join('')+
@@ -2344,6 +2433,25 @@ function renderConfigure(){
       const nextValue=String(event.target.value||'').trim();
       s.uiActions.doctor.profile=nextValue;
       s.uiActions.discovery.profile=nextValue;
+      s.uiActions.aiSession.profile=nextValue;
+    };
+  }
+  const aiSessionDetails=root.querySelector('#aiSessionStarterDetails');
+  if(aiSessionDetails){
+    aiSessionDetails.ontoggle=()=>{
+      s.uiActions.aiSession.expanded=aiSessionDetails.open;
+    };
+  }
+  bindInput('#aiSessionProfile',(value)=>{ s.uiActions.aiSession.profile=value.trim(); });
+  bindInput('#aiSessionEnvironment',(value)=>{ s.uiActions.aiSession.environment=value.trim(); });
+  bindInput('#aiSessionGoal',(value)=>{
+    s.uiActions.aiSession.goal=value;
+    s.uiActions.aiSession.copyStatus='';
+  });
+  const aiSessionDoctorSummary=root.querySelector('#aiSessionIncludeDoctorSummary');
+  if(aiSessionDoctorSummary){
+    aiSessionDoctorSummary.onchange=(event)=>{
+      s.uiActions.aiSession.includeDoctorSummary=Boolean(event.target.checked);
     };
   }
   const intentSelect=root.querySelector('#guidedIntentSelect');
@@ -2392,9 +2500,21 @@ function renderConfigure(){
         const nextValue=String(profileInput.value||'').trim()||'dev';
         s.uiActions.doctor.profile=nextValue;
         s.uiActions.discovery.profile=nextValue;
+        s.uiActions.aiSession.profile=nextValue;
       }
       await runDoctorReadinessAction();
       renderConfigure();
+    };
+  }
+  for(const generateButton of root.querySelectorAll('[data-ai-session-generate]')){
+    generateButton.onclick=async ()=>{
+      await runGenerateAiSessionPromptAction();
+      renderConfigure();
+    };
+  }
+  for(const copyButton of root.querySelectorAll('[data-ai-session-copy]')){
+    copyButton.onclick=async ()=>{
+      await copyAiSessionPrompt();
     };
   }
   for(const refreshButton of root.querySelectorAll('[data-config-refresh]')){
@@ -2995,6 +3115,20 @@ function setPreviewEditMode(editable){
   renderWorkbench();
 }
 
+async function copyTextToClipboard(text){
+  if(navigator&&navigator.clipboard&&navigator.clipboard.writeText){
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const area=document.createElement('textarea');
+  area.value=text;
+  document.body.appendChild(area);
+  area.focus();
+  area.select();
+  document.execCommand('copy');
+  document.body.removeChild(area);
+}
+
 async function copyWorkbenchPreview(){
   const text=currentPreviewText();
   if(!text){
@@ -3003,22 +3137,61 @@ async function copyWorkbenchPreview(){
     return;
   }
   try {
-    if(navigator&&navigator.clipboard&&navigator.clipboard.writeText){
-      await navigator.clipboard.writeText(text);
-    } else {
-      const area=document.createElement('textarea');
-      area.value=text;
-      document.body.appendChild(area);
-      area.focus();
-      area.select();
-      document.execCommand('copy');
-      document.body.removeChild(area);
-    }
+    await copyTextToClipboard(text);
     s.promptBuilder.saveStatus='Preview copied.';
   } catch(error){
     s.promptBuilder.saveStatus=workbenchUserError('Could not copy the preview',error);
   }
   renderWorkbench();
+}
+
+async function runGenerateAiSessionPromptAction(){
+  const profile=String(s.uiActions.aiSession.profile||s.uiActions.doctor.profile||'dev').trim()||'dev';
+  const environment=String(s.uiActions.aiSession.environment||'').trim();
+  const goal=String(s.uiActions.aiSession.goal||'').trim();
+  const doctorResult=s.uiActions.doctor&&s.uiActions.doctor.result&&typeof s.uiActions.doctor.result==='object'
+    ? s.uiActions.doctor.result
+    : null;
+  const includeDoctorSummary=Boolean(doctorResult&&s.uiActions.aiSession.includeDoctorSummary!==false);
+  const doctorSummary=includeDoctorSummary?buildAiSessionDoctorSummaryPayload(doctorResult):null;
+  s.uiActions.aiSession.running=true;
+  s.uiActions.aiSession.error=null;
+  s.uiActions.aiSession.copyStatus='';
+  s.uiActions.aiSession.expanded=true;
+  try{
+    const payload={
+      profile,
+      goal,
+      includeDoctorSummary
+    };
+    if(environment) payload.environment=environment;
+    if(doctorSummary) payload.doctorSummary=doctorSummary;
+    const result=await sendJson('POST','/api/ui-actions/generate-ai-session-prompt',payload);
+    s.uiActions.aiSession.result=result;
+  }catch(error){
+    s.uiActions.aiSession.error=error.message||String(error);
+    s.uiActions.aiSession.result=null;
+  }finally{
+    s.uiActions.aiSession.running=false;
+  }
+}
+
+async function copyAiSessionPrompt(){
+  const text=s.uiActions.aiSession&&s.uiActions.aiSession.result&&s.uiActions.aiSession.result.prompt
+    ? String(s.uiActions.aiSession.result.prompt)
+    : '';
+  if(!text){
+    s.uiActions.aiSession.copyStatus='No session prompt is available to copy yet.';
+    renderConfigure();
+    return;
+  }
+  try{
+    await copyTextToClipboard(text);
+    s.uiActions.aiSession.copyStatus='Session prompt copied.';
+  }catch(error){
+    s.uiActions.aiSession.copyStatus='Could not copy the session prompt.';
+  }
+  renderConfigure();
 }
 
 function exportWorkbenchPreview(){

--- a/src/ui/uiMetadataService.js
+++ b/src/ui/uiMetadataService.js
@@ -155,6 +155,56 @@ const PROFILE_WIZARD_METADATA = Object.freeze({
   ]),
 });
 
+function buildSetupMetadata() {
+  return {
+    schemaVersion: 1,
+    title: 'Setup',
+    summary: 'Use Setup as the primary local onboarding path before Reports or Advanced / Tools.',
+    primaryAction: {
+      label: 'Check Readiness',
+      actionPath: '/api/ui-actions/doctor',
+    },
+    steps: [
+      {
+        id: 'choose-profile',
+        title: 'Choose Or Create A Profile',
+        description: 'Review shared profiles or prepare a local-only overlay before running Doctor.',
+      },
+      {
+        id: 'preview-save',
+        title: 'Preview And Save Locally',
+        description: 'Preview local-only changes and save them before relying on them in Doctor.',
+      },
+      {
+        id: 'doctor',
+        title: 'Run Zeus Doctor',
+        description: 'Validate the effective runtime config after CLI, env, and profile precedence are applied.',
+      },
+    ],
+    precedenceRules: [
+      'CLI overrides env.',
+      'Env overrides profile.',
+      'Profile overrides defaults.',
+    ],
+    boundaryNotes: [
+      'This screen only edits local-only config and placeholder-based environment routing.',
+      'It does not expose secrets and it does not connect to IBM i or DB2 here.',
+    ],
+    recommendedNextTokens: [
+      'setup focus',
+      'doctor uses effective config',
+      'warnings do not auto-abort',
+    ],
+    doctorStatusGuidance: {
+      ready: 'Setup looks ready. Continue to Reports when output exists, or use Advanced / Tools if you need local-only analysis or prompt work.',
+      warning: 'Review the warning cards below. Env vars may be changing the effective target even when the saved profile looks correct.',
+      failed: 'Resolve the failed doctor checks before moving on.',
+      error: 'Review the readiness error, then try Check Readiness again.',
+      running: 'Wait for Check Readiness to finish.',
+    },
+  };
+}
+
 function buildAiSessionStarterMetadata() {
   const mcpTools = listMcpTools();
   const starterToolNames = [
@@ -266,6 +316,7 @@ function buildUiMetadataPayload() {
       sections: CONFIG_UI_SECTIONS,
       fields: listConfigUiFields({ includeSensitive: true }),
     },
+    setup: buildSetupMetadata(),
     guidedConfiguration: buildGuidedConfigurationPayload({
       configFields: listConfigUiFields({ includeSensitive: true }),
     }),

--- a/src/ui/uiMetadataService.js
+++ b/src/ui/uiMetadataService.js
@@ -21,6 +21,11 @@ const {
   COMMAND_CATEGORIES,
   listCommandUiMetadata,
 } = require('../cli/commandMetadata');
+const { listMcpTools } = require('../mcp/mcpTools');
+const {
+  AI_SESSION_GOAL_MAX_LENGTH,
+  AI_SESSION_PROMPT_TEMPLATE_PATH,
+} = require('./aiSessionPromptService');
 const { buildGuidedConfigurationPayload } = require('./guidedConfigWizardModel');
 
 const UI_METADATA_SCHEMA_VERSION = 1;
@@ -150,6 +155,72 @@ const PROFILE_WIZARD_METADATA = Object.freeze({
   ]),
 });
 
+function buildAiSessionStarterMetadata() {
+  const mcpTools = listMcpTools();
+  const starterToolNames = [
+    'zeus.doctor',
+    'zeus.search-source',
+    'zeus.analyze',
+    'zeus.workflow',
+    'zeus.query-table',
+    'zeus.query-sql',
+    'zeus.bundle',
+  ].filter((name) => mcpTools.some((tool) => tool && tool.name === name));
+
+  return {
+    schemaVersion: 1,
+    title: 'Start AI Session',
+    templateSource: AI_SESSION_PROMPT_TEMPLATE_PATH,
+    actionPath: '/api/ui-actions/generate-ai-session-prompt',
+    goalMaxLength: AI_SESSION_GOAL_MAX_LENGTH,
+    authoritativeCatalogPath: 'docs/tool-catalog.md',
+    envLoading: {
+      powerShell: {
+        label: 'Windows PowerShell',
+        command: '. .\\config\\load-env.ps1 -Environment <environment>',
+      },
+      bash: {
+        label: 'Bash',
+        command: 'source ./config/load-env.sh <environment>',
+      },
+    },
+    reminders: [
+      'Environment variables are shell-scoped. The Local UI cannot load env vars into an already-open terminal session.',
+      'The Local UI server only sees env vars that were present when it started.',
+      'Run Doctor first to validate the effective runtime config before asking an AI assistant to do deeper work.',
+      'Do not paste credentials, secret env values, or full credential-bearing JDBC URLs into the goal.',
+    ],
+    capabilityGuidance: {
+      starterCommands: [
+        'doctor',
+        'profiles',
+        'search-source',
+        'analyze',
+        'workflow run',
+        'query-table',
+        'query-sql',
+        'impact',
+        'bundle',
+      ],
+      approvalRequiredCommands: [
+        'write-sql',
+        'upsert',
+        'upsert-sql',
+        'insert',
+        'update',
+        'delete',
+        'bridge',
+      ],
+      mcp: {
+        available: mcpTools.length > 0,
+        toolCount: mcpTools.length,
+        starterTools: starterToolNames,
+        note: 'Use allowlisted Zeus MCP tools if the AI client exposes them. Do not invent Zeus MCP tool names or unsupported capabilities.',
+      },
+    },
+  };
+}
+
 function deriveWorkflowCards(commandEntries = listCommandUiMetadata()) {
   return WORKFLOW_CARD_DEFINITIONS.map((definition) => {
     const matchingCommands = commandEntries.filter((entry) => entry.category === definition.category);
@@ -198,6 +269,7 @@ function buildUiMetadataPayload() {
     guidedConfiguration: buildGuidedConfigurationPayload({
       configFields: listConfigUiFields({ includeSensitive: true }),
     }),
+    aiSessionStarter: buildAiSessionStarterMetadata(),
     profileWizard: PROFILE_WIZARD_METADATA,
     commands: {
       categories: COMMAND_CATEGORIES,

--- a/tests/ai-session-prompt-service.test.js
+++ b/tests/ai-session-prompt-service.test.js
@@ -1,0 +1,108 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  AI_SESSION_PROMPT_PLACEHOLDER,
+  AiSessionPromptError,
+  createAiSessionPromptService,
+  extractSessionPromptTemplate,
+} = require('../src/ui/aiSessionPromptService');
+
+function buildTemplate(body = AI_SESSION_PROMPT_PLACEHOLDER) {
+  return [
+    '# Title',
+    '',
+    '## Session Start Prompt (Copy/Paste)',
+    '',
+    '```text',
+    'You are a safe assistant.',
+    'Use docs/tool-catalog.md.',
+    body,
+    '```',
+    '',
+    '## Notes',
+  ].join('\n');
+}
+
+test('extractSessionPromptTemplate reads the fenced text block', () => {
+  const promptTemplate = extractSessionPromptTemplate(buildTemplate());
+
+  assert.match(promptTemplate, /You are a safe assistant\./);
+  assert.match(promptTemplate, /\[INSERT USER GOAL HERE\]/);
+});
+
+test('AI session prompt service replaces the goal placeholder and preserves safety guidance', () => {
+  const service = createAiSessionPromptService({
+    templateLoader: () => buildTemplate(),
+  });
+
+  const result = service.generatePrompt({
+    profile: 'development',
+    environment: 'sandbox',
+    goal: 'Analyze program ORDERPGM and summarize dependencies.',
+    includeDoctorSummary: true,
+    doctorSummary: {
+      status: 'warning',
+      summary: { pass: 2, warn: 1, fail: 0, info: 0, skip: 0 },
+      finishedAt: '2026-06-19T12:00:00.000Z',
+    },
+  });
+
+  assert.match(result.prompt, /Session context from Local UI Setup/);
+  assert.match(result.prompt, /Profile: development/);
+  assert.match(result.prompt, /Environment hint: sandbox/);
+  assert.match(result.prompt, /Doctor summary: status=warning/);
+  assert.match(result.prompt, /Analyze program ORDERPGM and summarize dependencies\./);
+  assert.match(result.prompt, /docs\/tool-catalog\.md/);
+  assert.doesNotMatch(result.prompt, /\[INSERT USER GOAL HERE\]/);
+  assert.ok(Array.isArray(result.warnings));
+  assert.equal(result.metadata.templateSource, 'docs/ai/session-prompt.md');
+});
+
+test('AI session prompt service omits secrets from generated prompt metadata', () => {
+  const service = createAiSessionPromptService({
+    templateLoader: () => buildTemplate(),
+  });
+
+  const result = service.generatePrompt({
+    profile: 'development',
+    goal: 'Review fetch/analyze flow.',
+    includeDoctorSummary: true,
+    doctorSummary: {
+      status: 'failed',
+      summary: { pass: 0, warn: 0, fail: 1, info: 0, skip: 0 },
+      finishedAt: '2026-06-19T12:00:00.000Z',
+    },
+  });
+
+  assert.doesNotMatch(result.prompt, /password=/i);
+  assert.doesNotMatch(result.prompt, /jdbc:[^\n]*:\/\/[^:\s/;,@]+:[^@\s/;]+@/i);
+});
+
+test('AI session prompt service fails safely when the template block is missing', () => {
+  const service = createAiSessionPromptService({
+    templateLoader: () => '# Missing prompt block\n',
+  });
+
+  assert.throws(
+    () => service.generatePrompt({
+      profile: 'development',
+      goal: 'Review dependencies.',
+    }),
+    (error) => error instanceof AiSessionPromptError && /Session Start Prompt text block/i.test(error.message),
+  );
+});
+
+test('AI session prompt service fails safely when the placeholder is missing', () => {
+  const service = createAiSessionPromptService({
+    templateLoader: () => buildTemplate('No placeholder here.'),
+  });
+
+  assert.throws(
+    () => service.generatePrompt({
+      profile: 'development',
+      goal: 'Review dependencies.',
+    }),
+    (error) => error instanceof AiSessionPromptError && /session goal placeholder/i.test(error.message),
+  );
+});

--- a/tests/ai-session-prompt-service.test.js
+++ b/tests/ai-session-prompt-service.test.js
@@ -31,6 +31,30 @@ test('extractSessionPromptTemplate reads the fenced text block', () => {
   assert.match(promptTemplate, /\[INSERT USER GOAL HERE\]/);
 });
 
+test('extractSessionPromptTemplate stops at the first closing fence inside the section', () => {
+  const promptTemplate = extractSessionPromptTemplate([
+    '# Title',
+    '',
+    '## Session Start Prompt (Copy/Paste)',
+    '',
+    '````text',
+    'Prompt body line 1',
+    '```bash',
+    'echo nested example',
+    '```',
+    AI_SESSION_PROMPT_PLACEHOLDER,
+    '````',
+    '',
+    'Additional notes in the same section should not be captured.',
+    '',
+    '## Notes',
+  ].join('\n'));
+
+  assert.match(promptTemplate, /Prompt body line 1/);
+  assert.match(promptTemplate, /echo nested example/);
+  assert.doesNotMatch(promptTemplate, /Additional notes in the same section/);
+});
+
 test('AI session prompt service replaces the goal placeholder and preserves safety guidance', () => {
   const service = createAiSessionPromptService({
     templateLoader: () => buildTemplate(),

--- a/tests/local-ui-action-service.test.js
+++ b/tests/local-ui-action-service.test.js
@@ -8,6 +8,7 @@ const {
   buildObjectDiscoveryConfigContext,
   createLocalUiActionService,
   normalizeAnalyzeExistingWorkspacePayload,
+  normalizeAiSessionPromptPayload,
   normalizeDiscoveryPreviewPayload,
   normalizeDoctorDiagnostics,
   normalizeDoctorPayload,
@@ -65,6 +66,41 @@ test('unknown action is rejected', async () => {
     () => service.executeAction('fetch', { profile: 'dev' }),
     (error) => error instanceof UiActionError && error.statusCode === 404,
   );
+});
+
+test('generate-ai-session-prompt action accepts valid payload and returns prompt metadata', async () => {
+  const service = createLocalUiActionService();
+  const result = await service.executeAction('generate-ai-session-prompt', {
+    profile: 'dev',
+    environment: 'development',
+    goal: 'Analyze program ORDERPGM and summarize dependencies.',
+    includeDoctorSummary: true,
+    doctorSummary: {
+      status: 'warning',
+      summary: {
+        total: 2,
+        pass: 1,
+        warn: 1,
+        fail: 0,
+        info: 0,
+        skip: 0,
+      },
+      finishedAt: '2026-06-19T12:00:00.000Z',
+    },
+  });
+
+  assert.equal(result.action, 'generate-ai-session-prompt');
+  assert.equal(result.status, 'completed');
+  assert.equal(result.input.profile, 'dev');
+  assert.equal(result.input.environment, 'development');
+  assert.equal(result.input.includeDoctorSummary, true);
+  assert.match(result.prompt, /Analyze program ORDERPGM and summarize dependencies\./);
+  assert.match(result.prompt, /docs\/tool-catalog\.md/);
+  assert.ok(Array.isArray(result.warnings));
+  assert.equal(result.metadata.profile, 'dev');
+  assert.equal(result.metadata.environment, 'development');
+  assert.equal(result.metadata.includedDoctorSummary, true);
+  assert.equal(result.metadata.templateSource, 'docs/ai/session-prompt.md');
 });
 
 test('discovery-preview action derives source scope locally from resolved fetch config', async () => {
@@ -186,6 +222,88 @@ test('unknown payload keys are rejected', () => {
       cmd: 'rm -rf /',
     }),
     /unsupported key/i,
+  );
+});
+
+test('AI session prompt payload rejects unknown keys, unsafe goal text, and invalid doctor summary details', () => {
+  assert.throws(
+    () => normalizeAiSessionPromptPayload({
+      profile: 'dev',
+      goal: 'Review ORDERPGM.',
+      command: 'rm -rf /',
+    }),
+    /unsupported key/i,
+  );
+
+  assert.throws(
+    () => normalizeAiSessionPromptPayload({
+      profile: 'dev',
+      goal: 'jdbc:as400://user:secret@internal-host.example;password=secret',
+    }),
+    /contain secrets/i,
+  );
+
+  assert.throws(
+    () => normalizeAiSessionPromptPayload({
+      profile: 'dev',
+      goal: 'Review ORDERPGM.',
+      doctorSummary: {
+        status: 'ready',
+        checks: [{ name: 'Java' }],
+      },
+    }),
+    /unsupported doctorSummary key/i,
+  );
+});
+
+test('AI session prompt payload rejects empty, overly long, and control-character goals', () => {
+  assert.throws(
+    () => normalizeAiSessionPromptPayload({
+      profile: 'dev',
+      goal: '',
+    }),
+    /goal is required/i,
+  );
+
+  assert.throws(
+    () => normalizeAiSessionPromptPayload({
+      profile: 'dev',
+      goal: 'A'.repeat(4001),
+    }),
+    /goal exceeds 4000 characters/i,
+  );
+
+  assert.throws(
+    () => normalizeAiSessionPromptPayload({
+      profile: 'dev',
+      goal: 'Review ORDERPGM.\u0007',
+    }),
+    /unsupported control characters/i,
+  );
+});
+
+test('AI session prompt payload accepts multiline goals and optional environment names', () => {
+  const payload = normalizeAiSessionPromptPayload({
+    profile: 'dev',
+    environment: 'sandbox-1',
+    goal: 'Review ORDERPGM.\r\nSummarize evidence-first next steps.',
+    includeDoctorSummary: false,
+  });
+
+  assert.equal(payload.profile, 'dev');
+  assert.equal(payload.environment, 'sandbox-1');
+  assert.equal(payload.goal, 'Review ORDERPGM.\nSummarize evidence-first next steps.');
+  assert.equal(payload.includeDoctorSummary, false);
+});
+
+test('AI session prompt payload rejects unsafe environment names', () => {
+  assert.throws(
+    () => normalizeAiSessionPromptPayload({
+      profile: 'dev',
+      environment: '../private',
+      goal: 'Review ORDERPGM.',
+    }),
+    /environment/i,
   );
 });
 

--- a/tests/local-ui-server.test.js
+++ b/tests/local-ui-server.test.js
@@ -249,6 +249,11 @@ test('local UI server exposes run explorer data and Prompt Workbench routes thro
     assert.ok(uiMetadata.guidedConfiguration.steps.length >= 7);
     assert.ok(Array.isArray(uiMetadata.guidedConfiguration.discoveryActions));
     assert.ok(uiMetadata.guidedConfiguration.discoveryActions.some((entry) => entry.id === 'discover-source-libraries'));
+    assert.equal(uiMetadata.aiSessionStarter.templateSource, 'docs/ai/session-prompt.md');
+    assert.equal(uiMetadata.aiSessionStarter.actionPath, '/api/ui-actions/generate-ai-session-prompt');
+    assert.equal(uiMetadata.aiSessionStarter.goalMaxLength, 4000);
+    assert.equal(uiMetadata.aiSessionStarter.envLoading.powerShell.command.includes('load-env.ps1'), true);
+    assert.equal(uiMetadata.aiSessionStarter.envLoading.bash.command.includes('load-env.sh'), true);
     assert.equal(uiMetadata.profileWizard.mode, 'local-only-profile-wizard');
     assert.ok(Array.isArray(uiMetadata.profileWizard.steps));
     assert.ok(uiMetadata.profileWizard.steps.some((entry) => entry.id === 'managed-environments'));
@@ -418,6 +423,54 @@ test('local UI server exposes run explorer data and Prompt Workbench routes thro
       }),
     });
     assert.equal(doctorUnknownKey.status, 400);
+
+    const aiSessionPromptResponse = await fetch(`${started.url}/api/ui-actions/generate-ai-session-prompt`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        profile: 'dev',
+        environment: 'development',
+        goal: 'Analyze program ORDERPGM and summarize dependencies.',
+        includeDoctorSummary: true,
+        doctorSummary: {
+          status: 'warning',
+          summary: {
+            total: 2,
+            pass: 1,
+            warn: 1,
+            fail: 0,
+            info: 0,
+            skip: 0,
+          },
+          finishedAt: '2026-06-19T12:00:00.000Z',
+        },
+      }),
+    });
+    assert.equal(aiSessionPromptResponse.status, 200);
+    const aiSessionPromptPayload = await aiSessionPromptResponse.json();
+    assert.equal(aiSessionPromptPayload.action, 'generate-ai-session-prompt');
+    assert.equal(aiSessionPromptPayload.status, 'completed');
+    assert.match(aiSessionPromptPayload.prompt, /Analyze program ORDERPGM and summarize dependencies\./);
+    assert.match(aiSessionPromptPayload.prompt, /docs\/tool-catalog\.md/);
+    assert.equal(aiSessionPromptPayload.metadata.profile, 'dev');
+    assert.equal(aiSessionPromptPayload.metadata.environment, 'development');
+    assert.equal(aiSessionPromptPayload.metadata.includedDoctorSummary, true);
+    assert.equal(Array.isArray(aiSessionPromptPayload.warnings), true);
+    assert.equal(JSON.stringify(aiSessionPromptPayload).includes('password=super-secret'), false);
+
+    const invalidAiSessionPromptResponse = await fetch(`${started.url}/api/ui-actions/generate-ai-session-prompt`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        profile: 'dev',
+        goal: 'jdbc:as400://user:secret@internal-host.example;password=secret',
+      }),
+    });
+    assert.equal(invalidAiSessionPromptResponse.status, 400);
 
     const discoveryResponse = await fetch(`${started.url}/api/ui-actions/discovery-preview`, {
       method: 'POST',
@@ -633,6 +686,14 @@ test('local UI server exposes run explorer data and Prompt Workbench routes thro
     assert.match(shellHtml, /Recommended Next Step/);
     assert.match(shellHtml, /Check Readiness/);
     assert.match(shellHtml, /Doctor Readiness Check/);
+    assert.match(shellHtml, /Start AI Session/);
+    assert.match(shellHtml, /Generate Session Prompt/);
+    assert.match(shellHtml, /Copy Prompt/);
+    assert.match(shellHtml, /Include compact Doctor summary/);
+    assert.match(shellHtml, /The Local UI cannot load env vars into your already-open terminal/);
+    assert.match(shellHtml, /load-env\.ps1/);
+    assert.match(shellHtml, /load-env\.sh/);
+    assert.match(shellHtml, /Do not paste credentials into the goal/);
     assert.match(shellHtml, /Local-only Profile Wizard/);
     assert.match(shellHtml, /Advanced Setup Details/);
     assert.match(shellHtml, /Reports are local and read-only/);

--- a/tests/local-ui-server.test.js
+++ b/tests/local-ui-server.test.js
@@ -244,6 +244,10 @@ test('local UI server exposes run explorer data and Prompt Workbench routes thro
     assert.equal(uiMetadata.workflowCards.find((entry) => entry.id === 'review-reports').uiTarget, 'reports');
     assert.equal(uiMetadata.workflowCards.find((entry) => entry.id === 'fetch-sources').enabledInShell, false);
     assert.equal(uiMetadata.workflowCards.find((entry) => entry.id === 'fetch-sources').status, 'Coming later');
+    assert.equal(uiMetadata.setup.title, 'Setup');
+    assert.equal(uiMetadata.setup.primaryAction.label, 'Check Readiness');
+    assert.equal(uiMetadata.setup.primaryAction.actionPath, '/api/ui-actions/doctor');
+    assert.ok(Array.isArray(uiMetadata.setup.precedenceRules));
     assert.equal(uiMetadata.guidedConfiguration.schemaVersion, 1);
     assert.ok(Array.isArray(uiMetadata.guidedConfiguration.steps));
     assert.ok(uiMetadata.guidedConfiguration.steps.length >= 7);

--- a/tests/ui-metadata-service.test.js
+++ b/tests/ui-metadata-service.test.js
@@ -22,6 +22,8 @@ test('ui metadata payload exposes config, command, and workflow card contracts',
   assert.ok(Array.isArray(payload.guidedConfiguration.steps));
   assert.ok(Array.isArray(payload.guidedConfiguration.intents));
   assert.ok(Array.isArray(payload.guidedConfiguration.discoveryActions));
+  assert.ok(payload.aiSessionStarter);
+  assert.equal(payload.aiSessionStarter.actionPath, '/api/ui-actions/generate-ai-session-prompt');
   assert.ok(payload.profileWizard);
   assert.equal(payload.profileWizard.mode, 'local-only-profile-wizard');
   assert.ok(Array.isArray(payload.profileWizard.steps));
@@ -94,4 +96,15 @@ test('ui metadata includes sensitive field markers but no resolved values', () =
     assert.equal(Object.prototype.hasOwnProperty.call(field, 'value'), false);
     assert.equal(Object.prototype.hasOwnProperty.call(field, 'resolvedValue'), false);
   }
+
+  assert.equal(payload.aiSessionStarter.goalMaxLength, 4000);
+  assert.equal(payload.aiSessionStarter.templateSource, 'docs/ai/session-prompt.md');
+  assert.equal(payload.aiSessionStarter.authoritativeCatalogPath, 'docs/tool-catalog.md');
+  assert.equal(payload.aiSessionStarter.envLoading.powerShell.command.includes('load-env.ps1'), true);
+  assert.equal(payload.aiSessionStarter.envLoading.bash.command.includes('load-env.sh'), true);
+  assert.ok(Array.isArray(payload.aiSessionStarter.capabilityGuidance.starterCommands));
+  assert.ok(Array.isArray(payload.aiSessionStarter.capabilityGuidance.approvalRequiredCommands));
+  assert.ok(Array.isArray(payload.aiSessionStarter.capabilityGuidance.mcp.starterTools));
+  assert.equal(JSON.stringify(payload.aiSessionStarter).includes('PASSWORD'), false);
+  assert.equal(JSON.stringify(payload.aiSessionStarter).includes('internal-host.example'), false);
 });

--- a/tests/ui-metadata-service.test.js
+++ b/tests/ui-metadata-service.test.js
@@ -22,6 +22,8 @@ test('ui metadata payload exposes config, command, and workflow card contracts',
   assert.ok(Array.isArray(payload.guidedConfiguration.steps));
   assert.ok(Array.isArray(payload.guidedConfiguration.intents));
   assert.ok(Array.isArray(payload.guidedConfiguration.discoveryActions));
+  assert.ok(payload.setup);
+  assert.equal(payload.setup.primaryAction.actionPath, '/api/ui-actions/doctor');
   assert.ok(payload.aiSessionStarter);
   assert.equal(payload.aiSessionStarter.actionPath, '/api/ui-actions/generate-ai-session-prompt');
   assert.ok(payload.profileWizard);
@@ -100,6 +102,11 @@ test('ui metadata includes sensitive field markers but no resolved values', () =
   assert.equal(payload.aiSessionStarter.goalMaxLength, 4000);
   assert.equal(payload.aiSessionStarter.templateSource, 'docs/ai/session-prompt.md');
   assert.equal(payload.aiSessionStarter.authoritativeCatalogPath, 'docs/tool-catalog.md');
+  assert.equal(payload.setup.title, 'Setup');
+  assert.ok(Array.isArray(payload.setup.precedenceRules));
+  assert.ok(Array.isArray(payload.setup.boundaryNotes));
+  assert.ok(Array.isArray(payload.setup.recommendedNextTokens));
+  assert.equal(payload.setup.primaryAction.label, 'Check Readiness');
   assert.equal(payload.aiSessionStarter.envLoading.powerShell.command.includes('load-env.ps1'), true);
   assert.equal(payload.aiSessionStarter.envLoading.bash.command.includes('load-env.sh'), true);
   assert.ok(Array.isArray(payload.aiSessionStarter.capabilityGuidance.starterCommands));


### PR DESCRIPTION
Adds a Setup-based AI Session Starter for generating safe, evidence-first AI session prompts from docs/ai/session-prompt.md.

Highlights:
- Adds AI Session Starter flow in Setup
- Generates prompts from the session prompt source of truth
- Preserves evidence-first and safety-first operating model
- Keeps credentials and env values out of generated prompts
- Adds policy metadata for Setup guidance
- Refactors Local UI setup shell rendering
- Breaks Local UI / MCP require cycle
- Hardens session prompt template parsing for nested fenced content
- Adds regression coverage for nested fenced prompt content
- Keeps .local TODO ledger untracked

Checks:
- npm run lint
- npm run check:public-knowledge-claims
- npm test