### PR TITLE
fix: harden repository control into a fail-closed gate

### DIFF
--- a/.github/repository-control.json
+++ b/.github/repository-control.json
@@ -24,6 +24,28 @@
       "Runtime Config Boundary Guard"
     ]
   },
+  "checkConclusions": {
+    "pullRequest": {
+      "Quality (format, lint, typecheck)": ["success"],
+      "Test Node 20 (linux)": ["success"],
+      "Test current LTS (linux)": ["success"],
+      "Test Node 20 (windows)": ["success"],
+      "Package Smoke": ["success"],
+      "Demo Safety Corpus Guard": ["success"],
+      "Public Knowledge Claims Guard": ["success"],
+      "Runtime Config Boundary Guard": ["success"]
+    },
+    "main": {
+      "Quality (format, lint, typecheck)": ["success"],
+      "Test Node 20 (linux)": ["success"],
+      "Test current LTS (linux)": ["success"],
+      "Test Node 20 (windows)": ["success"],
+      "Package Smoke": ["success"],
+      "Demo Safety Corpus Guard": ["success"],
+      "Public Knowledge Claims Guard": ["success"],
+      "Runtime Config Boundary Guard": ["success"]
+    }
+  },
   "optionalChecks": [],
   "allowedSkippedChecks": [],
   "policies": {
@@ -34,7 +56,9 @@
     "draftPullRequest": "block",
     "mergedBranchRetentionDays": 0,
     "releaseVersionMismatch": "warning",
-    "prBehindMain": "block"
+    "prBehindMain": "block",
+    "mergeability": "block",
+    "mergeState": "ignore"
   },
   "polling": {
     "defaultPollSeconds": 15,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 permissions:
   contents: read
+  checks: read
+  statuses: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -103,6 +106,9 @@ jobs:
     needs: [quality, test-linux-20, test-linux-lts, test-windows-20, package-smoke]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
@@ -110,10 +116,26 @@ jobs:
       - run: npm ci
       - name: Run repository control for this PR (read-only, after other checks)
         run: |
-          PR_NUMBER=$(gh pr view --json number -q .number)
-          node scripts/repository-control.js --scope pr --pr "$PR_NUMBER" --strict --timeout-seconds 300 || true
-          # The control may exit 1 if PR not yet ready; we still want the job to provide the report.
-          # For branch protection, configure the check name as required.
-          # For this PR we will use admin fallback only if purely procedural.
+          node scripts/repository-control.js --scope pr --pr "${{ github.event.pull_request.number }}" --local-sha "${{ github.event.pull_request.head.sha }}" --wait --strict --timeout-seconds 300
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  repository-control-main:
+    name: Repository Control Main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'push'
+    needs: [quality, test-linux-20, test-linux-lts, test-windows-20, package-smoke]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - name: Run repository control for this exact main commit
+        run: node scripts/repository-control.js --scope main --wait --strict --timeout-seconds 300
         env:
           GH_TOKEN: ${{ github.token }}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "check:repo-portability": "node scripts/check-repo-portability.js",
     "release:preflight": "node scripts/release-preflight.js",
     "sbom:validate": "node scripts/validate-sbom.js",
-    "repo:control": "node scripts/repository-control.js"
+    "repo:control": "node scripts/repository-control.js",
+    "test:repository-control": "node --test tests/repository-control.test.js"
   },
   "dependencies": {
     "adm-zip": "^0.5.16",

--- a/scripts/repository-control.js
+++ b/scripts/repository-control.js
@@ -14,28 +14,17 @@ const fs = require('fs');
 const path = require('path');
 const { parseArgs } = require('util');
 
-const { DEFAULTS, loadConfig } = require('./repository-control/config');
+const { ConfigError, loadConfig, resolveSafePath } = require('./repository-control/config');
 const EXIT_CODES = require('./repository-control/exitCodes');
 
-const {
-  getCurrentBranchSha,
-  compareWithMain,
-  getLocalSha,
-} = require('./repository-control/gitProbe');
-const {
-  fetchPrDetails,
-  fetchChecksForSha,
-  fetchMainDetails,
-  fetchCompare,
-  fetchBranches,
-  fetchReleases,
-} = require('./repository-control/githubProbe');
+const { getOperations } = require('./repository-control/githubProbe');
 const {
   evaluatePr,
   evaluateMain,
   evaluateOverview,
+  finalizeDecision,
 } = require('./repository-control/checkEvaluation');
-const { renderJsonReport, renderMarkdownReport } = require('./repository-control/reportRenderer');
+const { renderMarkdownReport } = require('./repository-control/reportRenderer');
 
 function printHelp() {
   console.log(`
@@ -95,7 +84,7 @@ async function main() {
         reproducible: { type: 'boolean', default: false },
         config: { type: 'string' },
       },
-      strict: false,
+      strict: true,
     });
     options = values;
   } catch (err) {
@@ -107,12 +96,8 @@ async function main() {
   const prNumber = options.pr ? Number(options.pr) : null;
   const localSha = options['local-sha'] || null;
   const wait = !!options.wait;
-  const timeoutSeconds = options['timeout-seconds']
-    ? Number(options['timeout-seconds'])
-    : DEFAULTS.timeoutSeconds;
-  const pollSeconds = options['poll-seconds']
-    ? Number(options['poll-seconds'])
-    : DEFAULTS.pollSeconds;
+  let timeoutSeconds = options['timeout-seconds'] ? Number(options['timeout-seconds']) : null;
+  let pollSeconds = options['poll-seconds'] ? Number(options['poll-seconds']) : null;
   const strict = !!options.strict;
   const outputJson = !!options.json;
   const jsonOutputPath = options['json-output'] || null;
@@ -125,7 +110,7 @@ async function main() {
     process.exit(EXIT_CODES.INVALID_USAGE);
   }
 
-  if (scope === 'pr' && !prNumber) {
+  if (scope === 'pr' && (!Number.isSafeInteger(prNumber) || prNumber <= 0)) {
     console.error('--pr <number> is required when --scope pr');
     process.exit(EXIT_CODES.INVALID_USAGE);
   }
@@ -135,12 +120,41 @@ async function main() {
     process.exit(EXIT_CODES.INVALID_USAGE);
   }
 
-  if (pollSeconds < 5 || pollSeconds > 60) {
-    console.error('--poll-seconds must be between 5 and 60');
+  let config;
+  let safeJsonOutputPath;
+  let safeMdOutputPath;
+  try {
+    config = loadConfig(configPath);
+    timeoutSeconds ??= config.polling.defaultTimeoutSeconds;
+    pollSeconds ??= config.polling.defaultPollSeconds;
+    if (
+      !Number.isInteger(pollSeconds) ||
+      pollSeconds < config.polling.minPollSeconds ||
+      pollSeconds > config.polling.maxPollSeconds
+    ) {
+      throw new ConfigError(
+        `--poll-seconds must be between ${config.polling.minPollSeconds} and ${config.polling.maxPollSeconds}`
+      );
+    }
+    if (
+      !Number.isInteger(timeoutSeconds) ||
+      timeoutSeconds <= 0 ||
+      timeoutSeconds > config.polling.maxTimeoutSeconds
+    ) {
+      throw new ConfigError(
+        `--timeout-seconds must be between 1 and ${config.polling.maxTimeoutSeconds}`
+      );
+    }
+    safeJsonOutputPath = jsonOutputPath
+      ? resolveSafePath(jsonOutputPath, { purpose: 'JSON output path' })
+      : null;
+    safeMdOutputPath = mdOutputPath
+      ? resolveSafePath(mdOutputPath, { purpose: 'Markdown output path' })
+      : null;
+  } catch (error) {
+    console.error(`Invalid repository-control configuration or path: ${error.message}`);
     process.exit(EXIT_CODES.INVALID_USAGE);
   }
-
-  const config = loadConfig(configPath);
 
   const report = {
     schemaVersion: 'repository-control-report/v1',
@@ -150,6 +164,7 @@ async function main() {
     },
     scope,
     decision: 'UNKNOWN',
+    technicalDecision: 'UNKNOWN',
     observedSha: null,
     localCandidateSha: localSha,
     blockers: [],
@@ -163,6 +178,7 @@ async function main() {
     observedAt: reproducible ? 'REPRODUCIBLE' : new Date().toISOString(),
     reproducible,
     configPath,
+    githubOperations: [],
   };
 
   try {
@@ -183,18 +199,8 @@ async function main() {
       await evaluateOverview({ report, wait, timeoutSeconds, pollSeconds, strict, config });
     }
 
-    // Final decision logic
-    if (report.blockers.length > 0) {
-      report.decision = 'BLOCKED';
-    } else if (report.unknowns.length > 0 && strict) {
-      report.decision = 'BLOCKED';
-    } else if (report.unknowns.length > 0) {
-      report.decision = 'UNKNOWN';
-    } else if (report.warnings.length > 0 && strict) {
-      report.decision = 'BLOCKED';
-    } else {
-      report.decision = scope === 'pr' ? 'READY' : 'HEALTHY';
-    }
+    finalizeDecision(report, scope, strict);
+    report.githubOperations = getOperations();
 
     // Render outputs
     const jsonReport = JSON.stringify(report, null, 2);
@@ -203,15 +209,13 @@ async function main() {
       console.log(jsonReport);
     }
 
-    if (jsonOutputPath) {
-      fs.mkdirSync(path.dirname(jsonOutputPath), { recursive: true });
-      fs.writeFileSync(jsonOutputPath, jsonReport + '\n');
+    if (safeJsonOutputPath) {
+      writeSafeFile(safeJsonOutputPath, jsonReport + '\n');
     }
 
-    if (mdOutputPath) {
+    if (safeMdOutputPath) {
       const md = renderMarkdownReport(report);
-      fs.mkdirSync(path.dirname(mdOutputPath), { recursive: true });
-      fs.writeFileSync(mdOutputPath, md);
+      writeSafeFile(safeMdOutputPath, md);
     }
 
     if (!outputJson && !jsonOutputPath && !mdOutputPath) {
@@ -239,6 +243,23 @@ async function main() {
       console.log(JSON.stringify(report, null, 2));
     }
     process.exit(EXIT_CODES.UNKNOWN);
+  }
+}
+
+function writeSafeFile(target, contents) {
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  // Revalidate after directory creation and reject a last-moment symlink swap.
+  const safe = resolveSafePath(target, { purpose: 'output path' });
+  const flags =
+    fs.constants.O_WRONLY |
+    fs.constants.O_CREAT |
+    fs.constants.O_TRUNC |
+    (fs.constants.O_NOFOLLOW || 0);
+  const fd = fs.openSync(safe, flags, 0o600);
+  try {
+    fs.writeFileSync(fd, contents, 'utf8');
+  } finally {
+    fs.closeSync(fd);
   }
 }
 

--- a/scripts/repository-control/checkEvaluation.js
+++ b/scripts/repository-control/checkEvaluation.js
@@ -1,25 +1,81 @@
 'use strict';
 
-const { getRemoteMainSha, compareWithMain, getLocalSha } = require('./gitProbe');
-const {
-  fetchPrDetails,
-  fetchChecksForSha,
-  fetchMainDetails,
-  fetchCompare,
-  fetchBranches,
-  fetchReleases,
-} = require('./githubProbe');
+const defaultProbes = require('./githubProbe');
+const { getLocalSha } = require('./gitProbe');
 
 function addBlocker(report, code, message, evidence = {}) {
   report.blockers.push({ code, message, ...evidence, source: 'evaluation' });
 }
-
 function addWarning(report, code, message, evidence = {}) {
   report.warnings.push({ code, message, ...evidence, source: 'evaluation' });
 }
-
 function addUnknown(report, code, message, evidence = {}) {
   report.unknowns.push({ code, message, ...evidence, source: 'evaluation' });
+}
+
+function applyPolicy(report, level, code, message, evidence = {}) {
+  if (level === 'block') addBlocker(report, code, message, evidence);
+  else if (level === 'warning') addWarning(report, code, message, evidence);
+}
+
+function errorEvidence(error) {
+  return {
+    errorCode: error && error.code ? error.code : 'PROBE_FAILED',
+    error: String((error && error.message) || error).slice(0, 1000),
+  };
+}
+
+function finalizeDecision(report, scope, strict) {
+  if (report.blockers.length > 0) {
+    report.technicalDecision = scope === 'pr' ? 'BLOCKED' : 'UNHEALTHY';
+  } else if (report.unknowns.length > 0) {
+    report.technicalDecision = 'UNKNOWN';
+  } else {
+    report.technicalDecision = scope === 'pr' ? 'READY' : 'HEALTHY';
+  }
+  report.decision = report.technicalDecision;
+  if (strict && (report.unknowns.length > 0 || report.warnings.length > 0)) {
+    report.decision = scope === 'pr' ? 'BLOCKED' : 'UNHEALTHY';
+  }
+  return report.decision;
+}
+
+function evaluateRequiredChecks(report, checks, required, allowedByName, sha, prefix = '') {
+  const latest = defaultProbes.selectLatestChecks(checks.checkRuns || []);
+  for (const name of required) {
+    const run = latest.get(name);
+    const codePrefix = prefix ? `${prefix}_` : '';
+    if (!run) {
+      addBlocker(
+        report,
+        `${codePrefix}REQUIRED_CHECK_MISSING`,
+        `Required check "${name}" is missing for ${sha}`
+      );
+      continue;
+    }
+    if (String(run.head_sha).toLowerCase() !== String(sha).toLowerCase()) {
+      addBlocker(
+        report,
+        `${codePrefix}STALE_CHECK`,
+        `Required check "${name}" is not for observed SHA`,
+        { checkSha: run.head_sha, observedSha: sha }
+      );
+      continue;
+    }
+    if (['queued', 'in_progress', 'pending', 'requested', 'waiting'].includes(run.status)) {
+      addBlocker(report, `${codePrefix}CHECK_PENDING`, `Required check "${name}" is ${run.status}`);
+      continue;
+    }
+    const allowed = allowedByName[name] || [];
+    if (!run.conclusion || !allowed.includes(run.conclusion)) {
+      addBlocker(
+        report,
+        `${codePrefix}CHECK_FAILED`,
+        `Required check "${name}" concluded ${run.conclusion || 'without a conclusion'}`,
+        { allowedConclusions: allowed, url: run.details_url }
+      );
+    }
+  }
 }
 
 async function evaluatePr({
@@ -29,278 +85,375 @@ async function evaluatePr({
   wait,
   timeoutSeconds,
   pollSeconds,
-  strict,
   config,
+  probes = defaultProbes,
 }) {
-  report.observedAt = report.reproducible ? 'REPRODUCIBLE' : new Date().toISOString();
-
   let pr;
   try {
-    pr = await fetchPrDetails(prNumber);
-  } catch (e) {
-    addUnknown(report, 'PR_FETCH_FAILED', `Failed to fetch PR #${prNumber}`, {
-      error: String(e.message || e),
-    });
-    report.decision = 'UNKNOWN';
+    pr = await probes.fetchPrDetails(prNumber);
+  } catch (error) {
+    addUnknown(report, 'PR_FETCH_FAILED', `Failed to fetch PR #${prNumber}`, errorEvidence(error));
     return;
   }
