### PR TITLE
feat(core): add versioned domain schema infrastructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:ci": "npm run test:contract && npm run test:smoke",
     "test:unit": "node scripts/run-tests.js --unit",
     "test:unit:list": "node scripts/run-tests.js --unit --list",
-    "test:contract": "node scripts/run-tests.js tests/analyze-run-manifest.test.js tests/bundle-manifest.test.js tests/fetch-readability-contract.test.js tests/ai-knowledge-projection.test.js tests/task-oriented-analysis-index.test.js tests/workflow-presets.test.js",
+    "test:contract": "node scripts/run-tests.js tests/analyze-run-manifest.test.js tests/bundle-manifest.test.js tests/fetch-readability-contract.test.js tests/ai-knowledge-projection.test.js tests/task-oriented-analysis-index.test.js tests/workflow-presets.test.js tests/schema-registry.test.js",
     "test:smoke": "node scripts/run-tests.js tests/v1-smoke.test.js tests/safe-sharing.test.js tests/reproducible-output.test.js",
     "test:corpus": "node scripts/run-tests.js tests/scanner-corpus.test.js",
     "test:benchmark": "node scripts/run-tests.js tests/analyze-benchmark.test.js",

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,31 @@
+# Zeus Domain Schemas
+
+This directory is the home for versioned domain contract schemas.
+
+**Status (package 02):** Initial metadata-only shells have been registered in code
+(`src/core/contracts/schemas.js`). Full structural definitions and producers/consumers
+will be migrated in subsequent packages.
+
+## Contract IDs (stable)
+
+- `zeus.evidence-model`
+- `zeus.run-manifest`
+- `zeus.artifact-reference`
+- `zeus.investigation-session`
+- `zeus.safety-policy`
+
+## Usage (via registry)
+
+```js
+const { createSchemaRegistry } = require('./src/core/contracts');
+const { INITIAL_SCHEMAS } = require('./src/core/contracts/schemas');
+
+const registry = createSchemaRegistry();
+for (const [id, { version, schema }] of Object.entries(INITIAL_SCHEMAS)) {
+  registry.register({ id, version, schema });
+}
+
+const result = registry.validate('zeus.run-manifest', 1, manifestData);
+```
+
+See `src/core/contracts/schemaRegistry.js` and the package 02 ADR baseline for policy.

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -98,6 +98,19 @@ const analyzers = new AnalyzerRegistry();
 const mcpTools = new McpToolRegistry();
 const knowledgeProviders = new ComponentRegistry();
 
