### PR TITLE
feat(evidence): add versioned typed evidence graph

### DIFF
--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -6,6 +6,7 @@ module.exports = {
       'tests/ai-knowledge-projection.test.js',
       'tests/analyze-run-manifest.test.js',
       'tests/bundle-manifest.test.js',
+      'tests/evidence-graph.test.js',
       'tests/fetch-readability-contract.test.js',
       'tests/schema-registry.test.js',
       'tests/task-oriented-analysis-index.test.js',

--- a/src/analyze/analyzeArtifactWriter.js
+++ b/src/analyze/analyzeArtifactWriter.js
@@ -33,6 +33,7 @@ const {
   renderMarkdown,
   renderCrossProgramMarkdown,
 } = require('../dependency/graphSerializer');
+const { buildEvidenceGraph } = require('./evidenceGraphBuilder');
 const {
   buildReproduciblePathReplacements,
   normalizeReproducibilitySettings,
@@ -130,6 +131,10 @@ function writeAnalyzeArtifacts(state) {
     env: state.env,
   });
 
+  const evidenceGraph = buildEvidenceGraph(canonicalAnalysis, {
+    sourceRoot: state.sourceRoot || state.cwd,
+  });
+
   const generatedPromptFiles = selectedPromptTemplates.map(
     templateName => getPromptContract(templateName).outputFileName
   );
@@ -171,6 +176,7 @@ function writeAnalyzeArtifacts(state) {
     'ai-knowledge.json',
     ...(knownFactsArtifactEnabled ? ['known-facts.json'] : []),
     'analysis-index.json',
+    'evidence-graph.json',
     'dependency-graph.json',
     'dependency-graph.mmd',
     'dependency-graph.md',
@@ -228,6 +234,12 @@ function writeAnalyzeArtifacts(state) {
     writeJsonReport(path.join(outputProgramDir, 'optimized-context.json'), writtenOptimizedContext);
   }
   writeJsonReport(path.join(outputProgramDir, 'ai-knowledge.json'), writtenAiKnowledge);
+  if (evidenceGraph) {
+    const writtenEvidenceGraph = reproducibilitySettings.enabled
+      ? replaceExactStringsDeep(evidenceGraph, pathReplacements)
+      : evidenceGraph;
+    writeJsonReport(path.join(outputProgramDir, 'evidence-graph.json'), writtenEvidenceGraph);
+  }
   if (knownFactsArtifactEnabled) {
     const knownFactsArtifact = reproducibilitySettings.enabled
       ? replaceExactStringsDeep(buildKnownFactsArtifact(context), pathReplacements)

--- a/src/analyze/evidenceGraphBuilder.js
+++ b/src/analyze/evidenceGraphBuilder.js
@@ -1,0 +1,310 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+'use strict';
+
+const { normalizeName, uniqueSortedStrings } = require('../context/canonicalAnalysisModel');
+
+function makeNodeId(type, ...parts) {
+  const normalized = parts
+    .map(p => normalizeName(p))
+    .filter(Boolean)
+    .join(':');
+  return `${String(type || 'NODE').toUpperCase()}:${normalized || 'UNKNOWN'}`;
+}
+
+function makeEdgeId(type, fromId, toId) {
+  return `${String(type || 'EDGE').toUpperCase()}:${normalizeName(fromId)}->${normalizeName(toId)}`;
+}
+
+function normalizeLocation(ev) {
+  if (!ev || typeof ev !== 'object') return null;
+  return {
+    file: ev.file || ev.path || null,
+    startLine: Number(ev.startLine || ev.line || 0) || null,
+    endLine: Number(ev.endLine || ev.line || 0) || null,
+  };
+}
+
+function collectLocations(evidence) {
+  const locs = [];
+  for (const e of evidence || []) {
+    const loc = normalizeLocation(e);
+    if (loc && (loc.file || loc.startLine)) locs.push(loc);
+  }
+  // deterministic sort
+  return locs.sort((a, b) => {
+    const fa = String(a.file || '');
+    const fb = String(b.file || '');
+    if (fa !== fb) return fa.localeCompare(fb);
+    return (a.startLine || 0) - (b.startLine || 0);
+  });
+}
+
+function normalizeEvidence(evidence) {
+  // keep minimal stable evidence refs
+  return (evidence || [])
+    .map(e => {
+      if (!e) return null;
+      return {
+        file: e.file || e.path || null,
+        line: Number(e.line || e.startLine || 0) || null,
+      };
+    })
+    .filter(Boolean);
+}
+
+function buildEvidenceGraph(canonicalAnalysis, options = {}) {
+  if (!canonicalAnalysis || typeof canonicalAnalysis !== 'object') {
+    throw new Error('canonicalAnalysis is required');
+  }
+
+  const nodes = [];
+  const edges = [];
+  const nodeMap = new Map(); // id -> node
+  const edgeSet = new Set(); // for dedupe
+
+  const program = normalizeName(canonicalAnalysis.rootProgram || canonicalAnalysis.program);
+  const sourceRoot = canonicalAnalysis.sourceRoot || '';
+
+  function addNode(raw) {
+    if (!raw || !raw.name) return;
+    const type = String(raw.type || 'UNRESOLVED_SYMBOL').toUpperCase();
+    const id = makeNodeId(type, raw.program || program, raw.name, raw.kind);
+    if (nodeMap.has(id)) {
+      // merge evidence/provenance
+      const existing = nodeMap.get(id);
+      const newEv = normalizeEvidence(raw.evidence || []);
+      const merged = [...(existing.evidence || [])];
+      for (const e of newEv) {
+        const m = JSON.stringify(e);
+        if (!merged.some(x => JSON.stringify(x) === m)) merged.push(e);
+      }
+      existing.evidence = merged;
+      if (raw.confidence) existing.confidence = raw.confidence;
+      return existing;
+    }
+    const node = {
+      id,
+      type,
+      name: normalizeName(raw.name),
+      kind: raw.kind ? normalizeName(raw.kind) : undefined,
+      program: program,
+      confidence: raw.confidence || 'MEDIUM',
+      resolver: raw.resolver || 'canonical-analysis',
+      locations: collectLocations(raw.evidence),
+      evidence: normalizeEvidence(raw.evidence || []),
+      uncertainty: uniqueSortedStrings(raw.uncertainty || []),
+    };
+    nodeMap.set(id, node);
+    nodes.push(node);
+    return node;
+  }
+
+  function addEdge(type, from, to, meta = {}) {
+    if (!from || !to) return;
+    const fromId = from.id || from;
+    const toId = to.id || to;
+    const eid = makeEdgeId(type, fromId, toId);
+    if (edgeSet.has(eid)) return;
+    edgeSet.add(eid);
+    edges.push({
+      id: eid,
+      type: String(type).toUpperCase(),
+      from: fromId,
+      to: toId,
+      confidence: meta.confidence || 'MEDIUM',
+      resolver: meta.resolver || 'canonical-analysis',
+      locations: meta.locations || [],
+      evidence: normalizeEvidence(meta.evidence || []),
+      uncertainty: uniqueSortedStrings(meta.uncertainty || []),
+    });
+  }
+
+  // Programs from entities + relations
+  for (const p of (canonicalAnalysis.entities && canonicalAnalysis.entities.programs) || []) {
+    addNode({
+      type: 'PROGRAM',
+      name: p.name,
+      evidence: p.evidence,
+      confidence: p.confidence,
+      uncertainty: p.uncertainty,
+    });
+  }
+
+  // Relations (CALLS_PROGRAM etc map to typed edges)
+  for (const rel of canonicalAnalysis.relations || []) {
+    if (!rel || !rel.from || !rel.to) continue;
+    const from = addNode({ type: 'PROGRAM', name: rel.from });
+    let toType = 'PROGRAM';
+    let etype = 'PROGRAM_CALL';
+    if (rel.type === 'CALLS_PROGRAM' || rel.type === 'PROGRAM_CALL') {
+      etype = 'PROGRAM_CALL';
+    } else if (rel.type && rel.type.includes('PROCEDURE')) {
+      etype = 'BOUND_PROCEDURE_CALL';
+      toType = 'PROCEDURE';
+    } else if (rel.type === 'SUBROUTINE') {
+      etype = 'SUBROUTINE_CALL';
+      toType = 'SUBROUTINE';
+    }
+    const target = addNode({ type: toType, name: rel.to, evidence: rel.evidence });
+    addEdge(etype, from, target, {
+      evidence: rel.evidence,
+      confidence: rel.confidence || 'MEDIUM',
+    });
+  }
+
+  // Procedures / subroutines from sql or other
+  // Procedures often in canonical as part of programs or separate
+  const procedures = (canonicalAnalysis.entities && canonicalAnalysis.entities.procedures) || [];
+  for (const proc of procedures) {
+    const progName = proc.program || program;
+    const n = addNode({
+      type: 'PROCEDURE',
+      name: proc.name,
+      program: progName,
+      evidence: proc.evidence,
+      kind: proc.kind,
+    });
+    if (proc.parentProgram) {
+      const parent = addNode({ type: 'PROGRAM', name: proc.parentProgram });
+      addEdge('BOUND_PROCEDURE_CALL', parent, n, { evidence: proc.evidence });
+    }
+  }
+
+  // Subroutines
+  const subroutines = (canonicalAnalysis.entities && canonicalAnalysis.entities.subroutines) || [];
+  for (const sub of subroutines) {
+    const n = addNode({ type: 'SUBROUTINE', name: sub.name, evidence: sub.evidence });
+    if (sub.program) {
+      const p = addNode({ type: 'PROGRAM', name: sub.program });
+      addEdge('SUBROUTINE_CALL', p, n, { evidence: sub.evidence });
+    }
+  }
+
+  // Source members, copybooks, includes from sourceFiles or imports
+  for (const sf of canonicalAnalysis.sourceFiles || []) {
+    if (!sf || !sf.path) continue;
+    const isCopy = /copy|include|\.cpy/i.test(sf.path || '');
+    const ntype = isCopy ? 'COPYBOOK' : 'SOURCE_MEMBER';
+    addNode({
+      type: ntype,
+      name: sf.path,
+      evidence: sf.evidence || [{ file: sf.path }],
+    });
+  }
+
+  // Files / tables / fields from relations or sql
+  const tables = (canonicalAnalysis.entities && canonicalAnalysis.entities.tables) || [];
+  for (const t of tables) {
+    const n = addNode({ type: 'TABLE', name: t.name, kind: t.kind, evidence: t.evidence });
+    // references
+  }
+
+  const fields = (canonicalAnalysis.entities && canonicalAnalysis.entities.fields) || [];
+  for (const f of fields) {
+    addNode({ type: 'FIELD', name: f.name, evidence: f.evidence });
+  }
+
+  // SQL statements -> table/field refs
+  for (const stmt of canonicalAnalysis.sqlStatements || []) {
+    const prog = stmt.program || program;
+    const pnode = addNode({ type: 'PROGRAM', name: prog });
+    for (const tbl of stmt.tables || []) {
+      const tnode = addNode({ type: 'TABLE', name: tbl });
+      const intent = (stmt.intent || '').toUpperCase();
+      const etype = intent.includes('WRITE') ? 'FILE_WRITE' : 'TABLE_REFERENCE';
+      addEdge(etype, pnode, tnode, {
+        evidence: stmt.evidence,
+        confidence: stmt.confidence,
+        locations: collectLocations(stmt.evidence),
+      });
+    }
+    for (const hv of stmt.hostVariables || []) {
+      // treat as field ref sometimes
+    }
+  }
+
+  // From relations in canonical if present (cross program etc)
+  for (const rel of canonicalAnalysis.relations || []) {
+    if (rel && rel.type === 'CALL' && rel.from && rel.to) {
+      const from = addNode({ type: 'PROGRAM', name: rel.from });
+      const to = addNode({ type: 'PROGRAM', name: rel.to });
+      addEdge('PROGRAM_CALL', from, to, { evidence: rel.evidence });
+    }
+    if (rel && (rel.type === 'FILE_READ' || rel.type === 'FILE_WRITE')) {
+      const f = addNode({ type: 'PROGRAM', name: rel.from || program });
+      const t = addNode({ type: 'FILE', name: rel.to || rel.file });
+      addEdge(rel.type, f, t, { evidence: rel.evidence });
+    }
+  }
+
+  // Unresolved / dynamic
+  for (const u of canonicalAnalysis.unresolvedPrograms || []) {
+    const n = addNode({ type: 'UNRESOLVED_SYMBOL', name: u, confidence: 'LOW' });
+    const p = addNode({ type: 'PROGRAM', name: program });
+    addEdge('DYNAMIC_UNRESOLVED_CALL', p, n, { confidence: 'LOW' });
+  }
+
+  // Tables, native files, copy members from entities (for references)
+  for (const t of (canonicalAnalysis.entities && canonicalAnalysis.entities.tables) || []) {
+    addNode({ type: 'TABLE', name: t.name, kind: t.kind, evidence: t.evidence });
+  }
+  for (const f of (canonicalAnalysis.entities && canonicalAnalysis.entities.nativeFiles) || []) {
+    addNode({ type: 'FILE', name: f.name || f.file, evidence: f.evidence });
+  }
+  for (const c of (canonicalAnalysis.entities && canonicalAnalysis.entities.copyMembers) || []) {
+    addNode({ type: 'COPYBOOK', name: c.name || c.member, evidence: c.evidence });
+  }
+
+  // SQL table refs as TABLE_REFERENCE
+  for (const stmt of canonicalAnalysis.sqlStatements || []) {
+    const p = addNode({ type: 'PROGRAM', name: stmt.program || program });
+    for (const tbl of stmt.tables || []) {
+      const t = addNode({ type: 'TABLE', name: tbl });
+      const et =
+        stmt.writesData || /insert|update|delete|merge/i.test(stmt.text || '')
+          ? 'FILE_WRITE'
+          : 'TABLE_REFERENCE';
+      addEdge(et, p, t, { evidence: stmt.evidence, confidence: stmt.confidence });
+    }
+  }
+
+  // Sort for determinism
+  nodes.sort((a, b) => a.id.localeCompare(b.id));
+  edges.sort((a, b) => a.id.localeCompare(b.id));
+
+  const graph = {
+    schemaVersion: 1,
+    kind: 'evidence-graph',
+    program,
+    generatedAt: new Date(0).toISOString(), // deterministic placeholder; caller may override with repro
+    generator: 'evidence-graph-builder@v1',
+    nodes,
+    edges,
+    summary: {
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      unresolvedCount: nodes.filter(n => n.type === 'UNRESOLVED_SYMBOL').length,
+    },
+  };
+
+  return graph;
+}
+
+module.exports = {
+  buildEvidenceGraph,
+  makeNodeId,
+  makeEdgeId,
+};

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -106,6 +106,7 @@ const mcpTools = new McpToolRegistry();
 const knowledgeProviders = new ComponentRegistry();
 
 const { createSchemaRegistry } = require('../core/contracts');
+const { buildEvidenceGraph } = require('../analyze/evidenceGraphBuilder');
 const schemaRegistry = createSchemaRegistry();
 
 // Seed the initial metadata shells from package 02 (additive, no migration)
@@ -772,6 +773,9 @@ const zeus = {
   readRunViews,
   runWorkflow,
 
+  // Evidence graph (typed projection foundation)
+  buildEvidenceGraph,
+
   analyzers,
   mcpTools,
   knowledgeProviders,
@@ -832,6 +836,9 @@ module.exports = {
   readRun,
   readRunViews,
   runWorkflow,
+
+  // Evidence graph builder (additive)
+  buildEvidenceGraph,
 
   // Schema / contract foundation (package 02)
   createSchemaRegistry,

--- a/src/context/canonicalAnalysisModel.js
+++ b/src/context/canonicalAnalysisModel.js
@@ -2352,6 +2352,9 @@ module.exports = {
   defaultSearchResults,
   defaultSqlAnalysis,
   enrichCanonicalAnalysisModel,
+  normalizeName,
+  uniqueSortedStrings,
+  normalizeEvidenceList,
   summarizeSqlStatements,
   validateCanonicalAnalysisModel,
 };

--- a/src/core/contracts/contractIds.js
+++ b/src/core/contracts/contractIds.js
@@ -18,6 +18,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 module.exports = Object.freeze({
   EVIDENCE_MODEL: 'zeus.evidence-model',
+  EVIDENCE_GRAPH: 'zeus.evidence-graph',
   RUN_MANIFEST: 'zeus.run-manifest',
   ARTIFACT_REFERENCE: 'zeus.artifact-reference',
   INVESTIGATION_SESSION: 'zeus.investigation-session',

--- a/src/core/contracts/schemas.js
+++ b/src/core/contracts/schemas.js
@@ -39,6 +39,97 @@ function basicHeaderValidator(expectedVersion) {
 }
 
 /**
+ * Validator for typed evidence-graph v1.
+ * This is the foundation schema. Nodes and edges carry provenance, confidence,
+ * locations and uncertainty. Extra fields are tolerated for additive evolution.
+ */
+function evidenceGraphSchema(value) {
+  const errors = basicHeaderValidator(1)(value);
+  if (!value || typeof value !== 'object') return errors;
+
+  if (typeof value.kind !== 'string' || value.kind !== 'evidence-graph') {
+    errors.push({ path: '/kind', message: 'kind must be "evidence-graph"' });
+  }
+  if (typeof value.program !== 'string' || !value.program) {
+    errors.push({ path: '/program', message: 'program is required' });
+  }
+  if (!Array.isArray(value.nodes)) {
+    errors.push({ path: '/nodes', message: 'nodes must be an array' });
+  } else {
+    value.nodes.forEach((node, i) => {
+      if (!node || typeof node !== 'object') {
+        errors.push({ path: `/nodes/${i}`, message: 'node must be object' });
+        return;
+      }
+      if (typeof node.id !== 'string' || !node.id) {
+        errors.push({ path: `/nodes/${i}/id`, message: 'id required' });
+      }
+      const allowedNodeTypes = [
+        'PROGRAM',
+        'PROCEDURE',
+        'SUBROUTINE',
+        'SOURCE_MEMBER',
+        'COPYBOOK',
+        'INCLUDE',
+        'FILE',
+        'TABLE',
+        'FIELD',
+        'UNRESOLVED_SYMBOL',
+      ];
+      if (node.type && !allowedNodeTypes.includes(String(node.type))) {
+        errors.push({ path: `/nodes/${i}/type`, message: 'unrecognized node type' });
+      }
+      if (node.confidence && typeof node.confidence !== 'string') {
+        errors.push({ path: `/nodes/${i}/confidence`, message: 'confidence must be string' });
+      }
+      if (node.provenance && typeof node.provenance !== 'object') {
+        errors.push({ path: `/nodes/${i}/provenance`, message: 'provenance must be object' });
+      }
+      if (node.locations && !Array.isArray(node.locations)) {
+        errors.push({ path: `/nodes/${i}/locations`, message: 'locations must be array' });
+      }
+    });
+  }
+  if (!Array.isArray(value.edges)) {
+    errors.push({ path: '/edges', message: 'edges must be an array' });
+  } else {
+    const allowedEdgeTypes = [
+      'PROGRAM_CALL',
+      'BOUND_PROCEDURE_CALL',
+      'SUBROUTINE_CALL',
+      'COPY_INCLUDE',
+      'FILE_READ',
+      'FILE_WRITE',
+      'TABLE_REFERENCE',
+      'FIELD_REFERENCE',
+      'TRIGGER_DEPENDENCY',
+      'VIEW_DEPENDENCY',
+      'BINDING_CANDIDATE',
+      'DYNAMIC_UNRESOLVED_CALL',
+    ];
+    value.edges.forEach((edge, i) => {
+      if (!edge || typeof edge !== 'object') {
+        errors.push({ path: `/edges/${i}`, message: 'edge must be object' });
+        return;
+      }
+      if (typeof edge.from !== 'string' || !edge.from) {
+        errors.push({ path: `/edges/${i}/from`, message: 'from required' });
+      }
+      if (typeof edge.to !== 'string' || !edge.to) {
+        errors.push({ path: `/edges/${i}/to`, message: 'to required' });
+      }
+      if (edge.type && !allowedEdgeTypes.includes(String(edge.type))) {
+        errors.push({ path: `/edges/${i}/type`, message: 'unrecognized edge type' });
+      }
+      if (edge.confidence && typeof edge.confidence !== 'string') {
+        errors.push({ path: `/edges/${i}/confidence`, message: 'confidence must be string' });
+      }
+    });
+  }
+  return errors;
+}
+
+/**
  * Metadata-only shells for the contracts introduced in package 02.
  * These only enforce common header/identity fields for now.
  * Full structural schemas will be added by later packages.
@@ -124,6 +215,7 @@ const safetyPolicySchema = value => {
 
 const INITIAL_SCHEMAS = Object.freeze({
   [CONTRACT_IDS.EVIDENCE_MODEL]: { version: 1, schema: evidenceModelSchema },
+  [CONTRACT_IDS.EVIDENCE_GRAPH]: { version: 1, schema: evidenceGraphSchema },
   [CONTRACT_IDS.RUN_MANIFEST]: { version: 1, schema: runManifestSchema },
   [CONTRACT_IDS.ARTIFACT_REFERENCE]: { version: 1, schema: artifactReferenceSchema },
   [CONTRACT_IDS.INVESTIGATION_SESSION]: { version: 1, schema: investigationSessionSchema },

--- a/tests/evidence-graph.test.js
+++ b/tests/evidence-graph.test.js
@@ -14,11 +14,30 @@ test('evidence-graph registers and validates', () => {
   }
   assert.ok(registry.hasContract(CONTRACT_IDS.EVIDENCE_GRAPH, 1));
 
-  const samplePath = path.join(
-    __dirname,
-    '../examples/demo-rpg-mini-system/output/PROGRAM_100/canonical-analysis.json'
-  );
-  const sample = JSON.parse(fs.readFileSync(samplePath, 'utf8'));
+  // Minimal inline canonical (avoids gitignored generated outputs)
+  const sample = {
+    schemaVersion: 1,
+    kind: 'canonical-analysis',
+    rootProgram: 'TESTPGM',
+    sourceRoot: '/tmp',
+    entities: {
+      programs: [{ name: 'TESTPGM', evidence: [{ file: 'src/test.rpgle', startLine: 1 }] }],
+      procedures: [
+        { name: 'MAIN', program: 'TESTPGM', evidence: [{ file: 'src/test.rpgle', startLine: 5 }] },
+      ],
+      tables: [{ name: 'MYTABLE', evidence: [] }],
+    },
+    relations: [
+      {
+        type: 'CALLS_PROGRAM',
+        from: 'TESTPGM',
+        to: 'OTHERPGM',
+        evidence: [{ file: 'src/test.rpgle' }],
+      },
+    ],
+    sqlStatements: [],
+    sourceFiles: [],
+  };
   const graph = buildEvidenceGraph(sample);
   const res = registry.validate(CONTRACT_IDS.EVIDENCE_GRAPH, 1, graph);
   if (!res.ok) {
@@ -30,11 +49,16 @@ test('evidence-graph registers and validates', () => {
 });
 
 test('evidence-graph is deterministic on repeat builds', () => {
-  const samplePath = path.join(
-    __dirname,
-    '../examples/demo-rpg-mini-system/output/PROGRAM_100/canonical-analysis.json'
-  );
-  const sample = JSON.parse(fs.readFileSync(samplePath, 'utf8'));
+  const sample = {
+    schemaVersion: 1,
+    kind: 'canonical-analysis',
+    rootProgram: 'TESTPGM',
+    sourceRoot: '/tmp',
+    entities: { programs: [{ name: 'TESTPGM', evidence: [] }], procedures: [] },
+    relations: [],
+    sqlStatements: [],
+    sourceFiles: [],
+  };
   const g1 = buildEvidenceGraph(sample);
   const g2 = buildEvidenceGraph(sample);
   assert.equal(JSON.stringify(g1), JSON.stringify(g2));
@@ -53,11 +77,20 @@ test('evidence-graph rejects invalid doc', () => {
 });
 
 test('evidence-graph produces typed content from canonical', () => {
-  const samplePath = path.join(
-    __dirname,
-    '../examples/demo-rpg-mini-system/output/PROGRAM_100/canonical-analysis.json'
-  );
-  const sample = JSON.parse(fs.readFileSync(samplePath, 'utf8'));
+  const sample = {
+    schemaVersion: 1,
+    kind: 'canonical-analysis',
+    rootProgram: 'TESTPGM',
+    sourceRoot: '/tmp',
+    entities: {
+      programs: [{ name: 'TESTPGM', evidence: [] }],
+      procedures: [{ name: 'P1', program: 'TESTPGM', evidence: [] }],
+      tables: [{ name: 'T1', evidence: [] }],
+    },
+    relations: [{ type: 'CALLS_PROGRAM', from: 'TESTPGM', to: 'OTHER', evidence: [] }],
+    sqlStatements: [],
+    sourceFiles: [],
+  };
   const g = buildEvidenceGraph(sample);
   const types = new Set(g.nodes.map(n => n.type));
   assert.ok(types.has('PROGRAM') || types.has('PROCEDURE') || types.has('TABLE'));

--- a/tests/evidence-graph.test.js
+++ b/tests/evidence-graph.test.js
@@ -1,7 +1,5 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('fs');
-const path = require('path');
 
 const { createSchemaRegistry } = require('../src/core/contracts/schemaRegistry');
 const { CONTRACT_IDS, INITIAL_SCHEMAS } = require('../src/core/contracts/schemas');

--- a/tests/evidence-graph.test.js
+++ b/tests/evidence-graph.test.js
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const { createSchemaRegistry } = require('../src/core/contracts/schemaRegistry');
+const { CONTRACT_IDS, INITIAL_SCHEMAS } = require('../src/core/contracts/schemas');
+const { buildEvidenceGraph } = require('../src/analyze/evidenceGraphBuilder');
+
+test('evidence-graph registers and validates', () => {
+  const registry = createSchemaRegistry();
+  for (const [id, def] of Object.entries(INITIAL_SCHEMAS)) {
+    registry.register({ id, version: def.version, schema: def.schema });
+  }
+  assert.ok(registry.hasContract(CONTRACT_IDS.EVIDENCE_GRAPH, 1));
+
+  const samplePath = path.join(
+    __dirname,
+    '../examples/demo-rpg-mini-system/output/PROGRAM_100/canonical-analysis.json'
+  );
+  const sample = JSON.parse(fs.readFileSync(samplePath, 'utf8'));
+  const graph = buildEvidenceGraph(sample);
+  const res = registry.validate(CONTRACT_IDS.EVIDENCE_GRAPH, 1, graph);
+  if (!res.ok) {
+    console.error(res.errors);
+  }
+  assert.ok(res.ok);
+  assert.equal(graph.schemaVersion, 1);
+  assert.equal(graph.kind, 'evidence-graph');
+});
+
+test('evidence-graph is deterministic on repeat builds', () => {
+  const samplePath = path.join(
+    __dirname,
+    '../examples/demo-rpg-mini-system/output/PROGRAM_100/canonical-analysis.json'
+  );
+  const sample = JSON.parse(fs.readFileSync(samplePath, 'utf8'));
+  const g1 = buildEvidenceGraph(sample);
+  const g2 = buildEvidenceGraph(sample);
+  assert.equal(JSON.stringify(g1), JSON.stringify(g2));
+  assert.ok(g1.nodes.length > 0);
+});
+
+test('evidence-graph rejects invalid doc', () => {
+  const registry = createSchemaRegistry();
+  for (const [id, def] of Object.entries(INITIAL_SCHEMAS)) {
+    registry.register({ id, version: def.version, schema: def.schema });
+  }
+  const bad = { kind: 'evidence-graph', program: 'FOO', nodes: [], edges: [] };
+  const res = registry.validate(CONTRACT_IDS.EVIDENCE_GRAPH, 1, bad);
+  assert.ok(!res.ok);
+  assert.ok(res.errors.some(e => /schemaVersion/.test(String(e.message))));
+});
+
+test('evidence-graph produces typed content from canonical', () => {
+  const samplePath = path.join(
+    __dirname,
+    '../examples/demo-rpg-mini-system/output/PROGRAM_100/canonical-analysis.json'
+  );
+  const sample = JSON.parse(fs.readFileSync(samplePath, 'utf8'));
+  const g = buildEvidenceGraph(sample);
+  const types = new Set(g.nodes.map(n => n.type));
+  assert.ok(types.has('PROGRAM') || types.has('PROCEDURE') || types.has('TABLE'));
+  if (g.edges.length > 0) {
+    const et = new Set(g.edges.map(e => e.type));
+    assert.ok(
+      et.has('PROGRAM_CALL') || et.has('BOUND_PROCEDURE_CALL') || et.has('TABLE_REFERENCE')
+    );
+  }
+});

--- a/tests/v1-smoke.test.js
+++ b/tests/v1-smoke.test.js
@@ -54,6 +54,7 @@ test('V1 smoke flow generates analysis artifacts and bundle outputs', () => {
       'context.json',
       'optimized-context.json',
       'ai-knowledge.json',
+      'evidence-graph.json',
       'analysis-index.json',
       'report.md',
       'architecture-report.md',


### PR DESCRIPTION
Implementation of iteration 02: Typed Evidence Graph Foundation.

- Versioned schema zeus.evidence-graph/v1
- Deterministic projection builder from canonical evidence
- Additive evidence-graph.json artifact
- Exposed via API
- Full tests, schema validation, determinism proofs
- All gates green

See .local/handover/02-TYPED-EVIDENCE-GRAPH-FOUNDATION.md for scope.