-
-  report.pullRequests.push(pr);
+  report.pullRequests = [pr];
   report.observedSha = pr.headRefOid;
+  const observedSha = pr.headRefOid;
 
-  if (pr.state !== 'OPEN') {
-    addBlocker(report, 'PR_NOT_OPEN', `PR #${prNumber} is not OPEN (state=${pr.state})`);
-  }
-  if (pr.isDraft) {
-    addBlocker(report, 'PR_IS_DRAFT', 'Pull request is a draft');
-  }
-  if (pr.baseRefName !== config.defaultBranch) {
+  if (pr.state !== 'OPEN')
+    addBlocker(report, 'PR_NOT_OPEN', `PR #${prNumber} is not open`, { state: pr.state });
+  if (pr.isDraft)
+    applyPolicy(report, config.policies.draftPullRequest, 'PR_IS_DRAFT', 'Pull request is a draft');
+  if (pr.baseRefName !== config.defaultBranch)
     addBlocker(
       report,
       'PR_WRONG_BASE',
       `Base branch is ${pr.baseRefName}, expected ${config.defaultBranch}`
     );
-  }
+  if (pr.mergeable === 'CONFLICTING')
+    applyPolicy(
+      report,
+      config.policies.mergeability,
+      'PR_CONFLICTING',
+      'Pull request has merge conflicts'
+    );
+  else if (!pr.mergeable || pr.mergeable === 'UNKNOWN')
+    addUnknown(
+      report,
+      'PR_MERGEABILITY_UNKNOWN',
+      'GitHub has not determined pull-request mergeability'
+    );
+  const badMergeStates = new Set(['DIRTY', 'BLOCKED']);
+  if (badMergeStates.has(pr.mergeStateStatus))
+    applyPolicy(
+      report,
+      config.policies.mergeState,
+      'PR_MERGE_STATE_BLOCKED',
+      `Pull request merge state is ${pr.mergeStateStatus}`
+    );
+  else if (!pr.mergeStateStatus || pr.mergeStateStatus === 'UNKNOWN')
+    addUnknown(report, 'PR_MERGE_STATE_UNKNOWN', 'GitHub merge state is unknown');
 
-  // Exact SHA comparison if local provided
   if (localSha) {
-    const normalizedLocal = getLocalSha(localSha);
-    if (!normalizedLocal) {
-      addBlocker(report, 'LOCAL_SHA_INVALID', `--local-sha ${localSha} could not be resolved`);
-    } else if (normalizedLocal.toLowerCase() !== String(pr.headRefOid).toLowerCase()) {
+    const normalized = getLocalSha(localSha);
+    report.localCandidateSha = normalized;
+    if (!normalized)
+      addBlocker(report, 'LOCAL_SHA_INVALID', `--local-sha ${localSha} cannot be resolved`);
+    else if (normalized.toLowerCase() !== observedSha.toLowerCase())
       addBlocker(report, 'SHA_MISMATCH', 'Local candidate SHA does not match remote PR head SHA', {
-        local: normalizedLocal,
-        remote: pr.headRefOid,
+        local: normalized,
+        remote: observedSha,
       });
-    }
-    report.localCandidateSha = normalizedLocal;
   }
 