+const { createSchemaRegistry } = require('../core/contracts');
+const schemaRegistry = createSchemaRegistry();
+
+// Seed the initial metadata shells from package 02 (additive, no migration)
+try {
+  const { INITIAL_SCHEMAS } = require('../core/contracts/schemas');
+  for (const [id, def] of Object.entries(INITIAL_SCHEMAS)) {
+    schemaRegistry.register({ id, version: def.version, schema: def.schema });
+  }
+} catch (e) {
+  // Graceful: callers can always create their own isolated registries.
+}
+
 // Core functions
 async function runWorkflow(profile, preset, options = {}) {
   const { runtime = {}, ...args } = options;
@@ -209,6 +222,12 @@ const zeus = {
   components: new ComponentRegistry(),
   analyzeStages: analyzeStageRegistry,
 
+  // Package 02: versioned domain schema registry (additive)
+  contracts: {
+    schemaRegistry,
+    createSchemaRegistry,
+  },
+
   // Investigation Sessions (Prio 1)
   investigations: {
     createOrLoad: investigationSession.createOrLoadSession,
@@ -251,6 +270,10 @@ module.exports = {
   readRun,
   readRunViews,
   runWorkflow,
+
+  // Schema / contract foundation (package 02)
+  createSchemaRegistry,
+  contracts: zeus.contracts,
 
   zeus,
   createZeus: () => ({ ...zeus }),

--- a/src/core/contracts/contractIds.js
+++ b/src/core/contracts/contractIds.js
@@ -1,0 +1,25 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+/**
+ * Stable contract identifiers for Zeus domain schemas.
+ * These IDs are intended to be long-lived. Major version changes signal breaking changes.
+ */
+module.exports = Object.freeze({
+  EVIDENCE_MODEL: 'zeus.evidence-model',
+  RUN_MANIFEST: 'zeus.run-manifest',
+  ARTIFACT_REFERENCE: 'zeus.artifact-reference',
+  INVESTIGATION_SESSION: 'zeus.investigation-session',
+  SAFETY_POLICY: 'zeus.safety-policy',
+});

--- a/src/core/contracts/errors.js
+++ b/src/core/contracts/errors.js
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+/**
+ * Structured validation error for domain contracts.
+ * Path is JSON-pointer style (e.g. '/root/program' or '/entities/0/name').
+ * Message is stable, human readable, and must not contain secrets.
+ */
+class SchemaValidationError extends Error {
+  constructor(message, errors = []) {
+    super(message);
+    this.name = 'SchemaValidationError';
+    this.errors = Array.isArray(errors) ? errors : [];
+  }
+}
+
+/**
+ * Normalize and bound a list of validation errors.
+ * - Deduplicates by path+message (stable order)
+ * - Limits total count to prevent huge outputs
+ * - Strips any obviously sensitive values from messages
+ */
+function normalizeValidationErrors(errors, { maxErrors = 20 } = {}) {
+  if (!Array.isArray(errors) || errors.length === 0) return [];
+
+  const seen = new Set();
+  const normalized = [];
+
+  for (const e of errors) {
+    if (!e || typeof e !== 'object') continue;
+
+    const path = typeof e.path === 'string' ? e.path : '';
+    let message = typeof e.message === 'string' ? e.message : 'invalid value';
+
+    // Redact potential secrets aggressively (very conservative)
+    message = message
+      .replace(/([A-Za-z0-9+/=]{20,})/g, '[REDACTED]')
+      .replace(/\b(password|secret|token|key)\b[^,]*/gi, '[REDACTED]');
+
+    const key = `${path}|${message}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    normalized.push({ path, message });
+
+    if (normalized.length >= maxErrors) break;
+  }
+
+  // Sort for determinism: by path then message
+  normalized.sort((a, b) => {
+    if (a.path === b.path) return a.message.localeCompare(b.message);
+    return a.path.localeCompare(b.path);
+  });
+
+  return normalized;
+}
+
+module.exports = {
+  SchemaValidationError,
+  normalizeValidationErrors,
+};

--- a/src/core/contracts/index.js
+++ b/src/core/contracts/index.js
@@ -1,0 +1,22 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+const { createSchemaRegistry } = require('./schemaRegistry');
+const { SchemaValidationError, normalizeValidationErrors } = require('./errors');
+
+module.exports = {
+  createSchemaRegistry,
+  SchemaValidationError,
+  normalizeValidationErrors,
+};

--- a/src/core/contracts/schemaRegistry.js
+++ b/src/core/contracts/schemaRegistry.js
@@ -1,0 +1,149 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+const { normalizeValidationErrors, SchemaValidationError } = require('./errors');
+
+/**
+ * Creates a schema registry for versioned domain contracts.
+ *
+ * Each contract is identified by a stable string id + major version number.
+ * Validation is additive-friendly: extra properties are allowed by default
+ * unless the schema validator explicitly rejects them.
+ *
+ * Public contract (preferred shape per package 02):
+ *
+ *   const registry = createSchemaRegistry();
+ *   registry.register({ id: 'zeus.run-manifest', version: 1, schema });
+ *   const result = registry.validate('zeus.run-manifest', 1, value);
+ *   // { ok: true, value } | { ok: false, errors: [{path, message}, ...] }
+ */
+function createSchemaRegistry(options = {}) {
+  const { allowRegistrationAfterUse = false } = options;
+  const entries = new Map(); // `${id}@${version}` -> {id, version, validateFn}
+  let used = false;
+
+  function makeKey(id, version) {
+    return `${id}@${version}`;
+  }
+
+  /**
+   * Register a contract schema.
+   * schema may be:
+   *   - a function (value) => Error[]   (recommended for v1)
+   *   - an object descriptor (reserved for future richer validation)
+   */
+  function register({ id, version, schema }) {
+    if (used && !allowRegistrationAfterUse) {
+      throw new Error('Schema registry is sealed: registration after first use is not allowed');
+    }
+    if (!id || typeof id !== 'string' || !id.trim()) {
+      throw new Error('Contract id must be a non-empty string');
+    }
+    if (!Number.isInteger(version) || version < 1) {
+      throw new Error('Contract version must be a positive integer');
+    }
+    if (schema == null) {
+      throw new Error('schema is required');
+    }
+
+    const key = makeKey(id, version);
+    if (entries.has(key)) {
+      throw new Error(`Duplicate registration for contract "${id}" version ${version}`);
+    }
+
+    let validateFn;
+    if (typeof schema === 'function') {
+      validateFn = schema;
+    } else if (schema && typeof schema === 'object') {
+      // Minimal descriptor support for now: treat as "has schemaVersion" + passthrough
+      validateFn = (value) => {
+        const errs = [];
+        if (value && typeof value === 'object' && 'schemaVersion' in value) {
+          if (Number(value.schemaVersion) !== version) {
+            errs.push({ path: '/schemaVersion', message: `expected ${version}, got ${value.schemaVersion}` });
+          }
+        }
+        return errs;
+      };
+    } else {
+      throw new Error('schema must be a validation function or descriptor object');
+    }
+
+    entries.set(key, { id, version, validateFn });
+  }
+
+  /**
+   * Validate a value against a registered contract version.
+   * Returns a stable result shape. Errors are always deterministic in order.
+   */
+  function validate(id, version, value) {
+    used = true;
+    const key = makeKey(id, version);
+    const entry = entries.get(key);
+
+    if (!entry) {
+      return {
+        ok: false,
+        errors: normalizeValidationErrors([{
+          path: '',
+          message: `Unknown contract or unsupported version: ${id} v${version}`,
+        }]),
+      };
+    }
+
+    let rawErrors = [];
+    try {
+      const result = entry.validateFn(value);
+      if (Array.isArray(result)) {
+        rawErrors = result;
+      } else if (result && Array.isArray(result.errors)) {
+        rawErrors = result.errors;
+      }
+    } catch (e) {
+      rawErrors = [{ path: '', message: `validation threw: ${String(e.message || e)}` }];
+    }
+
+    const errors = normalizeValidationErrors(rawErrors);
+
+    if (errors.length === 0) {
+      return { ok: true, value };
+    }
+
+    return { ok: false, errors };
+  }
+
+  function listContracts() {
+    return Array.from(entries.values())
+      .map(({ id, version }) => ({ id, version }))
+      .sort((a, b) => a.id.localeCompare(b.id) || a.version - b.version);
+  }
+
+  function hasContract(id, version) {
+    return entries.has(makeKey(id, version));
+  }
+
+  return {
+    register,
+    validate,
+    listContracts,
+    hasContract,
+    // For introspection in tests / api
+    _internal: { size: () => entries.size },
+  };
+}
+
+module.exports = {
+  createSchemaRegistry,
+  SchemaValidationError: require('./errors').SchemaValidationError,
+};

--- a/src/core/contracts/schemas.js
+++ b/src/core/contracts/schemas.js
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+const CONTRACT_IDS = require('./contractIds');
+
+/**
+ * Basic header validator used by all initial shells.
+ * Requires a numeric schemaVersion that matches the registered version.
+ */
+function basicHeaderValidator(expectedVersion) {
+  return (value) => {
+    const errors = [];
+    if (value == null || typeof value !== 'object') {
+      errors.push({ path: '', message: 'expected an object' });
+      return errors;
+    }
+    const sv = value.schemaVersion;
+    if (sv === undefined) {
+      errors.push({ path: '/schemaVersion', message: 'schemaVersion is required' });
+    } else if (Number(sv) !== expectedVersion) {
+      errors.push({
+        path: '/schemaVersion',
+        message: `expected ${expectedVersion}, got ${sv}`,
+      });
+    }
+    return errors;
+  };
+}
+
+/**
+ * Metadata-only shells for the contracts introduced in package 02.
+ * These only enforce common header/identity fields for now.
+ * Full structural schemas will be added by later packages.
+ */
+
+const evidenceModelSchema = basicHeaderValidator(1);
+
+const runManifestSchema = (value) => {
+  const errors = basicHeaderValidator(1)(value);
+  if (value && typeof value === 'object') {
+    if (!value.tool || typeof value.tool !== 'object') {
+      errors.push({ path: '/tool', message: 'tool metadata object is required' });
+    }
+    if (typeof value.run !== 'object' || value.run === null) {
+      errors.push({ path: '/run', message: 'run object is required' });
+    }
+  }
+  return errors;
+};
+
+const artifactReferenceSchema = basicHeaderValidator(1);
+
+const investigationSessionSchema = basicHeaderValidator(1);
+
+const safetyPolicySchema = (value) => {
+  const errors = basicHeaderValidator(1)(value);
+  if (value && typeof value === 'object' && value.level != null) {
+    const level = String(value.level);
+    if (!['S0', 'S1', 'S2', 'S3', 'S4'].includes(level)) {
+      errors.push({ path: '/level', message: 'level must be one of S0-S4' });
+    }
+  }
+  return errors;
+};
+
+const INITIAL_SCHEMAS = Object.freeze({
+  [CONTRACT_IDS.EVIDENCE_MODEL]: { version: 1, schema: evidenceModelSchema },
+  [CONTRACT_IDS.RUN_MANIFEST]: { version: 1, schema: runManifestSchema },
+  [CONTRACT_IDS.ARTIFACT_REFERENCE]: { version: 1, schema: artifactReferenceSchema },
+  [CONTRACT_IDS.INVESTIGATION_SESSION]: { version: 1, schema: investigationSessionSchema },
+  [CONTRACT_IDS.SAFETY_POLICY]: { version: 1, schema: safetyPolicySchema },
+});
+
+module.exports = {
+  CONTRACT_IDS,
+  INITIAL_SCHEMAS,
+  basicHeaderValidator,
+};

--- a/tests/schema-registry.test.js
+++ b/tests/schema-registry.test.js
@@ -1,0 +1,138 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createSchemaRegistry,
+  SchemaValidationError,
+} = require('../src/core/contracts');
+
+const {
+  CONTRACT_IDS,
+  INITIAL_SCHEMAS,
+} = require('../src/core/contracts/schemas');
+
+test('createSchemaRegistry allows registration and successful validation', () => {
+  const registry = createSchemaRegistry();
+  registry.register({
+    id: 'zeus.test-contract',
+    version: 1,
+    schema: (v) => (v && v.ok === true ? [] : [{ path: '', message: 'must have ok:true' }]),
+  });
+
+  const good = registry.validate('zeus.test-contract', 1, { ok: true, extra: 42 });
+  assert.equal(good.ok, true);
+  assert.deepEqual(good.value, { ok: true, extra: 42 });
+
+  const bad = registry.validate('zeus.test-contract', 1, { ok: false });
+  assert.equal(bad.ok, false);
+  assert.ok(Array.isArray(bad.errors));
+  assert.ok(bad.errors.length > 0);
+});
+
+test('validate returns deterministic structured errors for unknown contract', () => {
+  const registry = createSchemaRegistry();
+  const res = registry.validate('zeus.does-not-exist', 99, {});
+  assert.equal(res.ok, false);
+  assert.ok(res.errors.length >= 1);
+  assert.match(res.errors[0].message, /Unknown contract or unsupported version/);
+});
+
+test('duplicate registration is rejected', () => {
+  const registry = createSchemaRegistry();
+  registry.register({ id: 'zeus.dup', version: 1, schema: () => [] });
+  assert.throws(() => {
+    registry.register({ id: 'zeus.dup', version: 1, schema: () => [] });
+  }, /Duplicate registration/);
+});
+
+test('registry rejects non-positive version and bad ids', () => {
+  const registry = createSchemaRegistry();
+  assert.throws(() => registry.register({ id: '', version: 1, schema: () => [] }));
+  assert.throws(() => registry.register({ id: 'zeus.bad', version: 0, schema: () => [] }));
+  assert.throws(() => registry.register({ id: 'zeus.bad', version: 1.5, schema: () => [] }));
+});
+
+test('initial contract shells from package 02 are registered and validate basic headers', () => {
+  const registry = createSchemaRegistry();
+
+  for (const [id, { version, schema }] of Object.entries(INITIAL_SCHEMAS)) {
+    registry.register({ id, version, schema });
+  }
+
+  // zeus.run-manifest shell
+  const manifestOk = registry.validate(CONTRACT_IDS.RUN_MANIFEST, 1, {
+    schemaVersion: 1,
+    tool: { name: 'zeus' },
+    run: { status: 'succeeded' },
+  });
+  assert.equal(manifestOk.ok, true);
+
+  const manifestBadVersion = registry.validate(CONTRACT_IDS.RUN_MANIFEST, 1, {
+    schemaVersion: 99,
+    tool: {},
+    run: {},
+  });
+  assert.equal(manifestBadVersion.ok, false);
+  assert.ok(manifestBadVersion.errors.some(e => e.path.includes('schemaVersion')));
+
+  // safety policy shell
+  const safetyOk = registry.validate(CONTRACT_IDS.SAFETY_POLICY, 1, {
+    schemaVersion: 1,
+    level: 'S2',
+  });
+  assert.equal(safetyOk.ok, true);
+
+  const safetyBad = registry.validate(CONTRACT_IDS.SAFETY_POLICY, 1, {
+    schemaVersion: 1,
+    level: 'S9',
+  });
+  assert.equal(safetyBad.ok, false);
+});
+
+test('validation errors are bounded and deterministic', () => {
+  const registry = createSchemaRegistry();
+  registry.register({
+    id: 'zeus.multi-error',
+    version: 1,
+    schema: () => [
+      { path: '/b', message: 'second' },
+      { path: '/a', message: 'first' },
+      { path: '/a', message: 'first' }, // duplicate
+      ...Array.from({ length: 30 }, (_, i) => ({ path: `/x${i}`, message: 'many' })),
+    ],
+  });
+
+  const res = registry.validate('zeus.multi-error', 1, {});
+  assert.equal(res.ok, false);
+  assert.ok(res.errors.length <= 20);
+  // Sorted by path
+  assert.equal(res.errors[0].path, '/a');
+  assert.equal(res.errors[1].path, '/b');
+});
+
+test('validation errors do not leak secrets', () => {
+  const registry = createSchemaRegistry();
+  registry.register({
+    id: 'zeus.secret-test',
+    version: 1,
+    schema: (v) => {
+      if (v && v.password) {
+        return [{ path: '/password', message: `bad password value was ${v.password}` }];
+      }
+      return [];
+    },
+  });
+
+  const res = registry.validate('zeus.secret-test', 1, { password: 'super-secret-123' });
+  assert.equal(res.ok, false);
+  const msg = JSON.stringify(res.errors);
+  assert.ok(!msg.includes('super-secret-123'));
+  assert.ok(msg.includes('[REDACTED]') || msg.includes('bad password'));
+});
+
+test('registry can be used via public contracts module', () => {
+  const { createSchemaRegistry } = require('../src/core/contracts');
+  const r = createSchemaRegistry();
+  assert.ok(typeof r.register === 'function');
+  assert.ok(typeof r.validate === 'function');
+});


### PR DESCRIPTION
## Problem & Goal
Package 02 adds a reusable, dependency-light schema registry and validation foundation for Zeus domain contracts. Currently every module defines its own ad-hoc `*_SCHEMA_VERSION` constant with manual checks. This package introduces a single central mechanism (createSchemaRegistry + validate) so that future packages can register versioned contracts, produce deterministic structured errors, and support additive evolution without breaking existing artifact formats.

**Additive only** — no existing JSON outputs, manifests, or reproducibility behavior are changed.

## Architectural Approach
- Inspected current state after package 01 (many independent schemaVersion constants, no central registry, no JSON Schema dep).
- Chose pure-JS implementation (no new runtime dependencies) to stay lightweight, Node 20 compatible, and deterministic.
- Location: `src/core/contracts/` (coherent home per package guidance and ADR-002 layering).
- Initial "metadata-only" schema shells for the five named contracts.
- Errors are path-aware, bounded, secret-redacted, and stably sorted.
- Exposed via `src/api/zeusApi.js` (additive) and direct require.
- Tests added using project's native `node:test` style.

## Files / Contracts Intentionally Changed
- New: `src/core/contracts/{errors.js, schemaRegistry.js, schemas.js, contractIds.js, index.js}`
- New: `schemas/README.md`
- New: `tests/schema-registry.test.js`
- Modified (additive): `src/api/zeusApi.js` (export contracts + seed initial schemas), `package.json` (added test file to test:contract for full verification)

## Files / Contracts Intentionally Not Changed
- All existing artifact writers, manifests, canonical model, knowledge projections, bundles, etc. (no schemaVersion or shape changes).
- No CLI, MCP, or command surface changes.
- No migration of producers (explicit non-goal).
- Reproducibility contracts and smoke outputs remain byte-for-byte identical.
- No new dependencies in package.json.

## Compatibility & Safety Assessment
- Purely additive infrastructure.
- Existing tests (including reproducible-output and smoke) continue to pass unchanged.
- Validation errors are deliberately bounded and redacted (S0–S4 friendly).
- No impact on approval gates, secret handling, or remote trust zones.

## Tests Added
- `tests/schema-registry.test.js` (8 tests covering registration, validation success/failure, unknown contracts, duplicates, version errors, error determinism, secret redaction, public API).
- Included in `npm run test:contract`.

## Exact Validation Commands & Outcomes
```bash
# Rebaseline
git fetch --all --tags --prune
git checkout main && git pull --ff-only origin main   # clean, at 488b872 (post-01)
git checkout -b agent/02-versioned-domain-schemas

# Package verification
node --test tests/schema-registry.test.js           # 8/8 PASS
npm run test:contract                               # 21/21 PASS (includes new tests)
npm run test:smoke                                  # 4/4 PASS
npm pack --dry-run                                  # success (no breakage)
npm run demo:safety-check                           # passed
node scripts/run-tests.js tests/reproducible-output.test.js  # PASS (byte-for-byte preserved)
git diff --check                                    # clean
```

## Self-Verification Findings
- **Goal focus:** All changes are the minimal coherent schema infrastructure + tests + documentation. No scope creep, no unrelated refactors, no CLI/MCP changes, no artifact migrations.
- **Correctness:** Implementation matches the declared public shape. Current contracts (schemaVersion fields) are untouched. Errors are stable and safe.
- **Test completeness:** Positive, negative, boundary (unknown version, duplicate reg, bad input), determinism, and redaction cases covered. Full contract + smoke + repro suites green.
- **Remote integrity:** Will be verified after push (SHA match, gh pr diff scope, checks).

## Residual Risks & Deferrals
- Schemas are currently metadata-only shells. Full structural validation will come in later packages (02 is foundation only).
- Seeding of initial schemas happens at zeusApi load time (gracefully fails if module load order issues).
- No automatic upgrade or compatibility adapters yet (deferred).

PR created under the operating contract. Normal squash merge requested.