### PR TITLE
docs(core): define commercial extension and module boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,13 @@ zeus.mcpTools.registerTool('my.tool', {
 zeus.registerPlugin(myPlugin);
 ```
 
+Diese Hooks sind ausschließlich für explizit importierten, vertrauenswürdigen In-Process-Code
+bestimmt. `registerPlugin` ist kein dynamischer Modul-Loader, keine Sandbox, kein Marketplace und
+keine Lizenz- oder Kompatibilitätsgrenze. Die spezifizierte zukünftige Modulgrenze sowie die
+Trennung von öffentlichem Core und separaten kommerziellen Implementierungen beschreibt
+[`ADR-006`](docs/architecture/adr-006-commercial-extension-architecture.md); eine ausführbare
+Modul-Registry oder kommerzielle Funktion wird damit noch nicht bereitgestellt.
+
 Zentrale Erweiterungspunkte:
 
 - Analyzer Registry
@@ -1039,6 +1046,13 @@ zeus.mcpTools.registerTool('my.tool', {
 
 zeus.registerPlugin(myPlugin);
 ```
+
+These hooks are only for explicitly imported, trusted in-process code. `registerPlugin` is not a
+dynamic module loader, sandbox, marketplace, license gate, or compatibility boundary. The
+specified future module boundary and the separation between public core contracts and separately
+distributed commercial implementations are defined in
+[`ADR-006`](docs/architecture/adr-006-commercial-extension-architecture.md); this does not yet ship
+an executable module registrar or commercial capability.
 
 Primary extension points:
 

--- a/docs/architecture/adr-006-commercial-extension-architecture.md
+++ b/docs/architecture/adr-006-commercial-extension-architecture.md
@@ -1,0 +1,249 @@
+---
+Title: ADR-006 Commercial Extension Architecture
+Description: Open-core ownership, versioned module descriptors, explicit registration, compatibility, availability, and artifact portability boundaries.
+Last Updated: 2026-07-16
+---
+
+# ADR-006: Commercial Extension Architecture
+
+**Status:** Accepted specification; executable module registrar and commercial modules are future work
+
+## Context
+
+Zeus is an Apache-2.0 open-core platform. The core must remain useful on its own while allowing
+explicitly installed packages to contribute capabilities through the existing Capability Registry.
+Public extension contracts and safety rules belong in the core. Paid handlers, entitlement
+enforcement, and enterprise operations do not.
+
+The current programmatic API has several in-process registries and a broad `registerPlugin` hook.
+Those are trusted embedding mechanisms, not a package loader, sandbox, compatibility gate, module
+transaction, marketplace, or entitlement boundary. JavaScript executes as soon as an imported
+package is evaluated, before any Zeus registration validation can protect the host.
+
+This ADR specifies the boundary that a future narrow module registrar and SDK must implement. It
+does not claim that such a registrar, commercial package, or entitlement system is currently
+shipped.
+
+## Decision
+
+### Ownership by edition
+
+Edition is classification metadata. It describes package ownership and expected distribution; it
+never grants access and must not be treated as proof of entitlement.
+
+| Edition      | Public core owns                                                                                                                           | Separately distributed implementation owns                                                                                                                      |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Community    | Module, capability, safety, compatibility, status, and artifact contracts; useful CLI/API/local MCP behavior; generic redacted diagnostics | Optional community implementations may be core-bundled or public packages                                                                                       |
+| Professional | The same public contracts and neutral registration path                                                                                    | Generation Assurance, bounded repair, advanced validator/policy packs, Db2 Test Intelligence, advanced reporting and model comparison in private packages       |
+| Enterprise   | The same public contracts, portability guarantees, and neutral registration path                                                           | Hardened VPC/Kubernetes operation, organization policy/audit/approval, offline entitlement administration, and owner-gated IBM i validation in private packages |
+
+The public core must not contain dormant paid implementations behind flags. It must not branch on
+a product ID, module ID, edition, or entitlement state. A commercial module owns its license
+storage, validation, and enforcement. Invalid or expired entitlement disables only that module's
+capabilities. There is no mandatory telemetry or remote kill switch.
+
+Future package names and repository locations are provisional until availability, trademark, and
+legal review. Community packages may be public. Professional and Enterprise implementations must
+be in explicitly authorized private packages or repositories; none are created by this decision.
+
+### Module descriptor contract v1
+
+The descriptor is immutable registration input. Its contract version is independent of the Zeus
+package version and of each contributed capability contract version. A normalized descriptor v1
+has this documented shape:
+
+```json
+{
+  "descriptorVersion": "zeus.module-descriptor/v1",
+  "id": "example.module",
+  "version": "1.0.0",
+  "edition": "community",
+  "compatibility": {
+    "moduleApi": ">=1.0.0 <2.0.0"
+  },
+  "capabilities": [{ "id": "example.inspect", "version": 1 }],
+  "safety": {
+    "level": "S1",
+    "sideEffects": ["local-read"]
+  },
+  "runtime": {
+    "requiredFeatures": ["local-filesystem"]
+  },
+  "entitlement": {
+    "mode": "none"
+  },
+  "docs": {
+    "title": "Example community module",
+    "reference": "docs/modules/example.md"
+  }
+}
+```
+
+The required fields and rules are:
+
+- `descriptorVersion`: exactly the supported descriptor contract major.
+- `id`: stable, namespaced, non-empty module ID; never inferred from a path.
+- `version`: module implementation semantic version.
+- `edition`: `community`, `professional`, or `enterprise`; classification only.
+- `compatibility.moduleApi`: supported range of the independently versioned public module API.
+- `capabilities`: non-empty deterministic list of `{id, version}` references registered through
+  the canonical Capability Registry. Each full capability descriptor still declares aliases,
+  input/output contracts, availability projections, execution handler, and documentation as
+  required by ADR-004.
+- `safety`: aggregate safety level and declared side effects. A capability may be stricter, never
+  weaker, than the module declaration.
+- `runtime.requiredFeatures`: names from a public allowlist, without values, paths, endpoints,
+  credentials, or customer identifiers.
+- `entitlement.mode`: `none` or `module-managed`. It carries no license material and gives the core
+  no enforcement responsibility.
+- `docs`: non-secret title and stable reference metadata.
+
+Missing or unknown required classification, compatibility, safety, side-effect, or runtime policy
+is rejection. Unknown additive fields are tolerated within v1 and retained only where a future
+normalizer explicitly permits them. Persisted descriptors have deterministic field order and
+values and contain no registration timestamps or raw runtime errors.
+
+Mutable health is not part of the immutable descriptor. A normalized runtime record may pair the
+descriptor with:
+
+```json
+{
+  "lifecycle": "registered",
+  "availability": "unavailable",
+  "reasonCode": "RUNTIME_FEATURE_MISSING"
+}
+```
+
+`availability` is `available`, `degraded`, or `unavailable`. Public status exposes only one fixed,
+redacted reason code:
+
+- `DESCRIPTOR_INVALID`
+- `MODULE_API_INCOMPATIBLE`
+- `DUPLICATE_MODULE_ID`
+- `CAPABILITY_CONFLICT`
+- `RUNTIME_FEATURE_MISSING`
+- `ENTITLEMENT_UNAVAILABLE`
+- `MODULE_POLICY_DENIED`
+- `MODULE_INITIALIZATION_FAILED`
+- `MODULE_DISABLED`
+- `MODULE_UNAVAILABLE` for any unclassified failure
+
+Raw exceptions, secrets, license material, customer or organization IDs, local paths, and private
+endpoints never enter descriptors or public module-status diagnostics. Secrets are never
+transmissible. Source, usage, and customer identifiers do not leave the trust zone or get sent for
+entitlement or availability validation.
+
+### Explicit registration and trust boundary
+
+The future host composition root explicitly imports an installed, operator-trusted package and
+passes its descriptor and registration callback to a narrow public registrar. The conceptual API
+is `registerModule({ descriptor, register })`; this is a specification name, not a current package
+export.
+
+The core never scans directories, package manifests, environment-provided paths, or marketplaces,
+and never dynamically `require`s, imports, or evaluates an untrusted name. Explicit import does not
+sandbox a package: the operator and package manager remain responsible for trusting its code.
+
+```mermaid
+flowchart LR
+    H[Trusted host composition root] -->|explicit import| P[Installed module package]
+    H -->|descriptor + callback| R[Future narrow module registrar]
+    R -->|validate and stage atomically| C[Core Capability Registry]
+    C --> A[Thin CLI / API / MCP projections]
+
+    subgraph Public Apache-2.0 boundary
+        R
+        C
+        A
+    end
+
+    subgraph Separate package ownership
+        P
+    end
+
+    U[User-owned artifacts] --> A
+    P -.->|unavailable: only its capabilities disabled| C
+```
+
+Before invoking contributed behavior, the registrar must validate descriptor completeness,
+descriptor major, module API compatibility, runtime feature names, module ID uniqueness,
+capability ID and alias ownership, and safety classification. All registrations from one module
+are staged and committed atomically. Any conflict or incompatibility rejects the entire module
+without partially mutating the Capability Registry.
+
+Module contributions use only the canonical Capability Registry. CLI and MCP remain projections
+of registered capability metadata and do not gain module-specific or product-specific branches.
+Registration happens during trusted startup before registries are sealed. Module descriptor v1
+has no hot reload, unload, replacement, or arbitrary discovery lifecycle.
+
+Lifecycle transitions are deterministic:
+
+```text
+declared -> validating -> registered -> available | degraded | unavailable
+                    \-> rejected
+```
+
+`rejected` means no contribution was committed. An initialization or later availability failure
+affects only that module's capabilities. The default core imports no external module, starts with
+zero modules, and retains all Community behavior.
+
+### Compatibility and deprecation
+
+Compatibility is negotiated against the public module API contract, not the current beta package
+version. A host accepts a module only when it supports the descriptor major and its module API
+version satisfies the module's declared range. Unsupported descriptor majors, malformed ranges,
+and incompatible ranges fail closed before the registration callback runs.
+
+Additive optional fields may remain in the same descriptor major. Removing or renaming a field,
+changing its type or meaning, or making an optional field mandatory requires a new descriptor
+major and module API major. Capability input/output contracts retain their own versions. Public
+deprecations follow ADR-003: document them, preserve an alias or compatible behavior for at least
+one minor release where practical, and provide migration notes before a breaking major change.
+
+### Artifact ownership and portability
+
+Source-derived and user-created artifacts remain owned and controlled by the user. They remain
+readable, copyable, exportable, and deletable through ordinary local means when a module is absent,
+incompatible, disabled, unentitled, or expired. Core startup and core run/artifact readers never
+require a commercial module. A module must never encrypt, lock, delete, or withhold an artifact on
+entitlement failure.
+
+Module-produced artifacts carry a public versioned contract plus producer module/capability
+provenance. If a specialized renderer is missing, its view may be unavailable, but the raw artifact
+and core metadata remain accessible. A module-specific format must either have a public reader
+contract or provide a non-entitled export or migration path before it can become a supported
+persisted format.
+
+## Consequences
+
+- Community remains a complete, useful baseline and the extension contract is Apache-2.0.
+- External packages can contribute capability metadata without changes to CLI or MCP adapters.
+- Paid behavior and entitlement enforcement remain separable from core orchestration.
+- Future registrar work must add executable validation, atomic staging, deterministic status, and
+  contract tests; the existing broad `registerPlugin` hook does not satisfy this specification.
+- Module failure is isolated, while malformed or incompatible registration fails closed.
+
+## Alternatives considered
+
+- **Ship paid code in core behind flags.** Rejected because public source would contain the paid
+  implementation and erode the open-core boundary.
+- **Create a parallel commercial registry.** Rejected because it would fork safety, adapter, and
+  compatibility behavior.
+- **Discover modules from directories or configuration strings.** Rejected because arbitrary code
+  loading expands the trust boundary and creates ambiguous startup behavior.
+- **Use `registerPlugin` as the commercial boundary.** Rejected because it receives the broad Zeus
+  object and provides neither compatibility validation nor atomic multi-capability registration.
+- **Add per-module CLI or MCP branches.** Rejected because adapters must remain neutral projections.
+- **Use package version alone for compatibility.** Rejected because descriptor, module API, and
+  capability contracts evolve independently.
+- **Expose raw availability errors.** Rejected because exceptions can disclose secrets and private
+  environment details.
+- **Put entitlement checks in core or lock user artifacts.** Rejected because a paid capability
+  failure must not disable core or deny users their data.
+
+## Follow-up boundary
+
+This iteration introduces documentation only. A later iteration may add the executable descriptor,
+registrar, and SDK after architecture and commercial re-review. That work must test descriptor
+completeness, atomic duplicate rejection, incompatibility before callback execution, deterministic
+listing, fixed redaction, and core startup with zero or unavailable modules.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Zeus RPG PromptKit Architecture Documentation
-Description: Accepted architecture decisions, kernel definition, dependency rules, contracts, capability model, and safety trust zones for the Zeus evidence-preparation toolkit.
-Last Updated: 2026-07-11
+Description: Accepted architecture decisions, kernel definition, dependency rules, contracts, capability model, safety trust zones, and open-core module boundaries for the Zeus evidence-preparation toolkit.
+Last Updated: 2026-07-16
 ---
 
 # Architecture Documentation
@@ -12,13 +12,14 @@ All subsequent implementation and agent guidance must be consistent with these d
 
 ## Accepted Architecture Decision Records (ADRs)
 
-| ADR                                    | Title                | Status   |
-| -------------------------------------- | -------------------- | -------- |
-| [001](adr-001-product-kernel.md)       | Product Kernel       | Accepted |
-| [002](adr-002-dependency-direction.md) | Dependency Direction | Accepted |
-| [003](adr-003-versioned-contracts.md)  | Versioned Contracts  | Accepted |
-| [004](adr-004-capability-registry.md)  | Capability Registry  | Accepted |
-| [005](adr-005-safety-trust-zones.md)   | Safety Trust Zones   | Accepted |
+| ADR                                                 | Title                             | Status                 |
+| --------------------------------------------------- | --------------------------------- | ---------------------- |
+| [001](adr-001-product-kernel.md)                    | Product Kernel                    | Accepted               |
+| [002](adr-002-dependency-direction.md)              | Dependency Direction              | Accepted               |
+| [003](adr-003-versioned-contracts.md)               | Versioned Contracts               | Accepted               |
+| [004](adr-004-capability-registry.md)               | Capability Registry               | Accepted               |
+| [005](adr-005-safety-trust-zones.md)                | Safety Trust Zones                | Accepted               |
+| [006](adr-006-commercial-extension-architecture.md) | Commercial Extension Architecture | Accepted specification |
 
 ## Related Reviews
 
@@ -31,6 +32,8 @@ All subsequent implementation and agent guidance must be consistent with these d
 - Data artifacts (manifests, knowledge projections, canonical model) follow versioning rules in ADR-003.
 - Code organization must respect the dependency direction (ADR-002).
 - The product kernel (ADR-001) defines the stable evidence and artifact production responsibilities.
+- External modules and capabilities must follow the open-core ownership, explicit registration,
+  compatibility, failure-isolation, and artifact-portability rules in ADR-006.
 
 ## Regenerating Supporting Artifacts
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Zeus RPG PromptKit Documentation Hub (v2.1)
-Description: Zentrale, KI-freundliche Navigation über alle Dokumentationsdomänen inklusive Safety-First-Einstieg und schnellen Referenzpfaden.
-Last Updated: 2026-06-19
+Description: Zentrale, KI-freundliche Navigation über alle Dokumentationsdomänen inklusive Safety-First-Einstieg, Open-Core-Grenzen und schnellen Referenzpfaden.
+Last Updated: 2026-07-16
 ---
 
 # Zeus RPG PromptKit Documentation Hub (v2.1)
@@ -44,17 +44,18 @@ See the lifecycle diagram and "What Zeus is / is not" there.
 
 ## Quick Links For AI Assistants
 
-| Need                              | Go To                                                                          | Why                                                                  |
-| --------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| Authoritative command behavior    | [`tool-catalog.md`](tool-catalog.md)                                           | Single source of truth für Commands, Safety und Beispiele            |
-| Session bootstrap                 | [`ai/session-prompt.md`](ai/session-prompt.md)                                 | Standardisierte Arbeitsweise mit Safety-Gates                        |
-| MCP operator setup                | [`mcp/operator-guide.md`](mcp/operator-guide.md)                               | Start-/Policy-/Audit-Referenz fuer lokalen MCP-Betrieb               |
-| Prompt schema and constraints     | [`ai/prompt-contracts.md`](ai/prompt-contracts.md)                             | Verhindert inkonsistente Prompt-Ausgaben                             |
-| Workflow options                  | [`workflows/investigation-workflows.md`](workflows/investigation-workflows.md) | Zeigt Opt-in Vertiefungsfeatures                                     |
-| Architecture decisions & baseline | [`architecture/index.md`](architecture/index.md)                               | ADRs for kernel, dependencies, contracts, registry, and safety zones |
-| Safe sharing guidance             | [`safety/safe-sharing.md`](safety/safe-sharing.md)                             | Reduktions-/Sanitization-Regeln für externe Nutzung                  |
-| CLI examples                      | [`cli/examples.md`](cli/examples.md)                                           | Schnell nutzbare, reproduzierbare Befehlsmuster                      |
-| DB2 discovery SQL                 | [`sql/system-environment-discovery.sql`](sql/system-environment-discovery.sql) | Standardisierte Discovery-Queries fuer System- und Ticketkontext     |
+| Need                              | Go To                                                                                                                    | Why                                                                                      |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Authoritative command behavior    | [`tool-catalog.md`](tool-catalog.md)                                                                                     | Single source of truth für Commands, Safety und Beispiele                                |
+| Session bootstrap                 | [`ai/session-prompt.md`](ai/session-prompt.md)                                                                           | Standardisierte Arbeitsweise mit Safety-Gates                                            |
+| MCP operator setup                | [`mcp/operator-guide.md`](mcp/operator-guide.md)                                                                         | Start-/Policy-/Audit-Referenz fuer lokalen MCP-Betrieb                                   |
+| Prompt schema and constraints     | [`ai/prompt-contracts.md`](ai/prompt-contracts.md)                                                                       | Verhindert inkonsistente Prompt-Ausgaben                                                 |
+| Workflow options                  | [`workflows/investigation-workflows.md`](workflows/investigation-workflows.md)                                           | Zeigt Opt-in Vertiefungsfeatures                                                         |
+| Architecture decisions & baseline | [`architecture/index.md`](architecture/index.md)                                                                         | ADRs for kernel, dependencies, contracts, registry, and safety zones                     |
+| Open-core module boundary         | [`architecture/adr-006-commercial-extension-architecture.md`](architecture/adr-006-commercial-extension-architecture.md) | Public/private ownership, explicit registration, compatibility, and artifact portability |
+| Safe sharing guidance             | [`safety/safe-sharing.md`](safety/safe-sharing.md)                                                                       | Reduktions-/Sanitization-Regeln für externe Nutzung                                      |
+| CLI examples                      | [`cli/examples.md`](cli/examples.md)                                                                                     | Schnell nutzbare, reproduzierbare Befehlsmuster                                          |
+| DB2 discovery SQL                 | [`sql/system-environment-discovery.sql`](sql/system-environment-discovery.sql)                                           | Standardisierte Discovery-Queries fuer System- und Ticketkontext                         |
 
 ## Visual Map
 
@@ -84,7 +85,7 @@ flowchart TD
 ## Governance Notes
 
 - `docs/tool-catalog.md` bleibt die verbindliche Referenz für KI-Assistenten.
-- `docs/architecture/index.md` (und die ADRs darin) sind die autoritative Quelle für Produkt-Kernel, Abhängigkeitsrichtung, versionierte Verträge, Capability-Registry und Safety-Trust-Zones.
+- `docs/architecture/index.md` (und die ADRs darin) sind die autoritative Quelle für Produkt-Kernel, Abhängigkeitsrichtung, versionierte Verträge, Capability-Registry, Safety-Trust-Zones und Open-Core-Modulgrenzen.
 - CLI und MCP bleiben der unterstützte Produktpfad; der lokale Viewer ist optional und experimentell.
 - Dokumentänderungen sollen Safety-Level und Scope-Terminologie konsistent halten (`S0` bis `S4`).
 - Regenerierung funktioniert direkt ueber `zeus docs:generate-catalog` oder `zeus docs generate-catalog` und haelt den Tool-Katalog aktuell.


### PR DESCRIPTION
## Summary

Defines the documentation-only commercial extension architecture and module boundaries in ADR-006, clarifies the existing trusted in-process plugin hook, and links the accepted specification from the architecture and documentation indexes.

## Scope

The iteration changes exactly four documentation files. It does not ship a module registrar, loader, entitlement implementation, marketplace, SDK, or commercial capability. The Apache-2.0 core and Open-Core/Commercial boundary remain unchanged.

## Validation

Architecture: GO. Business acceptance: GO. Independent QA: PASS WITH NON-BLOCKING NOTES. All mandatory repository gates passed on bf2e7ddb7ab72df025a58b919beebf08548843c9, including 126/126 discovery, 712 tests, package smoke, docs/public-claims/portability guards, audit with zero vulnerabilities, and npm pack dry-run.

## Integration

The original iteration commit 54f1d15d4aa422dbd5f563efb2cc8f9560e6e51e is preserved as the first parent of the final merge commit. The green Phase A baseline fix from main is included without changing the four-file iteration patch.