### PR TITLE
fix(tests): update table name resolution tests for sqlBatch changes

### DIFF
--- a/tests/table-name-resolution-service.test.js
+++ b/tests/table-name-resolution-service.test.js
@@ -1,5 +1,6 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('fs');
 
 const {
   buildResolveObjectDiagnostics,
@@ -8,12 +9,30 @@ const {
   resolveColumnsWithName,
   resolveTableNameBothDirections,
 } = require('../src/db2/tableNameResolutionService');
+const { SQL_STATEMENT_DELIMITER } = require('../src/db2/sqlBatch');
 const { resetConnectionGuardState } = require('../src/security/connectionGuards');
+
+function getExecutedQuery(args) {
+  if (!args || args.length < 4) {
+    return '';
+  }
+  if (args[3] === '--statements-file') {
+    const filePath = args[4];
+    try {
+      const content = fs.readFileSync(filePath, 'utf8');
+      const parts = content.split(SQL_STATEMENT_DELIMITER);
+      return (parts[0] || '').trim();
+    } catch (err) {
+      return '';
+    }
+  }
+  return args[3] || '';
+}
 
 function createRuntimeWithRows(rows, queryChecks = []) {
   return {
     runJavaHelper(_className, args) {
-      const query = args[3];
+      const query = getExecutedQuery(args);
       if (/SYSIBM\.SYSDUMMY1/.test(query)) {
         return {
           status: 0,
@@ -45,7 +64,7 @@ function createRuntimeWithFallbackSequence(sequence) {
   let index = 0;
   return {
     runJavaHelper(_className, args) {
-      const query = args[3];
+      const query = getExecutedQuery(args);
       if (/SYSIBM\.SYSDUMMY1/.test(query)) {
         return {
           status: 0,
@@ -248,7 +267,7 @@ test('resolveObjectsByName matches SQL and system names across schemas and valid
   const queries = [];
   const runtime = {
     runJavaHelper(_className, args) {
-      const query = args[3];
+      const query = getExecutedQuery(args);
       queries.push(query);
       if (/FROM QSYS2\.SYSTABLES/.test(query)) {
         return {


### PR DESCRIPTION
## Summary
The sqlBatch changes (multi-statement / long query support via --statements-file) caused 4 tests in table-name-resolution-service.test.js to fail because the mocks were reading `args[3]` directly as the SQL.

## Changes
- Added helper `getExecutedQuery(args)` that correctly extracts the logical SQL whether the runner used direct query or `--statements-file` + temp file.
- Updated all relevant mocks in the test file.
- All previously failing tests now pass.

## Test results
- The 4 affected tests now pass.
- No other breakage introduced.

This is the final piece to send the cleanup work (internal docs removal, path generalization, test fixes) to GitHub.