### PR TITLE
fix(cli): make explicit top-level help exit successfully

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - run: npm run typecheck
       - run: npm run test:discovery
       - run: npm run test:release-integrity
+      - run: npm run test:cli-help
       - run: npm run check:repo-portability
       - run: npm run check:public-knowledge-claims
       - run: npm run test:quality
@@ -82,6 +83,7 @@ jobs:
       - run: npm ci
       - run: npm run test:discovery
       - run: npm test
+      - run: npm run package:smoke
 
   package-smoke:
     name: Package Smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,7 @@ jobs:
           npm install --ignore-scripts --no-audit --no-fund "$ARTIFACT_DIR/$TARBALL"
           node -e "const p=require('zeus-rpg-promptkit/package.json'); if(p.version!==process.env.RELEASE_VERSION) process.exit(1); require('zeus-rpg-promptkit/api')"
           ./node_modules/.bin/zeus --help >/dev/null
+          ./node_modules/.bin/zeus -h >/dev/null
 
   verify-linux-lts:
     name: Verify release artifact on Linux current LTS
@@ -257,6 +258,7 @@ jobs:
           npm install --ignore-scripts --no-audit --no-fund "$ARTIFACT_DIR/$TARBALL"
           node -e "const p=require('zeus-rpg-promptkit/package.json'); if(p.version!==process.env.RELEASE_VERSION) process.exit(1); require('zeus-rpg-promptkit/api')"
           ./node_modules/.bin/zeus --help >/dev/null
+          ./node_modules/.bin/zeus -h >/dev/null
 
   verify-windows-20:
     name: Verify release artifact on Windows Node 20
@@ -298,6 +300,7 @@ jobs:
           npm install --ignore-scripts --no-audit --no-fund (Join-Path $artifactDir $env:TARBALL)
           node -e "const p=require('zeus-rpg-promptkit/package.json'); if(p.version!==process.env.RELEASE_VERSION) process.exit(1); require('zeus-rpg-promptkit/api')"
           & .\node_modules\.bin\zeus --help | Out-Null
+          & .\node_modules\.bin\zeus -h | Out-Null
 
   attest:
     name: Attest and strictly verify the release artifact

--- a/cli/zeus.js
+++ b/cli/zeus.js
@@ -497,6 +497,13 @@ async function main() {
   }
 
   let { command, args } = splitCommandArgs(argv);
