### PR TITLE
test(known-facts): make expiry checks clock-independent

### DIFF
--- a/tests/analyze-runtime-contract.test.js
+++ b/tests/analyze-runtime-contract.test.js
@@ -5,6 +5,10 @@ const os = require('os');
 const path = require('path');
 
 const { runAnalyzeArtifactAdapter, runAnalyzeCore } = require('../src/analyze/analyzePipeline');
+const { REPRODUCIBLE_TIMESTAMP } = require('../src/reproducibility/reproducibility');
+
+const KNOWN_FACTS_UPDATED_AT = '1999-12-16T00:00:00.000Z';
+const KNOWN_FACTS_EXPIRES_AT = '2000-01-15T00:00:00.000Z';
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -149,8 +153,8 @@ test('analyze core can opt in local known facts without auto-loading them by def
         profile: 'dev',
         versionMarker: {
           toolVersion: '0.1.0',
-          updatedAt: '2026-06-16T10:00:00.000Z',
-          expiresAt: '2026-07-16T10:00:00.000Z',
+          updatedAt: KNOWN_FACTS_UPDATED_AT,
+          expiresAt: KNOWN_FACTS_EXPIRES_AT,
           ttlDays: 30,
         },
         facts: [
@@ -175,6 +179,10 @@ test('analyze core can opt in local known facts without auto-loading them by def
       outputRoot,
       profile: 'dev',
       loadKnownFactsEnabled: true,
+      reproducibility: {
+        enabled: true,
+        stableTimestamp: REPRODUCIBLE_TIMESTAMP,
+      },
       cwd: tempRoot,
       config: {
         extensions: ['.rpgle'],

--- a/tests/local-known-facts-store.test.js
+++ b/tests/local-known-facts-store.test.js
@@ -63,6 +63,7 @@ test('local known facts store writes profile-scoped local-only facts with ttl me
     assert.equal(fs.existsSync(written.path), true);
     assert.equal(written.store.versionMarker.ttlDays, 14);
     assert.equal(written.store.versionMarker.updatedAt, now);
+    assert.equal(written.store.versionMarker.expiresAt, '2026-06-30T10:00:00.000Z');
     assert.equal(written.store.facts.length, 1);
     assert.equal(written.store.facts[0].confidence, 'HIGH');
 
@@ -78,7 +79,7 @@ test('local known facts store writes profile-scoped local-only facts with ttl me
   }
 });
 
-test('local known facts store flags expired payloads and rejects secret-like values', () => {
+test('local known facts store evaluates controlled time before, at, and after expiry', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-known-facts-expired-'));
 
   try {
@@ -86,8 +87,9 @@ test('local known facts store flags expired payloads and rejects secret-like val
       'qa',
       {
         versionMarker: {
-          updatedAt: '2026-06-01T00:00:00.000Z',
-          ttlDays: 1,
+          updatedAt: '2000-01-01T00:00:00.000Z',
+          expiresAt: '2000-01-02T00:00:00.000Z',
+          ttlDays: 30,
         },
         facts: [
           {
@@ -99,17 +101,90 @@ test('local known facts store flags expired payloads and rejects secret-like val
       },
       {
         cwd: tempRoot,
-        now: '2026-06-01T00:00:00.000Z',
+        now: '2000-01-01T00:00:00.000Z',
       }
     );
 
-    const expired = readKnownFactsStore('qa', {
+    const ready = readKnownFactsStore('qa', {
       cwd: tempRoot,
-      now: '2026-06-16T00:00:00.000Z',
+      now: '2000-01-01T23:59:59.999Z',
     });
-    assert.equal(expired.status, 'expired');
-    assert.equal(expired.expired, true);
+    assert.equal(ready.status, 'ready');
+    assert.equal(ready.expired, false);
 
+    const atBoundary = readKnownFactsStore('qa', {
+      cwd: tempRoot,
+      now: '2000-01-02T00:00:00.000Z',
+    });
+    assert.equal(atBoundary.status, 'expired');
+    assert.equal(atBoundary.expired, true);
+
+    const afterBoundary = readKnownFactsStore('qa', {
+      cwd: tempRoot,
+      now: '2000-01-02T00:00:00.001Z',
+    });
+    assert.equal(afterBoundary.status, 'expired');
+    assert.equal(afterBoundary.expired, true);
+
+    const defaultClock = readKnownFactsStore('qa', { cwd: tempRoot });
+    assert.equal(defaultClock.status, 'expired');
+    assert.equal(defaultClock.expired, true);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('local known facts store rejects invalid time and preserves missing status', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-known-facts-time-policy-'));
+
+  try {
+    const missing = readKnownFactsStore('missing', {
+      cwd: tempRoot,
+      now: '2000-01-01T00:00:00.000Z',
+    });
+    assert.equal(missing.status, 'missing');
+    assert.equal(missing.expired, false);
+
+    assert.throws(
+      () =>
+        writeKnownFactsStore(
+          'invalid-expiry',
+          {
+            versionMarker: {
+              updatedAt: '2000-01-01T00:00:00.000Z',
+              expiresAt: 'not-a-timestamp',
+            },
+            facts: [],
+          },
+          { cwd: tempRoot, now: '2000-01-01T00:00:00.000Z' }
+        ),
+      /Invalid timestamp: not-a-timestamp/
+    );
+
+    writeKnownFactsStore(
+      'invalid-now',
+      {
+        versionMarker: {
+          updatedAt: '2000-01-01T00:00:00.000Z',
+          expiresAt: '2000-01-02T00:00:00.000Z',
+        },
+        facts: [],
+      },
+      { cwd: tempRoot, now: '2000-01-01T00:00:00.000Z' }
+    );
+    assert.throws(
+      () => readKnownFactsStore('invalid-now', { cwd: tempRoot, now: 'not-a-timestamp' }),
+      /Invalid timestamp: not-a-timestamp/
+    );
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('local known facts store rejects secret-like values', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-known-facts-secrets-'));
+
+  try {
     assert.throws(
       () =>
         writeKnownFactsStore(

--- a/tests/zeus-api.test.js
+++ b/tests/zeus-api.test.js
@@ -5,8 +5,11 @@ const os = require('os');
 const path = require('path');
 
 const { analyze, listRuns, readKnowledge, runWorkflow, zeus } = require('../src/api/zeusApi');
+const { REPRODUCIBLE_TIMESTAMP } = require('../src/reproducibility/reproducibility');
 
 const fixtureRoot = path.join(__dirname, 'fixtures', 'v1-smoke', 'src');
+const KNOWN_FACTS_UPDATED_AT = '1999-12-16T00:00:00.000Z';
+const KNOWN_FACTS_EXPIRES_AT = '2000-01-15T00:00:00.000Z';
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -57,8 +60,8 @@ test('zeusApi exposes reusable analyze and workflow entry points', async () => {
         profile: 'local',
         versionMarker: {
           toolVersion: '0.1.0',
-          updatedAt: '2026-06-16T10:00:00.000Z',
-          expiresAt: '2026-07-16T10:00:00.000Z',
+          updatedAt: KNOWN_FACTS_UPDATED_AT,
+          expiresAt: KNOWN_FACTS_EXPIRES_AT,
           ttlDays: 30,
         },
         facts: [
@@ -81,11 +84,13 @@ test('zeusApi exposes reusable analyze and workflow entry points', async () => {
       member: 'ORDERPGM',
       mode: 'documentation',
       'with-known-facts': true,
+      reproducible: true,
       runtime: {
         cwd: tempRoot,
         env: {},
       },
     });
+    assert.equal(analyzeResult.reproducibility.stableTimestamp, REPRODUCIBLE_TIMESTAMP);
     assert.equal(analyzeResult.program, 'ORDERPGM');
     assert.equal(fs.existsSync(path.join(analyzeResult.outputProgramDir, 'context.json')), true);
     assert.equal(


### PR DESCRIPTION
## What changed

- make both Known-Facts integration fixtures use the existing reproducibility clock
- place fixture validity on a closed fixed timeline around that controlled instant
- cover ready, exact-boundary, expired, derived-expiry, invalid-time, missing-store, and default-clock behavior

## Why

The fixtures expired on 2026-07-16 and bound the test result to wall-clock time. The production
Known-Facts contract already accepts a controlled evaluation time and the analysis pipeline already
uses the reproducibility clock, so no production behavior or public API change is required.

## Compatibility and safety

- no production, schema, package, CLI, or API changes
- expiry remains fail-closed: `now >= expiresAt` is expired
- default production evaluation continues to use real time
- Known Facts remain local-only and explicitly opt-in

## Validation

- focused Known-Facts/API tests: 13/13 passed
- full repository test and quality gates passed
- 126/126 maintained tests classified with no omissions or duplicates
- package smoke, docs, demo safety, portability, public-knowledge, audit, and dry-run package passed
- negative proofs caught removed clock control and a weakened exact-boundary comparator