-  // Branch currency
   try {
-    const cmp = await fetchCompare(config.defaultBranch, pr.headRefOid);
-    report.branches.push({ ref: pr.headRefName, ...cmp });
-    if (config.policies.prBehindMain && cmp.behind_by > 0) {
-      addBlocker(
+    const comparison = await probes.fetchCompare(config.defaultBranch, observedSha);
+    report.branches.push({ ref: pr.headRefName, ...comparison });
+    if (config.policies.branchMustContainMain && comparison.behind_by > 0)
+      applyPolicy(
         report,
+        config.policies.prBehindMain,
         'PR_BEHIND_MAIN',
-        `PR head is ${cmp.behind_by} commits behind ${config.defaultBranch}`
+        `PR head is ${comparison.behind_by} commits behind ${config.defaultBranch}`
       );
-    }
-  } catch (e) {
-    addUnknown(report, 'COMPARE_FAILED', 'Could not compare PR head with main', {
-      error: String(e.message),
-    });
+  } catch (error) {
+    addUnknown(
+      report,
+      'COMPARE_FAILED',
+      'Could not compare PR head with main',
+      errorEvidence(error)
+    );
   }
 
-  // Checks for exact head SHA
-  let checks;
   try {
-    checks = await fetchChecksForSha(pr.headRefOid, { wait, timeoutSeconds, pollSeconds });
-  } catch (e) {
-    addUnknown(report, 'CHECKS_FETCH_FAILED', 'Failed to retrieve checks for PR head SHA', {
-      sha: pr.headRefOid,
-      error: String(e.message),
-    });
-    checks = { checkRuns: [], statuses: [] };
-  }
-
-  report.checks = checks.checkRuns.concat(
-    checks.statuses.map(s => ({ name: s.context, status: s.state }))
-  );
-
-  const required = config.requiredChecks.pullRequest || [];
-  const seen = new Set();
-
-  for (const req of required) {
-    const matching = checks.checkRuns.filter(c => c.name === req);
-    if (matching.length === 0) {
-      addBlocker(
+    const threads = await probes.fetchReviewThreads(prNumber);
+    const unresolved = threads.filter(thread => !thread.isResolved).length;
+    if (unresolved)
+      applyPolicy(
         report,
-        'REQUIRED_CHECK_MISSING',
-        `Required check "${req}" is missing for SHA ${pr.headRefOid}`
+        config.policies.unresolvedReviewThreads,
+        'UNRESOLVED_REVIEW_THREADS',
+        `Pull request has ${unresolved} unresolved review thread(s)`,
+        { count: unresolved }
       );
-      continue;
-    }
-
-    // Take the latest by completed_at or started_at
-    const latest = matching.sort((a, b) => {
-      const ta = new Date(a.completed_at || a.started_at || 0).getTime();
-      const tb = new Date(b.completed_at || b.started_at || 0).getTime();
-      return tb - ta;
-    })[0];
-
-    if (latest.head_sha !== pr.headRefOid) {
-      addBlocker(report, 'STALE_CHECK', `Check "${req}" is not for the current PR head SHA`, {
-        checkSha: latest.head_sha,
-        prSha: pr.headRefOid,
-      });
-      continue;
-    }
-
-    if (['queued', 'in_progress'].includes(latest.status)) {
-      addBlocker(report, 'CHECK_PENDING', `Required check "${req}" is still pending`);
-      continue;
-    }
-
-    if (latest.conclusion && !['success', 'neutral'].includes(latest.conclusion)) {
-      addBlocker(report, 'CHECK_FAILED', `Required check "${req}" concluded ${latest.conclusion}`, {
-        url: latest.details_url,
-      });
-    }
-
-    seen.add(req);
+  } catch (error) {
+    addUnknown(
+      report,
+      'REVIEW_THREADS_UNKNOWN',
+      'Could not determine unresolved review threads',
+      errorEvidence(error)
+    );
   }
+  if (pr.reviewDecision === 'CHANGES_REQUESTED')
+    applyPolicy(
+      report,
+      config.policies.changesRequested,
+      'CHANGES_REQUESTED',
+      'Review decision is CHANGES_REQUESTED'
+    );
 
-  // Reviews
-  if (pr.reviewDecision === 'CHANGES_REQUESTED') {
-    addBlocker(report, 'CHANGES_REQUESTED', 'Review decision is CHANGES_REQUESTED');
+  try {
+    const verifyCurrentSha = async () => (await probes.fetchPrDetails(prNumber)).headRefOid;
+    const checks = await probes.fetchChecksForSha(observedSha, {
+      wait,
+      timeoutSeconds,
+      pollSeconds,
+      requiredCheckNames: config.requiredChecks.pullRequest,
+      verifyCurrentSha,
+    });
+    report.checks = [
+      ...checks.checkRuns,
+      ...checks.statuses.map(status => ({
+        name: status.context,
+        status: status.state,
+        head_sha: status.sha,
+      })),
+    ];
+    evaluateRequiredChecks(
+      report,
+      checks,
+      config.requiredChecks.pullRequest,
+      config.checkConclusions.pullRequest,
+      observedSha
+    );
+  } catch (error) {
+    const code = error.code === 'OBSERVED_SHA_CHANGED' ? 'PR_HEAD_CHANGED' : 'CHECKS_FETCH_FAILED';
+    addUnknown(report, code, 'Could not obtain stable checks for the observed PR SHA', {
+      sha: observedSha,
+      ...errorEvidence(error),
+    });
   }
-
-  // If we have unknowns that are critical
-  if (strict && report.unknowns.length > 0) {
-    // already will be treated as block in final decision
-  }
-
-  report.decision = report.blockers.length === 0 ? 'READY' : 'BLOCKED';
 }
 
-async function evaluateMain({ report, wait, timeoutSeconds, pollSeconds, strict, config }) {
-  report.observedAt = report.reproducible ? 'REPRODUCIBLE' : new Date().toISOString();
-
-  let mainSha;
+async function evaluateMain({
+  report,
+  wait,
+  timeoutSeconds,
+  pollSeconds,
+  config,
+  probes = defaultProbes,
+  packageVersion = require('../../package.json').version,
+}) {
+  let sha;
   try {
-    mainSha = (await fetchMainDetails('HEAD')).sha; // better to use git or explicit
-  } catch (_) {
-    // fallback
-  }
-
-  // Prefer asking git for the remote main we are comparing against
-  const remoteMain = require('./gitProbe').getRemoteMainSha
-    ? require('./gitProbe').getRemoteMainSha()
-    : null;
-
-  const sha = remoteMain || mainSha;
-
-  if (!sha) {
-    addUnknown(report, 'MAIN_SHA_UNKNOWN', 'Could not determine current origin/main SHA');
-    report.decision = 'UNKNOWN';
+    sha = await probes.fetchRefSha(config.defaultBranch);
+  } catch (error) {
+    addUnknown(
+      report,
+      'MAIN_SHA_UNKNOWN',
+      'Could not determine remote main SHA',
+      errorEvidence(error)
+    );
     return;
   }
-
+  if (!sha) {
+    addUnknown(report, 'MAIN_SHA_UNKNOWN', 'Remote main ref did not contain a SHA');
+    return;
+  }
   report.observedSha = sha;
-  report.main = await fetchMainDetails(sha);
-
-  let checks;
   try {
-    checks = await fetchChecksForSha(sha, { wait, timeoutSeconds, pollSeconds });
-  } catch (e) {
-    addUnknown(report, 'MAIN_CHECKS_FAILED', 'Failed to fetch checks for current main SHA', {
-      sha,
-      error: String(e.message),
+    report.main = await probes.fetchMainDetails(sha);
+  } catch (error) {
+    addUnknown(
+      report,
+      'MAIN_DETAILS_FAILED',
+      'Could not retrieve main commit details',
+      errorEvidence(error)
+    );
+  }
+
+  try {
+    const checks = await probes.fetchChecksForSha(sha, {
+      wait,
+      timeoutSeconds,
+      pollSeconds,
+      requiredCheckNames: config.requiredChecks.main,
+      verifyCurrentSha: () => probes.fetchRefSha(config.defaultBranch),
     });
-    checks = { checkRuns: [], statuses: [] };
+    report.checks = [
+      ...checks.checkRuns,
+      ...checks.statuses.map(status => ({
+        name: status.context,
+        status: status.state,
+        head_sha: status.sha,
+      })),
+    ];
+    evaluateRequiredChecks(
+      report,
+      checks,
+      config.requiredChecks.main,
+      config.checkConclusions.main,
+      sha,
+      'MAIN'
+    );
+  } catch (error) {
+    const code = error.code === 'OBSERVED_SHA_CHANGED' ? 'MAIN_SHA_CHANGED' : 'MAIN_CHECKS_FAILED';
+    addUnknown(report, code, 'Could not obtain stable checks for the observed main SHA', {
+      sha,
+      ...errorEvidence(error),
+    });
   }
 
-  report.checks = checks.checkRuns;
-
-  const required = config.requiredChecks.main || [];
-  for (const req of required) {
-    const match = checks.checkRuns.find(c => c.name === req && c.head_sha === sha);
-    if (!match) {
-      addBlocker(
-        report,
-        'REQUIRED_MAIN_CHECK_MISSING',
-        `Required main check "${req}" missing or not on current SHA ${sha}`
-      );
-      continue;
-    }
-    if (['queued', 'in_progress'].includes(match.status)) {
-      addBlocker(report, 'MAIN_CHECK_PENDING', `Main check "${req}" pending on ${sha}`);
-    } else if (match.conclusion && match.conclusion !== 'success') {
-      addBlocker(report, 'MAIN_CHECK_FAILED', `Main check "${req}" ${match.conclusion}`, {
-        url: match.details_url,
-      });
-    }
-  }
-
-  // Direct push detection (best effort)
   try {
-    const associated = await fetchCompare('HEAD~1', sha); // rough
-    // In practice we rely on GitHub PR association in overview
-  } catch (_) {}
+    const associated = await probes.fetchAssociatedPullRequests(sha);
+    report.main = {
+      ...(report.main || { sha }),
+      associatedPullRequests: associated.map(pr => ({
+        number: pr.number,
+        url: pr.html_url,
+        mergedAt: pr.merged_at,
+      })),
+    };
+    if (!associated.some(pr => pr.merged_at))
+      applyPolicy(
+        report,
+        config.policies.directMainCommit,
+        'DIRECT_MAIN_COMMIT',
+        `Main commit ${sha} is not associated with a merged pull request`
+      );
+  } catch (error) {
+    addUnknown(
+      report,
+      'MAIN_PR_ASSOCIATION_UNKNOWN',
+      'Could not determine commit-to-PR association',
+      errorEvidence(error)
+    );
+  }
 
-  report.decision = report.blockers.length === 0 ? 'HEALTHY' : 'UNHEALTHY';
+  try {
+    const releases = await probes.fetchReleases();
+    report.release = releases[0] || null;
+    if (report.release) {
+      const tagVersion = String(report.release.tag_name || '').replace(/^v/, '');
+      if (tagVersion !== packageVersion)
+        applyPolicy(
+          report,
+          config.policies.releaseVersionMismatch,
+          'RELEASE_VERSION_MISMATCH',
+          `Latest release ${tagVersion || '(untagged)'} differs from package ${packageVersion}`,
+          { releaseTag: report.release.tag_name, packageVersion }
+        );
+      if (report.release.tag_name) {
+        const comparison = await probes.fetchCompare(report.release.tag_name, sha);
+        report.release = {
+          ...report.release,
+          mainAheadBy: comparison.ahead_by,
+          mainBehindBy: comparison.behind_by,
+          consistency:
+            comparison.behind_by > 0
+              ? 'RELEASE_NOT_ANCESTOR_OF_MAIN'
+              : 'MAIN_AT_OR_AHEAD_OF_RELEASE',
+        };
+        if (comparison.behind_by > 0)
+          applyPolicy(
+            report,
+            config.policies.releaseVersionMismatch,
+            'RELEASE_NOT_ON_MAIN',
+            `Latest release ${report.release.tag_name} is not an ancestor of main`
+          );
+      }
+    }
+  } catch (error) {
+    addUnknown(
+      report,
+      'RELEASE_EVALUATION_UNKNOWN',
+      'Could not evaluate release consistency',
+      errorEvidence(error)
+    );
+  }
 }
 
-async function evaluateOverview({ report, wait, timeoutSeconds, pollSeconds, strict, config }) {
-  report.observedAt = report.reproducible ? 'REPRODUCIBLE' : new Date().toISOString();
-
-  // Main health (light)
-  let mainSha;
+async function evaluateOverview({
+  report,
+  wait,
+  timeoutSeconds,
+  pollSeconds,
+  config,
+  probes = defaultProbes,
+  packageVersion,
+}) {
+  await evaluateMain({
+    report,
+    wait,
+    timeoutSeconds,
+    pollSeconds,
+    config,
+    probes,
+    ...(packageVersion ? { packageVersion } : {}),
+  });
   try {
-    mainSha = require('./gitProbe').getRemoteMainSha();
-    report.main = { sha: mainSha };
-    const mainChecks = await fetchChecksForSha(mainSha, { wait: false });
-    report.checks.push(...mainChecks.checkRuns);
-  } catch (e) {
-    addUnknown(report, 'MAIN_PROBE_FAILED', 'Could not probe current main', {
-      error: String(e.message),
-    });
-  }
-
-  // Open PRs
-  try {
-    const openPrs = JSON.parse(
-      require('child_process').execFileSync(
-        'gh',
-        ['pr', 'list', '--state', 'open', '--json', 'number,headRefName,headRefOid,state,isDraft'],
-        { encoding: 'utf8' }
-      )
+    report.pullRequests = await probes.fetchOpenPrs();
+  } catch (error) {
+    addUnknown(
+      report,
+      'OPEN_PR_LIST_FAILED',
+      'Could not list open pull requests',
+      errorEvidence(error)
     );
-    report.pullRequests = openPrs;
-  } catch (e) {
-    addUnknown(report, 'OPEN_PR_LIST_FAILED', 'Could not list open PRs');
   }
-
-  // Branches
   try {
-    const branches = await require('./githubProbe').fetchBranches();
-    for (const b of branches) {
-      if (b.name === config.defaultBranch) continue;
-      const cmp = await require('./githubProbe')
-        .fetchCompare(config.defaultBranch, b.commit.sha)
-        .catch(() => ({}));
-      const classification = cmp.behind_by > 0 ? 'BEHIND_MAIN' : 'AHEAD_WITHOUT_PR';
+    const openHeads = new Set(report.pullRequests.map(pr => pr.headRefName));
+    const branches = await probes.fetchBranches();
+    for (const branch of branches) {
+      if (branch.name === config.defaultBranch) continue;
+      let comparison;
+      try {
+        comparison = await probes.fetchCompare(config.defaultBranch, branch.commit.sha);
+      } catch (error) {
+        addUnknown(
+          report,
+          'BRANCH_COMPARE_FAILED',
+          `Could not classify branch ${branch.name}`,
+          errorEvidence(error)
+        );
+        continue;
+      }
+      let associated = [];
+      try {
+        associated = await probes.fetchAssociatedPullRequests(branch.commit.sha);
+      } catch (error) {
+        addUnknown(
+          report,
+          'BRANCH_PR_ASSOCIATION_UNKNOWN',
+          `Could not find PR association for ${branch.name}`,
+          errorEvidence(error)
+        );
+      }
+      const merged = associated.filter(pr => pr.merged_at);
+      const classification = openHeads.has(branch.name)
+        ? 'OPEN_PR'
+        : merged.length
+          ? 'MERGED_RETAINED'
+          : comparison.ahead_by > 0
+            ? 'AHEAD_WITHOUT_PR'
+            : 'STALE';
       report.branches.push({
-        name: b.name,
-        sha: b.commit.sha,
+        name: branch.name,
+        sha: branch.commit.sha,
         classification,
-        behind: cmp.behind_by,
-        ahead: cmp.ahead_by,
+        behind: comparison.behind_by,
+        ahead: comparison.ahead_by,
+        associatedPullRequests: associated.map(pr => pr.number),
       });
+      if (classification === 'MERGED_RETAINED' && config.policies.mergedBranchRetentionDays === 0)
+        addWarning(
+          report,
+          'MERGED_BRANCH_RETAINED',
+          `Merged branch ${branch.name} is still present`
+        );
     }
-  } catch (e) {
-    addUnknown(report, 'BRANCH_LIST_FAILED', 'Could not list branches');
-  }
-
-  // Release
-  try {
-    const releases = await require('./githubProbe').fetchReleases();
-    report.release = releases[0] || null;
-  } catch (e) {}
-
-  if (report.blockers.length === 0 && report.unknowns.length === 0) {
-    report.decision = 'HEALTHY';
-  } else if (report.blockers.length > 0) {
-    report.decision = 'UNHEALTHY';
-  } else {
-    report.decision = 'UNKNOWN';
+  } catch (error) {
+    addUnknown(report, 'BRANCH_LIST_FAILED', 'Could not list branches', errorEvidence(error));
   }
 }
 
 module.exports = {
-  evaluatePr,
+  addBlocker,
+  addUnknown,
+  addWarning,
+  applyPolicy,
   evaluateMain,
   evaluateOverview,
+  evaluatePr,
+  evaluateRequiredChecks,
+  finalizeDecision,
 };

--- a/scripts/repository-control/config.js
+++ b/scripts/repository-control/config.js
@@ -1,82 +1,215 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
-const DEFAULT_CONFIG = {
-  schemaVersion: 'repository-control-config/v1',
-  repository: 'gzeuner/zeus-rpg-promptkit',
-  defaultBranch: 'main',
-  requiredChecks: {
-    pullRequest: [],
-    main: [],
-  },
-  optionalChecks: [],
-  allowedSkippedChecks: [],
-  policies: {
-    branchMustContainMain: true,
-    directMainCommit: 'warning',
-    unresolvedReviewThreads: 'block',
-    changesRequested: 'block',
-    draftPullRequest: 'block',
-    mergedBranchRetentionDays: 0,
-    releaseVersionMismatch: 'warning',
-    prBehindMain: 'block',
-  },
-  polling: {
-    defaultPollSeconds: 15,
-    minPollSeconds: 5,
-    maxPollSeconds: 60,
-    defaultTimeoutSeconds: 1800,
-    maxTimeoutSeconds: 7200,
-  },
-};
+const CONFIG_SCHEMA = 'repository-control-config/v1';
+const POLICY_LEVELS = new Set(['ignore', 'warning', 'block']);
+const DEFAULTS = Object.freeze({ pollSeconds: 15, timeoutSeconds: 1800 });
 
-function loadConfig(configPath) {
-  const resolved = path.resolve(configPath);
+class ConfigError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ConfigError';
+    this.code = 'INVALID_CONFIG';
+  }
+}
+
+function isInside(root, target) {
+  const relative = path.relative(root, target);
+  return (
+    relative === '' ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+  );
+}
+
+function permittedRoots(cwd = process.cwd()) {
+  return [fs.realpathSync(cwd), fs.realpathSync(os.tmpdir())];
+}
+
+function assertNoSymlinkComponents(target, stopAt) {
+  const relative = path.relative(stopAt, target);
+  if (relative === '') return;
+  let cursor = stopAt;
+  for (const part of relative.split(path.sep)) {
+    cursor = path.join(cursor, part);
+    if (!fs.existsSync(cursor)) continue;
+    if (fs.lstatSync(cursor).isSymbolicLink()) {
+      throw new ConfigError(`Path must not contain symbolic links: ${target}`);
+    }
+  }
+}
+
+function resolveSafePath(input, { cwd = process.cwd(), purpose = 'path', mustExist = false } = {}) {
+  if (typeof input !== 'string' || input.trim() === '' || input.includes('\0')) {
+    throw new ConfigError(`${purpose} must be a non-empty path`);
+  }
+  const normalizedInput = path.normalize(input);
+  if (!path.isAbsolute(input) && normalizedInput.split(path.sep).includes('..')) {
+    throw new ConfigError(`${purpose} must not contain parent traversal`);
+  }
+  const resolved = path.resolve(cwd, input);
+  const roots = permittedRoots(cwd);
+  const root = roots.find(candidate => isInside(candidate, resolved));
+  if (!root)
+    throw new ConfigError(`${purpose} must remain inside the repository or temporary directory`);
+
+  assertNoSymlinkComponents(resolved, root);
+  if (mustExist) {
+    let stat;
+    try {
+      stat = fs.lstatSync(resolved);
+    } catch (error) {
+      throw new ConfigError(`${purpose} is missing or unreadable: ${resolved}`);
+    }
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      throw new ConfigError(`${purpose} must be a regular file: ${resolved}`);
+    }
+    try {
+      fs.accessSync(resolved, fs.constants.R_OK);
+    } catch (_) {
+      throw new ConfigError(`${purpose} is not readable: ${resolved}`);
+    }
+  } else {
+    const parent = path.dirname(resolved);
+    let existing = parent;
+    while (!fs.existsSync(existing)) {
+      const next = path.dirname(existing);
+      if (next === existing) break;
+      existing = next;
+    }
+    const realExisting = fs.realpathSync(existing);
+    if (!roots.some(candidate => isInside(candidate, realExisting))) {
+      throw new ConfigError(`${purpose} parent escapes an allowed root through a symbolic link`);
+    }
+  }
+  return resolved;
+}
+
+function requireStringArray(value, label, { nonEmpty = false } = {}) {
+  if (!Array.isArray(value) || (nonEmpty && value.length === 0)) {
+    throw new ConfigError(`${label} must be ${nonEmpty ? 'a non-empty' : 'an'} array`);
+  }
+  if (value.some(item => typeof item !== 'string' || item.trim() === '')) {
+    throw new ConfigError(`${label} must contain only non-empty strings`);
+  }
+  if (new Set(value).size !== value.length) throw new ConfigError(`${label} contains duplicates`);
+  return value;
+}
+
+function validatePolicy(value, label) {
+  if (!POLICY_LEVELS.has(value))
+    throw new ConfigError(`${label} must be ignore, warning, or block`);
+}
+
+function validateConfig(config, source) {
+  if (!config || typeof config !== 'object' || Array.isArray(config))
+    throw new ConfigError('Configuration must be an object');
+  if (config.schemaVersion !== CONFIG_SCHEMA)
+    throw new ConfigError(`Unsupported config schemaVersion in ${source}`);
+  if (!/^[^/\s]+\/[^/\s]+$/.test(String(config.repository || '')))
+    throw new ConfigError('repository must be owner/name');
+  if (!/^[A-Za-z0-9._/-]+$/.test(String(config.defaultBranch || '')))
+    throw new ConfigError('defaultBranch is invalid');
+  if (!config.requiredChecks || typeof config.requiredChecks !== 'object')
+    throw new ConfigError('requiredChecks is required');
+  const pr = requireStringArray(config.requiredChecks.pullRequest, 'requiredChecks.pullRequest', {
+    nonEmpty: true,
+  });
+  const main = requireStringArray(config.requiredChecks.main, 'requiredChecks.main', {
+    nonEmpty: true,
+  });
+  requireStringArray(config.optionalChecks || [], 'optionalChecks');
+  requireStringArray(config.allowedSkippedChecks || [], 'allowedSkippedChecks');
+
+  if (!config.checkConclusions || typeof config.checkConclusions !== 'object')
+    throw new ConfigError('checkConclusions is required');
+  for (const scope of ['pullRequest', 'main']) {
+    const entries = config.checkConclusions[scope];
+    if (!entries || typeof entries !== 'object' || Array.isArray(entries))
+      throw new ConfigError(`checkConclusions.${scope} is required`);
+    const expected = scope === 'pullRequest' ? pr : main;
+    for (const name of expected) {
+      const allowed = requireStringArray(entries[name], `checkConclusions.${scope}.${name}`, {
+        nonEmpty: true,
+      });
+      if (!allowed.every(value => ['success', 'neutral', 'skipped'].includes(value)))
+        throw new ConfigError(`Invalid allowed conclusion for ${name}`);
+    }
+  }
+
+  const policies = config.policies;
+  if (!policies || typeof policies !== 'object') throw new ConfigError('policies is required');
+  for (const name of [
+    'directMainCommit',
+    'unresolvedReviewThreads',
+    'changesRequested',
+    'draftPullRequest',
+    'releaseVersionMismatch',
+    'prBehindMain',
+    'mergeability',
+    'mergeState',
+  ]) {
+    validatePolicy(policies[name], `policies.${name}`);
+  }
+  if (typeof policies.branchMustContainMain !== 'boolean')
+    throw new ConfigError('policies.branchMustContainMain must be boolean');
+  if (
+    !Number.isInteger(policies.mergedBranchRetentionDays) ||
+    policies.mergedBranchRetentionDays < 0
+  )
+    throw new ConfigError('policies.mergedBranchRetentionDays must be a non-negative integer');
+
+  const polling = config.polling;
+  if (!polling || typeof polling !== 'object') throw new ConfigError('polling is required');
+  for (const key of [
+    'defaultPollSeconds',
+    'minPollSeconds',
+    'maxPollSeconds',
+    'defaultTimeoutSeconds',
+    'maxTimeoutSeconds',
+  ]) {
+    if (!Number.isInteger(polling[key]) || polling[key] <= 0)
+      throw new ConfigError(`polling.${key} must be a positive integer`);
+  }
+  if (
+    polling.minPollSeconds > polling.defaultPollSeconds ||
+    polling.defaultPollSeconds > polling.maxPollSeconds
+  )
+    throw new ConfigError('default poll interval is outside configured bounds');
+  if (polling.defaultTimeoutSeconds > polling.maxTimeoutSeconds)
+    throw new ConfigError('default timeout exceeds maximum');
+  return config;
+}
+
+function loadConfig(configPath, options = {}) {
+  const resolved = resolveSafePath(configPath, {
+    ...options,
+    purpose: 'configuration path',
+    mustExist: true,
+  });
   let raw;
   try {
     raw = fs.readFileSync(resolved, 'utf8');
-  } catch (e) {
-    // Fall back to defaults if config missing (still functional)
-    return { ...DEFAULT_CONFIG, _source: 'defaults', _configPath: resolved };
+  } catch (_) {
+    throw new ConfigError(`Configuration is missing or unreadable: ${resolved}`);
   }
-
   let parsed;
   try {
     parsed = JSON.parse(raw);
-  } catch (e) {
-    console.error(`Invalid JSON in repository control config: ${resolved}`);
-    process.exit(64);
+  } catch (_) {
+    throw new ConfigError(`Configuration is not valid JSON: ${resolved}`);
   }
-
-  // Basic validation / merge with defaults
-  const merged = {
-    ...DEFAULT_CONFIG,
-    ...parsed,
-    requiredChecks: {
-      ...DEFAULT_CONFIG.requiredChecks,
-      ...(parsed.requiredChecks || {}),
-    },
-    policies: {
-      ...DEFAULT_CONFIG.policies,
-      ...(parsed.policies || {}),
-    },
-    polling: {
-      ...DEFAULT_CONFIG.polling,
-      ...(parsed.polling || {}),
-    },
-    _source: 'file',
-    _configPath: resolved,
-  };
-
-  return merged;
+  const config = validateConfig(parsed, resolved);
+  return { ...config, _source: 'file', _configPath: resolved };
 }
 
 module.exports = {
+  CONFIG_SCHEMA,
+  ConfigError,
+  DEFAULTS,
   loadConfig,
-  DEFAULTS: {
-    pollSeconds: DEFAULT_CONFIG.polling.defaultPollSeconds,
-    timeoutSeconds: DEFAULT_CONFIG.polling.defaultTimeoutSeconds,
-  },
+  resolveSafePath,
+  validateConfig,
 };

--- a/scripts/repository-control/githubProbe.js
+++ b/scripts/repository-control/githubProbe.js
@@ -2,155 +2,339 @@
 
 const { execFileSync } = require('child_process');
 
-function gh(args) {
-  try {
-    const out = execFileSync('gh', args, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-      maxBuffer: 10 * 1024 * 1024,
-    });
-    return out.trim();
-  } catch (e) {
-    const stderr = (e.stderr || '').toString();
-    const err = new Error(`gh ${args.join(' ')} failed: ${stderr || e.message}`);
-    err.status = e.status;
-    err.stderr = stderr;
-    throw err;
+const DEFAULT_REPOSITORY = 'gzeuner/zeus-rpg-promptkit';
+const FAILURE_CONCLUSIONS = new Set([
+  'failure',
+  'cancelled',
+  'timed_out',
+  'action_required',
+  'startup_failure',
+]);
+
+class GithubProbeError extends Error {
+  constructor(message, code = 'GITHUB_PROBE_FAILED') {
+    super(message);
+    this.name = 'GithubProbeError';
+    this.code = code;
   }
 }
 
-function ghJson(args) {
-  const out = gh([
-    ...args,
-    '--json',
-    'number,url,state,isDraft,title,headRefName,headRefOid,baseRefName,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,headRef',
-  ]);
-  return JSON.parse(out);
+function redact(value) {
+  return String(value || '')
+    .replace(/(token|authorization|bearer)\s*[:=]?\s*\S+/gi, '$1=[REDACTED]')
+    .slice(0, 1000);
 }
 
-async function fetchPrDetails(prNumber) {
-  // Use gh pr view for rich data
-  const data = JSON.parse(
-    gh([
-      'pr',
-      'view',
-      String(prNumber),
-      '--json',
-      'number,url,state,isDraft,title,headRefName,headRefOid,baseRefName,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup',
-    ])
-  );
-  return data;
+function assertReadOnlyGhArgs(args) {
+  if (!Array.isArray(args) || args.length === 0)
+    throw new GithubProbeError('Empty gh invocation', 'WRITE_OPERATION_REJECTED');
+  if (args[0] === 'pr' && ['view', 'list'].includes(args[1])) return;
+  if (args[0] !== 'api')
+    throw new GithubProbeError(
+      `GitHub operation is not read-only: gh ${args.slice(0, 2).join(' ')}`,
+      'WRITE_OPERATION_REJECTED'
+    );
+  const methodIndex = args.findIndex(value => value === '--method' || value === '-X');
+  const method = methodIndex === -1 ? 'GET' : String(args[methodIndex + 1]).toUpperCase();
+  if (method !== 'GET' && !(args.includes('graphql') && method === 'POST'))
+    throw new GithubProbeError(
+      'Non-read-only GitHub API operation rejected',
+      'WRITE_OPERATION_REJECTED'
+    );
+  if (args.includes('graphql')) {
+    const queryIndex = args.findIndex(
+      value => value === '-f' && String(args[args.indexOf(value) + 1] || '').startsWith('query=')
+    );
+    const queryArg = args.find(value => typeof value === 'string' && value.startsWith('query='));
+    if (queryIndex === -1 && !queryArg)
+      throw new GithubProbeError(
+        'GraphQL operation lacks an explicit query',
+        'WRITE_OPERATION_REJECTED'
+      );
+    if (/\bmutation\b/i.test(queryArg || ''))
+      throw new GithubProbeError('GraphQL mutation rejected', 'WRITE_OPERATION_REJECTED');
+  }
 }
 
-async function fetchChecksForSha(
-  sha,
-  { wait = false, timeoutSeconds = 1800, pollSeconds = 15 } = {}
-) {
-  // Use gh pr checks or workflow runs, but for exact SHA we use commit checks
-  // gh api for check-runs on the commit
-  const start = Date.now();
-  let last = null;
+function defaultRunner(args) {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    maxBuffer: 20 * 1024 * 1024,
+  }).trim();
+}
 
-  while (true) {
+function createGithubProbe({
+  repository = DEFAULT_REPOSITORY,
+  runner = defaultRunner,
+  sleep = ms => new Promise(resolve => setTimeout(resolve, ms)),
+  now = () => Date.now(),
+} = {}) {
+  const operations = [];
+
+  function gh(args) {
+    assertReadOnlyGhArgs(args);
+    operations.push({ executable: 'gh', args: [...args], access: 'read-only' });
     try {
-      const runs = JSON.parse(
-        gh(['api', `repos/gzeuner/zeus-rpg-promptkit/commits/${sha}/check-runs?per_page=100`])
-      );
-      const checkRuns = runs.check_runs || [];
-
-      // Also get combined status for legacy
-      let combined = { statuses: [] };
-      try {
-        combined = JSON.parse(
-          gh(['api', `repos/gzeuner/zeus-rpg-promptkit/commits/${sha}/status`])
-        );
-      } catch (_) {}
-
-      const result = {
-        sha,
-        checkRuns: checkRuns.map(r => ({
-          name: r.name,
-          status: r.status,
-          conclusion: r.conclusion,
-          started_at: r.started_at,
-          completed_at: r.completed_at,
-          details_url: r.details_url,
-          head_sha: r.head_sha,
-          attempt: r.run_attempt || 1,
-        })),
-        statuses: (combined.statuses || []).map(s => ({
-          context: s.context,
-          state: s.state,
-          target_url: s.target_url,
-          updated_at: s.updated_at,
-        })),
-      };
-
-      last = result;
-
-      if (!wait) return result;
-
-      const pending = result.checkRuns.filter(c => ['queued', 'in_progress'].includes(c.status));
-      const hasFailure = result.checkRuns.some(c =>
-        ['failure', 'cancelled', 'timed_out', 'action_required', 'startup_failure'].includes(
-          c.conclusion
-        )
-      );
-
-      if (pending.length === 0 && !hasFailure) {
-        return result;
-      }
-
-      if (Date.now() - start > timeoutSeconds * 1000) {
-        return result;
-      }
-
-      await new Promise(r => setTimeout(r, pollSeconds * 1000));
-    } catch (e) {
-      if (!wait) throw e;
-      if (Date.now() - start > timeoutSeconds * 1000) {
-        if (last) return last;
-        throw e;
-      }
-      await new Promise(r => setTimeout(r, pollSeconds * 1000));
+      return runner(args);
+    } catch (error) {
+      throw new GithubProbeError(`GitHub read failed: ${redact(error.stderr || error.message)}`);
     }
   }
-}
 
-async function fetchMainDetails(sha) {
-  const commit = JSON.parse(gh(['api', `repos/gzeuner/zeus-rpg-promptkit/commits/${sha}`]));
-  return {
+  function apiJson(endpoint, extra = []) {
+    const output = gh(['api', '--method', 'GET', endpoint, ...extra]);
+    return JSON.parse(output || 'null');
+  }
+
+  function paginatedJson(endpoint) {
+    const pages = apiJson(endpoint, ['--paginate', '--slurp']);
+    return Array.isArray(pages) ? pages : [pages];
+  }
+
+  async function fetchPrDetails(prNumber) {
+    return JSON.parse(
+      gh([
+        'pr',
+        'view',
+        String(prNumber),
+        '--repo',
+        repository,
+        '--json',
+        'number,url,state,isDraft,title,headRefName,headRefOid,baseRefName,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,updatedAt',
+      ])
+    );
+  }
+
+  async function fetchRefSha(branch) {
+    const ref = apiJson(`repos/${repository}/git/ref/heads/${encodeURIComponent(branch)}`);
+    return ref && ref.object && ref.object.sha;
+  }
+
+  async function fetchReviewThreads(prNumber) {
+    const [owner, name] = repository.split('/');
+    const query = `query($owner:String!,$name:String!,$number:Int!,$cursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$cursor){nodes{isResolved}pageInfo{hasNextPage endCursor}}}}}`;
+    let cursor = null;
+    const threads = [];
+    do {
+      const args = [
+        'api',
+        'graphql',
+        '--method',
+        'POST',
+        '-f',
+        `query=${query}`,
+        '-F',
+        `owner=${owner}`,
+        '-F',
+        `name=${name}`,
+        '-F',
+        `number=${prNumber}`,
+      ];
+      if (cursor) args.push('-F', `cursor=${cursor}`);
+      const data = JSON.parse(gh(args));
+      const connection = data.data.repository.pullRequest.reviewThreads;
+      threads.push(...connection.nodes);
+      cursor = connection.pageInfo.hasNextPage ? connection.pageInfo.endCursor : null;
+    } while (cursor);
+    return threads;
+  }
+
+  async function snapshotChecks(sha) {
+    const checkPages = paginatedJson(`repos/${repository}/commits/${sha}/check-runs?per_page=100`);
+    const statusPages = paginatedJson(`repos/${repository}/commits/${sha}/statuses?per_page=100`);
+    const checkRuns = checkPages.flatMap(page => (page && page.check_runs) || []);
+    const statuses = statusPages.flatMap(page => (Array.isArray(page) ? page : []));
+    return {
+      sha,
+      checkRuns: checkRuns.map(run => ({
+        id: run.id,
+        name: run.name,
+        status: run.status,
+        conclusion: run.conclusion,
+        started_at: run.started_at,
+        completed_at: run.completed_at,
+        details_url: run.details_url,
+        head_sha: run.head_sha,
+        attempt: run.run_attempt || 1,
+      })),
+      statuses: statuses.map(status => ({
+        id: status.id,
+        context: status.context,
+        state: status.state,
+        target_url: status.target_url,
+        updated_at: status.updated_at,
+        sha: status.sha,
+      })),
+    };
+  }
+
+  async function fetchChecksForSha(
     sha,
-    message: commit.commit && commit.commit.message,
-    author: commit.commit && commit.commit.author,
-    committer: commit.commit && commit.commit.committer,
-    html_url: commit.html_url,
-  };
-}
+    {
+      wait = false,
+      timeoutSeconds = 1800,
+      pollSeconds = 15,
+      requiredCheckNames = [],
+      verifyCurrentSha,
+    } = {}
+  ) {
+    const started = now();
+    let last = null;
+    while (true) {
+      if (verifyCurrentSha) {
+        const current = await verifyCurrentSha();
+        if (String(current).toLowerCase() !== String(sha).toLowerCase())
+          throw new GithubProbeError(
+            `Observed identity changed from ${sha} to ${current}`,
+            'OBSERVED_SHA_CHANGED'
+          );
+      }
+      try {
+        last = await snapshotChecks(sha);
+      } catch (error) {
+        if (!wait || now() - started >= timeoutSeconds * 1000) throw error;
+        await sleep(pollSeconds * 1000);
+        continue;
+      }
+      if (!wait) {
+        if (verifyCurrentSha) {
+          const current = await verifyCurrentSha();
+          if (String(current).toLowerCase() !== String(sha).toLowerCase())
+            throw new GithubProbeError(
+              `Observed identity changed from ${sha} to ${current}`,
+              'OBSERVED_SHA_CHANGED'
+            );
+        }
+        return last;
+      }
+      const latest = selectLatestChecks(last.checkRuns);
+      const required = requiredCheckNames.map(name => latest.get(name)).filter(Boolean);
+      const allCreated = required.length === requiredCheckNames.length;
+      const pending = required.some(run =>
+        ['queued', 'in_progress', 'pending', 'requested', 'waiting'].includes(run.status)
+      );
+      const failed = required.some(run => FAILURE_CONCLUSIONS.has(run.conclusion));
+      if ((allCreated && !pending) || failed || now() - started >= timeoutSeconds * 1000) {
+        if (verifyCurrentSha) {
+          const current = await verifyCurrentSha();
+          if (String(current).toLowerCase() !== String(sha).toLowerCase())
+            throw new GithubProbeError(
+              `Observed identity changed from ${sha} to ${current}`,
+              'OBSERVED_SHA_CHANGED'
+            );
+        }
+        return last;
+      }
+      await sleep(pollSeconds * 1000);
+    }
+  }
 
-async function fetchCompare(base, head) {
-  const cmp = JSON.parse(gh(['api', `repos/gzeuner/zeus-rpg-promptkit/compare/${base}...${head}`]));
+  async function fetchMainDetails(sha) {
+    const commit = apiJson(`repos/${repository}/commits/${sha}`);
+    return {
+      sha: commit.sha || sha,
+      message: commit.commit && commit.commit.message,
+      author: commit.commit && commit.commit.author,
+      committer: commit.commit && commit.commit.committer,
+      html_url: commit.html_url,
+    };
+  }
+
+  async function fetchCompare(base, head) {
+    const comparison = apiJson(
+      `repos/${repository}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`
+    );
+    return {
+      behind_by: comparison.behind_by,
+      ahead_by: comparison.ahead_by,
+      status: comparison.status,
+      merge_base_commit: comparison.merge_base_commit && comparison.merge_base_commit.sha,
+    };
+  }
+
+  async function fetchBranches() {
+    return paginatedJson(`repos/${repository}/branches?per_page=100`).flatMap(page =>
+      Array.isArray(page) ? page : []
+    );
+  }
+
+  async function fetchReleases() {
+    return paginatedJson(`repos/${repository}/releases?per_page=100`).flatMap(page =>
+      Array.isArray(page) ? page : []
+    );
+  }
+
+  async function fetchOpenPrs() {
+    return JSON.parse(
+      gh([
+        'pr',
+        'list',
+        '--repo',
+        repository,
+        '--state',
+        'open',
+        '--limit',
+        '1000',
+        '--json',
+        'number,headRefName,headRefOid,state,isDraft,url',
+      ])
+    );
+  }
+
+  async function fetchAssociatedPullRequests(sha) {
+    return paginatedJson(`repos/${repository}/commits/${sha}/pulls?per_page=100`).flatMap(page =>
+      Array.isArray(page) ? page : []
+    );
+  }
+
   return {
-    behind_by: cmp.behind_by,
-    ahead_by: cmp.ahead_by,
-    status: cmp.status,
-    merge_base_commit: cmp.merge_base_commit && cmp.merge_base_commit.sha,
+    fetchPrDetails,
+    fetchRefSha,
+    fetchReviewThreads,
+    fetchChecksForSha,
+    fetchMainDetails,
+    fetchCompare,
+    fetchBranches,
+    fetchReleases,
+    fetchOpenPrs,
+    fetchAssociatedPullRequests,
+    getOperations: () => operations.map(item => ({ ...item, args: [...item.args] })),
   };
 }
 
-async function fetchBranches() {
-  return JSON.parse(gh(['api', 'repos/gzeuner/zeus-rpg-promptkit/branches?per_page=100']));
+function selectLatestChecks(checkRuns) {
+  const selected = new Map();
+  for (const run of checkRuns) {
+    const current = selected.get(run.name);
+    const rank = [
+      Number(run.attempt || 0),
+      Date.parse(run.completed_at || run.started_at || 0) || 0,
+      Number(run.id || 0),
+    ];
+    const currentRank = current
+      ? [
+          Number(current.attempt || 0),
+          Date.parse(current.completed_at || current.started_at || 0) || 0,
+          Number(current.id || 0),
+        ]
+      : [-1, -1, -1];
+    if (
+      rank[0] > currentRank[0] ||
+      (rank[0] === currentRank[0] &&
+        (rank[1] > currentRank[1] || (rank[1] === currentRank[1] && rank[2] > currentRank[2])))
+    )
+      selected.set(run.name, run);
+  }
+  return selected;
 }
 
-async function fetchReleases() {
-  return JSON.parse(gh(['api', 'repos/gzeuner/zeus-rpg-promptkit/releases?per_page=20']));
-}
-
+const defaultProbe = createGithubProbe();
 module.exports = {
-  fetchPrDetails,
-  fetchChecksForSha,
-  fetchMainDetails,
-  fetchCompare,
-  fetchBranches,
-  fetchReleases,
+  DEFAULT_REPOSITORY,
+  GithubProbeError,
+  assertReadOnlyGhArgs,
+  createGithubProbe,
+  selectLatestChecks,
+  ...defaultProbe,
 };

--- a/scripts/repository-control/reportRenderer.js
+++ b/scripts/repository-control/reportRenderer.js
@@ -8,6 +8,7 @@ function renderMarkdownReport(report) {
   lines.push(`**Repository**: ${report.repository.nameWithOwner}`);
   lines.push(`**Scope**: ${report.scope}`);
   lines.push(`**Decision**: ${report.decision}`);
+  lines.push(`**Technical Decision**: ${report.technicalDecision}`);
   lines.push(`**Observed SHA**: ${report.observedSha || 'N/A'}`);
   if (report.localCandidateSha) {
     lines.push(`**Local Candidate**: ${report.localCandidateSha}`);

--- a/tests/repository-control.test.js
+++ b/tests/repository-control.test.js
@@ -1,36 +1,572 @@
+'use strict';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
-const SCRIPT = path.join(__dirname, '../scripts/repository-control.js');
+const ROOT = path.resolve(__dirname, '..');
+const SCRIPT = path.join(ROOT, 'scripts/repository-control.js');
+const CONFIG_PATH = path.join(ROOT, '.github/repository-control.json');
+const {
+  ConfigError,
+  loadConfig,
+  resolveSafePath,
+  validateConfig,
+} = require('../scripts/repository-control/config');
+const {
+  assertReadOnlyGhArgs,
+  createGithubProbe,
+  selectLatestChecks,
+} = require('../scripts/repository-control/githubProbe');
+const {
+  evaluateMain,
+  evaluateOverview,
+  evaluatePr,
+  evaluateRequiredChecks,
+  finalizeDecision,
+} = require('../scripts/repository-control/checkEvaluation');
 
-function run(args) {
+const SHA_A = 'a'.repeat(40);
+const SHA_B = 'b'.repeat(40);
+
+function run(args, options = {}) {
   return spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: options.cwd || ROOT,
+    env: { ...process.env, GH_TOKEN: '', ...options.env },
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     timeout: 15000,
   });
 }
 
-test('repo:control --help exits 0', () => {
-  const res = run(['--help']);
-  assert.equal(res.status, 0);
-  assert.ok(res.stdout.includes('Repository Control (read-only)'));
+function config() {
+  return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+}
+function report(scope = 'pr') {
+  return {
+    scope,
+    observedSha: null,
+    localCandidateSha: null,
+    blockers: [],
+    warnings: [],
+    unknowns: [],
+    checks: [],
+    pullRequests: [],
+    branches: [],
+    main: null,
+    release: null,
+  };
+}
+function successRun(name, sha = SHA_A, extra = {}) {
+  return {
+    id: 1,
+    name,
+    status: 'completed',
+    conclusion: 'success',
+    head_sha: sha,
+    attempt: 1,
+    completed_at: '2026-01-01T00:00:00Z',
+    ...extra,
+  };
+}
+function successfulChecks(cfg, scope, sha = SHA_A) {
+  return {
+    checkRuns: cfg.requiredChecks[scope].map((name, index) =>
+      successRun(name, sha, { id: index + 1 })
+    ),
+    statuses: [],
+  };
+}
+
+function prProbes(cfg, overrides = {}) {
+  const pr = {
+    number: 7,
+    state: 'OPEN',
+    isDraft: false,
+    baseRefName: 'main',
+    headRefName: 'feature',
+    headRefOid: SHA_A,
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    reviewDecision: 'APPROVED',
+  };
+  return {
+    fetchPrDetails: async () => pr,
+    fetchCompare: async () => ({ behind_by: 0, ahead_by: 1, status: 'ahead' }),
+    fetchReviewThreads: async () => [],
+    fetchChecksForSha: async (_sha, options) => {
+      assert.deepEqual(options.requiredCheckNames, cfg.requiredChecks.pullRequest);
+      assert.equal(await options.verifyCurrentSha(), SHA_A);
+      return successfulChecks(cfg, 'pullRequest');
+    },
+    ...overrides,
+  };
+}
+
+function mainProbes(cfg, overrides = {}) {
+  return {
+    fetchRefSha: async () => SHA_A,
+    fetchMainDetails: async sha => ({ sha }),
+    fetchChecksForSha: async (_sha, options) => {
+      assert.deepEqual(options.requiredCheckNames, cfg.requiredChecks.main);
+      assert.equal(await options.verifyCurrentSha(), SHA_A);
+      return successfulChecks(cfg, 'main');
+    },
+    fetchAssociatedPullRequests: async () => [
+      { number: 7, merged_at: '2026-01-01T00:00:00Z', html_url: 'https://example.test/7' },
+    ],
+    fetchReleases: async () => [{ tag_name: 'v0.2.0-beta.2' }],
+    fetchCompare: async () => ({ ahead_by: 3, behind_by: 0 }),
+    ...overrides,
+  };
+}
+
+test('help exits 0 without configuration or GitHub access', () => {
+  const result = run(['--help']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Repository Control \(read-only\)/);
 });
 
-test('repo:control invalid scope exits 64', () => {
-  const res = run(['--scope', 'invalid']);
-  assert.equal(res.status, 64);
+test('unknown CLI options and invalid scopes exit 64', () => {
+  assert.equal(run(['--unknown']).status, 64);
+  assert.equal(run(['--scope', 'invalid']).status, 64);
 });
 
-test('repo:control overview runs (read-only, produces report)', () => {
-  const res = spawnSync(process.execPath, [SCRIPT, '--scope', 'overview', '--json'], {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: 30000,
+test('PR scope requires a positive integer and full local SHA', () => {
+  assert.equal(run(['--scope', 'pr']).status, 64);
+  assert.equal(run(['--scope', 'pr', '--pr', '-1']).status, 64);
+  assert.equal(run(['--scope', 'pr', '--pr', '1', '--local-sha', 'abc']).status, 64);
+});
+
+test('missing configuration fails closed with exit 64', () => {
+  const result = run(['--config', path.join(os.tmpdir(), `missing-${process.pid}.json`)]);
+  assert.equal(result.status, 64);
+  assert.match(result.stderr, /missing or unreadable/);
+});
+
+test('invalid JSON and empty required-check contracts fail closed', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-control-config-'));
+  const invalid = path.join(directory, 'invalid.json');
+  const empty = path.join(directory, 'empty.json');
+  fs.writeFileSync(invalid, '{');
+  const value = config();
+  value.requiredChecks.pullRequest = [];
+  fs.writeFileSync(empty, JSON.stringify(value));
+  assert.throws(() => loadConfig(invalid), ConfigError);
+  assert.throws(() => loadConfig(empty), /non-empty/);
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test('configuration validates explicit per-check conclusions and policy values', () => {
+  const value = config();
+  delete value.checkConclusions.pullRequest[value.requiredChecks.pullRequest[0]];
+  assert.throws(() => validateConfig(value, 'test'), /checkConclusions/);
+  const badPolicy = config();
+  badPolicy.policies.mergeability = 'maybe';
+  assert.throws(() => validateConfig(badPolicy, 'test'), /ignore, warning, or block/);
+});
+
+test('relative parent traversal is rejected before any GitHub probe', () => {
+  const result = run(['--scope', 'overview', '--json-output', '../escaped.json']);
+  assert.equal(result.status, 64);
+  assert.match(result.stderr, /parent traversal/);
+});
+
+test('absolute paths outside repository and temporary directory are rejected', () => {
+  assert.throws(
+    () => resolveSafePath('/var/repository-control-escape.json'),
+    /inside the repository or temporary/
+  );
+});
+
+test('symlink escape is rejected for output and configuration paths', () => {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-control-links-'));
+  const work = path.join(directory, 'work');
+  const outside = path.join(directory, 'outside');
+  fs.mkdirSync(work);
+  fs.mkdirSync(outside);
+  fs.symlinkSync(outside, path.join(work, 'link'));
+  assert.throws(() => resolveSafePath(path.join(work, 'link', 'report.json')), /symbolic links/);
+  const linkedConfig = path.join(work, 'config.json');
+  fs.symlinkSync(CONFIG_PATH, linkedConfig);
+  assert.throws(() => loadConfig(linkedConfig), /symbolic links/);
+  fs.rmSync(directory, { recursive: true, force: true });
+});
+
+test('read-only allowlist rejects mutating gh commands and GraphQL mutations', () => {
+  assert.doesNotThrow(() => assertReadOnlyGhArgs(['pr', 'view', '1']));
+  assert.doesNotThrow(() => assertReadOnlyGhArgs(['api', '--method', 'GET', 'repos/o/r']));
+  assert.throws(() => assertReadOnlyGhArgs(['pr', 'merge', '1']), /not read-only/);
+  assert.throws(
+    () => assertReadOnlyGhArgs(['api', '--method', 'DELETE', 'repos/o/r']),
+    /Non-read-only/
+  );
+  assert.throws(
+    () =>
+      assertReadOnlyGhArgs([
+        'api',
+        'graphql',
+        '--method',
+        'POST',
+        '-f',
+        'query=mutation { deleteProjectV2(input:{}) { clientMutationId } }',
+      ]),
+    /mutation rejected/
+  );
+});
+
+test('GitHub operation audit records executable, arguments, and read-only access', async () => {
+  const probe = createGithubProbe({
+    runner: args =>
+      args[0] === 'pr' ? JSON.stringify({ number: 1 }) : JSON.stringify({ sha: SHA_A, commit: {} }),
   });
-  // Should produce JSON report structure even if some data is UNKNOWN
-  const out = res.stdout || '';
-  assert.ok(out.includes('schemaVersion') || out.includes('"decision"'));
+  await probe.fetchPrDetails(1);
+  await probe.fetchMainDetails(SHA_A);
+  const operations = probe.getOperations();
+  assert.equal(operations.length, 2);
+  assert.ok(operations.every(item => item.executable === 'gh' && item.access === 'read-only'));
+  assert.ok(operations.every(item => Array.isArray(item.args)));
+});
+
+test('check and status pages are flattened without truncation', async () => {
+  const probe = createGithubProbe({
+    runner: args => {
+      const endpoint = args.find(arg => arg.includes('/commits/'));
+      if (endpoint.includes('check-runs'))
+        return JSON.stringify([
+          { check_runs: [successRun('one')] },
+          { check_runs: [successRun('two')] },
+        ]);
+      return JSON.stringify([
+        [{ id: 1, context: 'legacy-one', state: 'success', sha: SHA_A }],
+        [{ id: 2, context: 'legacy-two', state: 'success', sha: SHA_A }],
+      ]);
+    },
+  });
+  const checks = await probe.fetchChecksForSha(SHA_A);
+  assert.deepEqual(
+    checks.checkRuns.map(item => item.name),
+    ['one', 'two']
+  );
+  assert.deepEqual(
+    checks.statuses.map(item => item.context),
+    ['legacy-one', 'legacy-two']
+  );
+});
+
+test('rerun ordering prefers attempt, then completion time, then id', () => {
+  const selected = selectLatestChecks([
+    successRun('gate', SHA_A, { id: 99, attempt: 1, completed_at: '2026-02-01T00:00:00Z' }),
+    successRun('gate', SHA_A, {
+      id: 1,
+      attempt: 2,
+      completed_at: '2026-01-01T00:00:00Z',
+      conclusion: 'failure',
+    }),
+  ]);
+  assert.equal(selected.get('gate').attempt, 2);
+  assert.equal(selected.get('gate').conclusion, 'failure');
+});
+
+test('polling waits for delayed required-check creation', async () => {
+  let checkCalls = 0;
+  let clock = 0;
+  const probe = createGithubProbe({
+    now: () => clock++,
+    sleep: async () => {},
+    runner: args => {
+      const endpoint = args.find(arg => arg.includes('/commits/'));
+      if (endpoint.includes('check-runs')) {
+        checkCalls += 1;
+        return JSON.stringify([{ check_runs: checkCalls === 1 ? [] : [successRun('gate')] }]);
+      }
+      return JSON.stringify([[]]);
+    },
+  });
+  const result = await probe.fetchChecksForSha(SHA_A, {
+    wait: true,
+    timeoutSeconds: 20,
+    pollSeconds: 5,
+    requiredCheckNames: ['gate'],
+    verifyCurrentSha: async () => SHA_A,
+  });
+  assert.equal(checkCalls, 2);
+  assert.equal(result.checkRuns[0].name, 'gate');
+});
+
+test('polling rejects PR-head or main-ref changes during one snapshot', async () => {
+  let identityCalls = 0;
+  const probe = createGithubProbe({
+    runner: args =>
+      args.some(arg => arg.includes('check-runs'))
+        ? JSON.stringify([{ check_runs: [successRun('gate')] }])
+        : JSON.stringify([[]]),
+  });
+  await assert.rejects(
+    () =>
+      probe.fetchChecksForSha(SHA_A, {
+        requiredCheckNames: ['gate'],
+        verifyCurrentSha: async () => (++identityCalls === 1 ? SHA_A : SHA_B),
+      }),
+    error => error.code === 'OBSERVED_SHA_CHANGED'
+  );
+});
+
+test('neutral required conclusion blocks unless explicitly configured for that check', () => {
+  const neutral = {
+    checkRuns: [successRun('gate', SHA_A, { conclusion: 'neutral' })],
+    statuses: [],
+  };
+  const blocked = report();
+  evaluateRequiredChecks(blocked, neutral, ['gate'], { gate: ['success'] }, SHA_A);
+  assert.equal(blocked.blockers[0].code, 'CHECK_FAILED');
+  const allowed = report();
+  evaluateRequiredChecks(allowed, neutral, ['gate'], { gate: ['success', 'neutral'] }, SHA_A);
+  assert.equal(allowed.blockers.length, 0);
+});
+
+test('missing, pending, stale, failed and successful checks have distinct decisions', () => {
+  const cases = [
+    [{ checkRuns: [], statuses: [] }, 'REQUIRED_CHECK_MISSING'],
+    [
+      {
+        checkRuns: [successRun('gate', SHA_A, { status: 'in_progress', conclusion: null })],
+        statuses: [],
+      },
+      'CHECK_PENDING',
+    ],
+    [{ checkRuns: [successRun('gate', SHA_B)], statuses: [] }, 'STALE_CHECK'],
+    [
+      { checkRuns: [successRun('gate', SHA_A, { conclusion: 'failure' })], statuses: [] },
+      'CHECK_FAILED',
+    ],
+  ];
+  for (const [checks, code] of cases) {
+    const value = report();
+    evaluateRequiredChecks(value, checks, ['gate'], { gate: ['success'] }, SHA_A);
+    assert.equal(value.blockers[0].code, code);
+  }
+  const healthy = report();
+  evaluateRequiredChecks(
+    healthy,
+    { checkRuns: [successRun('gate')], statuses: [] },
+    ['gate'],
+    { gate: ['success'] },
+    SHA_A
+  );
+  assert.equal(healthy.blockers.length, 0);
+});
+
+test('final decision matrix preserves technical UNKNOWN and applies strict promotion', () => {
+  const healthy = report('main');
+  assert.equal(finalizeDecision(healthy, 'main', true), 'HEALTHY');
+  const blocked = report();
+  blocked.blockers.push({ code: 'X' });
+  assert.equal(finalizeDecision(blocked, 'pr', false), 'BLOCKED');
+  const unknown = report('main');
+  unknown.unknowns.push({ code: 'X' });
+  assert.equal(finalizeDecision(unknown, 'main', false), 'UNKNOWN');
+  assert.equal(finalizeDecision(unknown, 'main', true), 'UNHEALTHY');
+  assert.equal(unknown.technicalDecision, 'UNKNOWN');
+  const warning = report();
+  warning.warnings.push({ code: 'X' });
+  assert.equal(finalizeDecision(warning, 'pr', false), 'READY');
+  assert.equal(finalizeDecision(warning, 'pr', true), 'BLOCKED');
+  assert.equal(warning.technicalDecision, 'READY');
+});
+
+test('PR happy path is offline and ready at the exact SHA', async () => {
+  const cfg = config();
+  const value = report();
+  await evaluatePr({
+    report: value,
+    prNumber: 7,
+    wait: true,
+    timeoutSeconds: 20,
+    pollSeconds: 5,
+    config: cfg,
+    probes: prProbes(cfg),
+  });
+  assert.equal(value.observedSha, SHA_A);
+  assert.deepEqual(value.blockers, []);
+  assert.deepEqual(value.unknowns, []);
+});
+
+test('PR policies cover draft, conflicts, behind main, changes and unresolved threads', async () => {
+  const cfg = config();
+  const base = prProbes(cfg);
+  const value = report();
+  await evaluatePr({
+    report: value,
+    prNumber: 7,
+    wait: false,
+    timeoutSeconds: 20,
+    pollSeconds: 5,
+    config: cfg,
+    probes: prProbes(cfg, {
+      fetchPrDetails: async () => ({
+        ...(await base.fetchPrDetails()),
+        isDraft: true,
+        mergeable: 'CONFLICTING',
+        mergeStateStatus: 'DIRTY',
+        reviewDecision: 'CHANGES_REQUESTED',
+      }),
+      fetchCompare: async () => ({ behind_by: 2, ahead_by: 1 }),
+      fetchReviewThreads: async () => [{ isResolved: false }],
+    }),
+  });
+  const codes = new Set(value.blockers.map(item => item.code));
+  for (const code of [
+    'PR_IS_DRAFT',
+    'PR_CONFLICTING',
+    'PR_BEHIND_MAIN',
+    'CHANGES_REQUESTED',
+    'UNRESOLVED_REVIEW_THREADS',
+  ])
+    assert.ok(codes.has(code), code);
+});
+
+test('unknown mergeability, review permissions and head changes remain UNKNOWN evidence', async () => {
+  const cfg = config();
+  const base = prProbes(cfg);
+  const value = report();
+  await evaluatePr({
+    report: value,
+    prNumber: 7,
+    wait: false,
+    timeoutSeconds: 20,
+    pollSeconds: 5,
+    config: cfg,
+    probes: prProbes(cfg, {
+      fetchPrDetails: async () => ({ ...(await base.fetchPrDetails()), mergeable: 'UNKNOWN' }),
+      fetchReviewThreads: async () => {
+        throw new Error('denied');
+      },
+      fetchChecksForSha: async () => {
+        const error = new Error('changed');
+        error.code = 'OBSERVED_SHA_CHANGED';
+        throw error;
+      },
+    }),
+  });
+  const codes = new Set(value.unknowns.map(item => item.code));
+  for (const code of ['PR_MERGEABILITY_UNKNOWN', 'REVIEW_THREADS_UNKNOWN', 'PR_HEAD_CHANGED'])
+    assert.ok(codes.has(code), code);
+});
+
+test('main uses commit-to-PR association and release policy', async () => {
+  const cfg = config();
+  const value = report('main');
+  await evaluateMain({
+    report: value,
+    wait: true,
+    timeoutSeconds: 20,
+    pollSeconds: 5,
+    config: cfg,
+    probes: mainProbes(cfg, {
+      fetchAssociatedPullRequests: async () => [],
+      fetchReleases: async () => [{ tag_name: 'v0.1.0' }],
+      fetchCompare: async () => ({ ahead_by: 1, behind_by: 0 }),
+    }),
+    packageVersion: '0.2.0',
+  });
+  assert.ok(value.warnings.some(item => item.code === 'DIRECT_MAIN_COMMIT'));
+  assert.ok(value.warnings.some(item => item.code === 'RELEASE_VERSION_MISMATCH'));
+});
+
+test('main SHA changes are not reported healthy', async () => {
+  const cfg = config();
+  const value = report('main');
+  const error = new Error('changed');
+  error.code = 'OBSERVED_SHA_CHANGED';
+  await evaluateMain({
+    report: value,
+    wait: true,
+    timeoutSeconds: 20,
+    pollSeconds: 5,
+    config: cfg,
+    probes: mainProbes(cfg, {
+      fetchChecksForSha: async () => {
+        throw error;
+      },
+    }),
+  });
+  assert.ok(value.unknowns.some(item => item.code === 'MAIN_SHA_CHANGED'));
+});
+
+test('overview classifies open, merged-retained, ahead and stale branches', async () => {
+  const cfg = config();
+  const branches = [
+    { name: 'main', commit: { sha: SHA_A } },
+    { name: 'open', commit: { sha: '1' } },
+    { name: 'merged', commit: { sha: '2' } },
+    { name: 'ahead', commit: { sha: '3' } },
+    { name: 'stale', commit: { sha: '4' } },
+  ];
+  const probes = mainProbes(cfg, {
+    fetchOpenPrs: async () => [{ headRefName: 'open' }],
+    fetchBranches: async () => branches,
+    fetchCompare: async (_base, sha) => ({
+      ahead_by: sha === '4' ? 0 : 1,
+      behind_by: sha === '4' ? 2 : 0,
+    }),
+    fetchAssociatedPullRequests: async sha =>
+      sha === '2'
+        ? [{ number: 2, merged_at: '2026-01-01' }]
+        : sha === SHA_A
+          ? [{ number: 1, merged_at: '2026-01-01' }]
+          : [],
+  });
+  const value = report('overview');
+  await evaluateOverview({
+    report: value,
+    wait: false,
+    timeoutSeconds: 20,
+    pollSeconds: 5,
+    config: cfg,
+    probes,
+    packageVersion: '0.2.0-beta.2',
+  });
+  assert.deepEqual(
+    value.branches.map(item => item.classification),
+    ['OPEN_PR', 'MERGED_RETAINED', 'AHEAD_WITHOUT_PR', 'STALE']
+  );
+});
+
+test('workflow propagates both PR and main gate exit codes with read-only permissions', () => {
+  const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/ci.yml'), 'utf8');
+  const controlSection = workflow.slice(workflow.indexOf('repository-control:'));
+  assert.doesNotMatch(controlSection, /\|\|\s*true|continue-on-error/);
+  assert.match(controlSection, /--scope pr[\s\S]*--wait[\s\S]*--strict/);
+  assert.match(controlSection, /Repository Control Main[\s\S]*--scope main --wait --strict/);
+  for (const permission of [
+    'contents: read',
+    'checks: read',
+    'statuses: read',
+    'pull-requests: read',
+  ])
+    assert.match(workflow, new RegExp(permission));
+});
+
+test('repository-control tests contain no live GitHub invocation', () => {
+  const source = fs.readFileSync(__filename, 'utf8');
+  assert.doesNotMatch(source, /spawnSync\(['"]gh['"]|execFileSync\(['"]gh['"]/);
+});
+
+test('all production gh execution is centralized behind the read-only allowlist', () => {
+  const files = [
+    SCRIPT,
+    ...fs
+      .readdirSync(path.join(ROOT, 'scripts/repository-control'))
+      .filter(name => name.endsWith('.js'))
+      .map(name => path.join(ROOT, 'scripts/repository-control', name)),
+  ];
+  const executors = files.filter(file =>
+    /execFileSync\(['"]gh['"]/.test(fs.readFileSync(file, 'utf8'))
+  );
+  assert.deepEqual(executors, [path.join(ROOT, 'scripts/repository-control', 'githubProbe.js')]);
+  assert.match(fs.readFileSync(executors[0], 'utf8'), /assertReadOnlyGhArgs\(args\)/);
 });


### PR DESCRIPTION
## Summary

- make repository-control configuration and filesystem outputs fail closed, including traversal and symlink defenses
- propagate the real PR gate exit code and add an exact-main-SHA gate with least-privilege read permissions
- paginate and stabilize GitHub observations, enforce explicit check conclusions, and complete policy evidence
- replace live smoke coverage with a permanent 27-test offline decision matrix and read-only-operation proofs

## Validation

- clean npm ci
- focused repository-control tests: 27/27 passed five consecutive times
- npm test: passed twice; discovery 124/124, zero omissions/exclusions/duplicates; unit phase 608/608
- format, lint, typecheck, quality, benchmark, package smoke, docs, portability, security guards, npm audit: passed

No IBM i product behavior or release state is changed.