+  const topLevelHelpRequested =
+    (command === null || command === '-h') &&
+    argv.some(token => token === '--help' || token === '-h');
+  if (topLevelHelpRequested) {
+    printHelp();
+    return;
+  }
   if (!command) {
     printHelp();
     process.exit(1);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "sbom:validate": "node scripts/validate-sbom.js",
     "repo:control": "node scripts/repository-control.js",
     "test:repository-control": "node --test tests/repository-control.test.js",
-    "test:release-integrity": "node --test tests/release-integrity.test.js"
+    "test:release-integrity": "node --test tests/release-integrity.test.js",
+    "test:cli-help": "node --test tests/cli-help.test.js && npm run package:smoke"
   },
   "dependencies": {
     "adm-zip": "^0.5.16",

--- a/scripts/package-smoke.js
+++ b/scripts/package-smoke.js
@@ -15,6 +15,7 @@ const os = require('os');
 const ROOT = path.resolve(__dirname, '..');
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-smoke-'));
 const PACK_DIR = path.join(TMP, 'pack');
+const EXPECTED_VERSION = require('../package.json').version;
 
 function sh(cmd, cwd = ROOT) {
   console.log('$ ' + cmd);
@@ -24,6 +25,20 @@ function sh(cmd, cwd = ROOT) {
     throw new Error('failed: ' + cmd);
   }
   return r.stdout || '';
+}
+
+function runInstalled(file, args, cwd) {
+  console.log('$ ' + [file, ...args].join(' '));
+  const result = spawnSync(file, args, {
+    cwd,
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+  if (result.status !== 0) {
+    console.error(result.stderr || result.stdout);
+    throw new Error('failed installed executable: ' + file + ' ' + args.join(' '));
+  }
+  return result.stdout || '';
 }
 
 try {
@@ -40,20 +55,27 @@ try {
   const inst = path.join(TMP, 'i');
   fs.mkdirSync(inst, { recursive: true });
   sh('npm init -y', inst);
-  sh('npm install --no-audit --no-fund ' + tgz, inst);
+  sh('npm install --offline --no-audit --no-fund ' + tgz, inst);
 
-  // bin + api (best effort)
-  const bin = path.join(inst, 'node_modules', '.bin', 'zeus');
-  try {
-    const h = sh(bin + ' --help 2>&1 || true');
-    console.log('help len:', (h || '').length);
-  } catch (_e) {
-    console.log('bin present');
+  // Strictly verify the executable and public API from the temporary installation.
+  const binName = process.platform === 'win32' ? 'zeus.cmd' : 'zeus';
+  const bin = path.join(inst, 'node_modules', '.bin', binName);
+  const resolvedBin = fs.realpathSync(bin);
+  const installedNodeModules = path.join(inst, 'node_modules') + path.sep;
+  if (!resolvedBin.startsWith(installedNodeModules)) {
+    throw new Error('installed executable resolves outside temporary installation: ' + resolvedBin);
   }
-  try {
-    const a = sh('node -e "console.log(!!require(\'zeus-rpg-promptkit/api\'))" 2>&1 || true', inst);
-    console.log('api:', a);
-  } catch (_e) {}
+  const longHelp = runInstalled(bin, ['--help'], inst);
+  const shortHelp = runInstalled(bin, ['-h'], inst);
+  if (!/Usage:\s*\n\s*zeus /.test(longHelp) || !/Usage:\s*\n\s*zeus /.test(shortHelp)) {
+    throw new Error('installed help output is missing top-level usage');
+  }
+  sh(
+    "node -e \"const p=require('zeus-rpg-promptkit/package.json');" +
+      `if(p.version!=='${EXPECTED_VERSION}') process.exit(1);` +
+      "require('zeus-rpg-promptkit/api')\"",
+    inst
+  );
 
   console.log('PACKAGE SMOKE PASSED');
 } catch (_e) {

--- a/scripts/package-smoke.js
+++ b/scripts/package-smoke.js
@@ -55,7 +55,7 @@ try {
   const inst = path.join(TMP, 'i');
   fs.mkdirSync(inst, { recursive: true });
   sh('npm init -y', inst);
-  sh('npm install --offline --no-audit --no-fund ' + tgz, inst);
+  sh('npm install --no-audit --no-fund ' + tgz, inst);
 
   // Strictly verify the executable and public API from the temporary installation.
   const binName = process.platform === 'win32' ? 'zeus.cmd' : 'zeus';

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -6,6 +6,7 @@ module.exports = {
       'tests/ai-knowledge-projection.test.js',
       'tests/analyze-run-manifest.test.js',
       'tests/bundle-manifest.test.js',
+      'tests/cli-help.test.js',
       'tests/evidence-graph.test.js',
       'tests/graph-guided-context-planner.test.js',
       'tests/release-integrity.test.js',

--- a/tests/cli-help.test.js
+++ b/tests/cli-help.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const ROOT = path.resolve(__dirname, '..');
+const CLI = path.join(ROOT, 'cli', 'zeus.js');
+
+function run(args) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+}
+
+function assertTopLevelHelp(result) {
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Usage:\s*\n\s*zeus /);
+  assert.equal(result.stderr, '');
+  assert.equal(result.error, undefined);
+}
+
+test('explicit top-level --help exits successfully', () => {
+  assertTopLevelHelp(run(['--help']));
+});
+
+test('explicit top-level -h exits successfully', () => {
+  assertTopLevelHelp(run(['-h']));
+});
+
+test('no-command invocation retains usage error semantics', () => {
+  const result = run([]);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /Usage:\s*\n\s*zeus /);
+  assert.equal(result.stderr, '');
+});
+
+test('unknown command remains an error even when followed by --help', () => {
+  const result = run(['definitely-not-a-command', '--help']);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /Usage:\s*\n\s*zeus /);
+});
+
+test('known command help remains successful', () => {
+  const result = run(['bridge', '--help']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Bridge commands/);
+});
+
+test('help lookalikes are not accepted as explicit top-level help', () => {
+  for (const option of ['--help=true', '--helpful', '-hx']) {
+    const result = run([option]);
+    assert.equal(result.status, 1, option);
+  }
+});
+
+test('package smoke strictly invokes the temporary installed executable', () => {
+  const smoke = fs.readFileSync(path.join(ROOT, 'scripts', 'package-smoke.js'), 'utf8');
+  assert.match(smoke, /path\.join\(inst, 'node_modules', '\.bin', binName\)/);
+  assert.match(smoke, /runInstalled\(bin, \['--help'\], inst\)/);
+  assert.match(smoke, /runInstalled\(bin, \['-h'\], inst\)/);
+  assert.doesNotMatch(smoke, /cli[\\/]zeus\.js/);
+  assert.doesNotMatch(smoke, /\|\|\s*(?:true|echo)\b/);
+});
+
+test('Windows CI runs installed-package smoke validation', () => {
+  const ci = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+  const windowsStart = ci.indexOf('  test-windows-20:');
+  const nextJob = ci.indexOf('\n  package-smoke:', windowsStart);
+  assert.notEqual(windowsStart, -1);
+  assert.notEqual(nextJob, -1);
+  assert.match(ci.slice(windowsStart, nextJob), /npm run package:smoke/);
+});

--- a/tests/release-integrity.test.js
+++ b/tests/release-integrity.test.js
@@ -77,6 +77,16 @@ test('all platform jobs consume the same captured workflow artifact', () => {
   }
 });
 
+test('all platform jobs strictly verify both installed top-level help flags', () => {
+  for (const name of ['verify-linux-20', 'verify-linux-lts', 'verify-windows-20']) {
+    const section = job(name);
+    assert.match(section, /node_modules[\\/.]\.bin[\\/]zeus --help/, name);
+    assert.match(section, /node_modules[\\/.]\.bin[\\/]zeus -h/, name);
+    assert.doesNotMatch(section, /zeus (?:--help|-h).*\|\|\s*(?:true|echo)\b/, name);
+  }
+  assert.match(job('verify-windows-20'), /& \.\\node_modules\\\.bin\\zeus --help/);
+});
+
 test('source SHA is captured once from github.sha and exported', () => {
   const section = job('build');
   assert.equal(occurrences(section, /SOURCE_SHA="\$GITHUB_SHA"/g), 1);


### PR DESCRIPTION
## Summary

- recognize exact explicit top-level `--help` and `-h` requests after the existing argument split and return success
- preserve no-command and unknown-command error semantics
- add subprocess CLI contract coverage and strict installed-package smoke validation
- verify both installed help flags on Linux and Windows in CI and the future release workflow

## Reproduced defect and root cause

Before the change, source and freshly installed package invocations produced help but exited `1` for both `zeus --help` and `zeus -h`. The existing parser represented `--help` as metadata with no command and treated `-h` as a command token, so both paths reached an error exit.

## Behavior

| Invocation | Before | After |
| --- | --- | --- |
| `zeus --help` | help, exit 1 | help, exit 0 |
| `zeus -h` | help, exit 1 | help, exit 0 |
| `zeus` | help, exit 1 | unchanged: help, exit 1 |
| `zeus definitely-not-a-command` | help, exit 1 | unchanged: help, exit 1 |
| `zeus bridge --help` | command help, exit 0 | unchanged: command help, exit 0 |

Only exact `--help` and `-h` tokens in the top-level no-command/help position qualify. `--help=true`, `--helpful`, and `-hx` remain errors, and `unknown --help` remains an unknown-command error.

## Verification

- source subprocess tests cover long help, short help, no arguments, unknown command, known-command help, and malformed lookalikes
- package smoke packs once per run, installs the local tarball into a fresh temporary project, proves the executable resolves inside that installation, strictly runs installed `--help` and `-h`, verifies the package version, and imports the public API
- Windows CI executes the same cross-platform installed-package smoke using the native `.cmd` shim; no `npx` or global executable can satisfy it
- future release verification retains strict installed `zeus --help` and adds strict installed `zeus -h` on Linux Node 20, Linux current LTS, and Windows Node 20
- release-integrity tests statically preserve both installed help checks on every platform and the native Windows invocation
- focused CLI help command passed five consecutive times; the full test suite passed twice
- discovery: 126 maintained files discovered, 126 classified, 0 excluded, 0 omitted, 0 duplicate classifications
- negative mutations proved tests fail for each help regression, weakened no-command/unknown status, suppressed installed status, source-executable substitution, removed Windows verification, and removed release `zeus --help`; every mutation was reverted

Initial PR checks revealed that forcing npm's offline cache mode could not resolve fresh tarball dependencies on clean GitHub runners. That added cache constraint was removed; strict local executable selection and exit-status verification remain unchanged.

## Package-smoke and release-integrity impact

Package smoke no longer treats executable or API checks as best effort and contains no failure suppression. The hardened single-build, captured-SHA, checksum, SBOM, attestation, tagging, and publication architecture is unchanged; the existing strict installed `zeus --help` release check now passes naturally.

## Non-goals

- no release was created or dispatched, and nothing was published to npm
- no tag, release asset, release body, or historical Beta 2 exception changed
- no CLI redesign or new parser/framework was introduced
- no IBM i, RPG, CL, DDS, Db2, MCP, analysis, or investigation behavior changed
- no Iteration 19 or Typed Evidence Graph work is included
