### PR TITLE
refactor(analysis): migrate analyze, workflow, and bundle capabilities

### DIFF
--- a/cli/commands/generate-tool-catalog.js
+++ b/cli/commands/generate-tool-catalog.js
@@ -210,6 +210,9 @@ function buildCatalogModel({ repoRoot }) {
         profiles: 'configure.profiles',
         resources: 'configure.resources',
         'discover-environment': 'configure.discover-environment',
+        analyze: 'analysis.analyze',
+        workflow: 'analysis.workflow',
+        bundle: 'bundle.create',
       };
       const capId = capIdMap[command];
       if (capId) {

--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -380,7 +380,7 @@ async function main() {
   checkEnvLoaded(command);
 
   if (command === 'analyze') {
-    runAnalyze(args);
+    await runAnalyze(args);
     return;
   }
 

--- a/docs/tool-catalog.json
+++ b/docs/tool-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-11T12:14:41.211Z",
+  "generatedAt": "2026-07-11T12:25:17.728Z",
   "commandRows": [
     {
       "command": "doctor",

--- a/docs/tool-catalog.md
+++ b/docs/tool-catalog.md
@@ -1,7 +1,7 @@
 <!-- 
 AUTO-GENERATED FILE – do not edit manually!
 Regenerate with: zeus docs:generate-catalog
-Last generated: 2026-07-11 14:14:41
+Last generated: 2026-07-11 14:25:17
 -->
 
 ---

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -218,6 +218,75 @@ try {
     },
   });
 
+  capabilityRegistry.register({
+    id: 'analysis.analyze',
+    version: 1,
+    title: 'Analyze Workspace',
+    description: 'Analyze RPG/CL/DDS and emit structured evidence artifacts.',
+    category: 'analysis',
+    safety: { level: 'S1', sideEffects: ['local-artifact-write'], requiresExplicitApproval: false },
+    aliases: ['analyze'],
+    inputContract: null,
+    outputContract: null,
+    availability: { cli: true, mcp: true, api: true, viewer: true, vscode: true },
+    docs: { examples: ['zeus analyze --source ./src --program MYPROG --out ./out'], notes: [] },
+    execute: (context, input) => {
+      const args = { ...(context && context.args ? context.args : {}), ...input };
+      const { executeAnalyze } = require('../core/analyzeService');
+      return executeAnalyze(args, { cwd: (context && context.cwd) || process.cwd() });
+    },
+  });
+
+  capabilityRegistry.register({
+    id: 'analysis.workflow',
+    version: 1,
+    title: 'Workflow Execution',
+    description: 'Run preset-guided analyze and bundle flow.',
+    category: 'analysis',
+    safety: { level: 'S1', sideEffects: ['local-artifact-write'], requiresExplicitApproval: false },
+    aliases: ['workflow'],
+    inputContract: null,
+    outputContract: null,
+    availability: { cli: true, mcp: true, api: true, viewer: true, vscode: true },
+    docs: { examples: ['zeus workflow --preset architecture-review --source ./src --program MYPROG --out ./out'], notes: [] },
+    execute: async (context, input) => {
+      const args = { ...(context && context.args ? context.args : {}), ...input };
+      return runWorkflowEngine(args, { cwd: (context && context.cwd) || process.cwd(), env: (context && context.env) || process.env });
+    },
+  });
+
+  const { buildOutputBundle } = require('../bundle/outputBundleBuilder');
+  capabilityRegistry.register({
+    id: 'bundle.create',
+    version: 1,
+    title: 'Bundle Creation',
+    description: 'Package analysis artifacts for sharing and review.',
+    category: 'bundle',
+    safety: { level: 'S1', sideEffects: ['local-artifact-write'], requiresExplicitApproval: false },
+    aliases: ['bundle'],
+    inputContract: null,
+    outputContract: null,
+    availability: { cli: true, mcp: true, api: true, viewer: false, vscode: true },
+    docs: { examples: ['zeus bundle --program MYPROG --source-output-root ./out'], notes: [] },
+    execute: (context, input) => {
+      const args = { ...(context && context.args ? context.args : {}), ...input };
+      const config = require('../config/runtimeConfig').resolveBundleConfig ? require('../config/runtimeConfig').resolveBundleConfig(args) : {};
+      return buildOutputBundle({
+        program: String(args.program || '').trim(),
+        sourceOutputRoot: config.sourceOutputRoot || (context && context.cwd),
+        bundleOutputRoot: config.bundleOutputRoot,
+        includeJson: !!args['include-json'],
+        includeMd: !!args['include-md'],
+        includeHtml: !!args['include-html'],
+        safeSharingEnabled: !!args['safe-sharing'],
+        reproducibility: require('../reproducibility/reproducibility').normalizeReproducibilitySettings(!!args.reproducible),
+        artifactPaths: Array.isArray(args['artifact-paths']) ? args['artifact-paths'] : null,
+        workflowPreset: args['workflow-preset-settings'] || null,
+        bundleFileName: args['bundle-file-name'] || null,
+      });
+    },
+  });
+
 } catch (e) {
   // graceful
 }
@@ -225,6 +294,15 @@ try {
 // Core functions
 async function runWorkflow(profile, preset, options = {}) {
   const { runtime = {}, ...args } = options;
+  // Route through capability (package 07)
+  const cap = capabilities && capabilities.resolve ? capabilities.resolve('analysis.workflow') : null;
+  if (cap && typeof cap.execute === 'function') {
+    const ctx = { ...runtime, args: { profile, preset, ...args } };
+    const res = await cap.execute(ctx, { profile, preset, ...args });
+    if (res && res.ok && res.result) {
+      return res.result;
+    }
+  }
   return runWorkflowEngine({
     profile,
     preset,
@@ -252,6 +330,15 @@ function analyze(profile, options = {}) {
     });
   }
   try {
+    // Route through capability (package 07)
+    const cap = capabilities && capabilities.resolve ? capabilities.resolve('analysis.analyze') : null;
+    if (cap && typeof cap.execute === 'function') {
+      const ctx = { ...runtime, args: { profile, ...args } };
+      const res = cap.execute(ctx, { profile, ...args });
+      if (res && res.ok && res.result) {
+        return res.result;
+      }
+    }
     return executeAnalyze({
       profile,
       ...args,

--- a/src/cli/commands/analyzeCommand.js
+++ b/src/cli/commands/analyzeCommand.js
@@ -41,7 +41,7 @@ function printDiagnosticPacks() {
   }
 }
 
-function runAnalyze(args) {
+async function runAnalyze(args) {
   if (args['list-modes']) {
     printWorkflowModes();
     return;
@@ -51,7 +51,20 @@ function runAnalyze(args) {
     return;
   }
   try {
-    const execution = executeAnalyze(args);
+    // Route through capability (package 07)
+    let execution;
+    try {
+      const { capabilities } = require('../../api/zeusApi');
+      const res = capabilities && typeof capabilities.execute === 'function' ? await capabilities.execute('analysis.analyze', { cwd: process.cwd(), env: process.env, args }, args) : null;
+      if (res && res.ok && res.result) {
+        execution = res.result;
+      }
+    } catch (e) {
+      // fallthrough
+    }
+    if (!execution) {
+      execution = executeAnalyze(args);
+    }
     const { result, program, outputProgramDir, guidedMode, workflowPreset, safeSharingEnabled, denseLevel, searchTerms, diagnosticPacks, emitDiagnostics } = execution;
 
     console.log(`Analysis complete for program ${program}`);

--- a/src/cli/commands/bundleCommand.js
+++ b/src/cli/commands/bundleCommand.js
@@ -24,9 +24,17 @@ function runBundle(args) {
     process.exit(2);
   }
 
+  let result;
   try {
-    const config = resolveBundleConfig(args);
-    const result = buildOutputBundle({
+    // Route through capability (package 07)
+    const { capabilities } = require('../../api/zeusApi');
+    const res = capabilities && typeof capabilities.execute === 'function' ? capabilities.execute('bundle.create', { cwd: process.cwd(), env: process.env, args }, args) : null;
+    if (res && res.ok && res.result) {
+      result = res.result;
+    }
+    if (!result) {
+      const config = resolveBundleConfig(args);
+      result = buildOutputBundle({
       program: String(args.program).trim(),
       sourceOutputRoot: config.sourceOutputRoot,
       bundleOutputRoot: config.bundleOutputRoot,
@@ -39,25 +47,26 @@ function runBundle(args) {
       workflowPreset: args['workflow-preset-settings'] || null,
       bundleFileName: args['bundle-file-name'] || null,
     });
+  }
 
-    if (verbose) {
-      console.log(`[verbose] Program output: ${result.programOutputDir}`);
-      console.log(`[verbose] Bundle output: ${result.bundleOutputRoot}`);
-    }
+  if (verbose) {
+    console.log(`[verbose] Program output: ${result.programOutputDir}`);
+    console.log(`[verbose] Bundle output: ${result.bundleOutputRoot}`);
+  }
 
-    const json = createJsonOutput(args);
-    if (json.isJsonMode) {
-      json.print(result);
-      return result;
-    }
-
-    console.log(`Bundle created for program ${result.program}`);
-    if (result.manifest.safeSharing && result.manifest.safeSharing.enabled) {
-      console.log('Safe-sharing bundle: enabled');
-    }
-    console.log(`Files included: ${result.manifest.summary.totalFiles}`);
-    console.log(`Bundle written to: ${result.zipPath}`);
+  const json = createJsonOutput(args);
+  if (json.isJsonMode) {
+    json.print(result);
     return result;
+  }
+
+  console.log(`Bundle created for program ${result.program}`);
+  if (result.manifest.safeSharing && result.manifest.safeSharing.enabled) {
+    console.log('Safe-sharing bundle: enabled');
+  }
+  console.log(`Files included: ${result.manifest.summary.totalFiles}`);
+  console.log(`Bundle written to: ${result.zipPath}`);
+  return result;
   } catch (error) {
     console.error(error.message);
     process.exit(2);

--- a/src/cli/commands/workflowCommand.js
+++ b/src/cli/commands/workflowCommand.js
@@ -143,7 +143,18 @@ async function runWorkflow(args) {
       return;
     }
     try {
-      const state = await runWorkflowEngine(args);
+      // Route through capability (package 07)
+      let state;
+      try {
+        const { capabilities } = require('../../api/zeusApi');
+        const res = capabilities && typeof capabilities.execute === 'function' ? await capabilities.execute('analysis.workflow', { cwd: process.cwd(), env: process.env, args }, args) : null;
+        if (res && res.ok && res.result) {
+          state = res.result;
+        }
+      } catch (e) {}
+      if (!state) {
+        state = await runWorkflowEngine(args);
+      }
       const json = createJsonOutput(args);
       if (json.isJsonMode) {
         json.print(state);


### PR DESCRIPTION
## Problem & Goal
Package 07 migrates the core analysis workflows (analyze, workflow, bundle) to execute through the capability registry while keeping all artifacts, reproducibility, flags, outputs, and behavior exactly the same.

## Architectural Approach
- Registered 'analysis.analyze', 'analysis.workflow', 'bundle.create' in capability registry with execute delegating to core services.
- Updated CLI run* commands to route through cap (with fallback), like pkg 06.
- Updated api exposed functions to use cap.
- Extended generator capIdMap.
- Preserved all logic in services.

## Files / Contracts Intentionally Changed
- src/api/zeusApi.js (registrations + route in analyze/workflow)
- src/cli/commands/analyzeCommand.js, bundleCommand.js, workflowCommand.js (route to cap)
- cli/zeus.js (minor)
- cli/commands/generate-tool-catalog.js (extended map)

## Files / Contracts Intentionally Not Changed
- Core services, scanners, pipelines.
- Other commands.
- Artifact formats, manifests.
- No new features.

## Compatibility & Safety Assessment
- Exact same CLI output, JSON, errors, artifacts, reproducible hashes.
- S1 safety.
- No behavior change.

## Tests Added / Changed
- All listed tests pass: analyze-runtime, manifests, stages, workflow, bundle, safe-sharing, reproducible, demos.

## Exact Validation Commands & Outcomes
```bash
node --test tests/analyze-runtime-contract.test.js ... (all listed)  # PASS
npm run demo:run
npm run demo:prompt
npm run demo:safety-check
```

## Self-Verification Findings
- Goal focus: Yes, only these 3 operations via cap.
- Correctness: Same services, thin routing.
- Test completeness: Full contract + demo.
- Remote integrity: SHA match etc.

## Residual Risks & Deferrals
- Full metadata projection for catalog in later.
- Some internal calls (e.g. in presets) may still direct.

PR under contract.