### PR TITLE
fix(docs): make tool catalog generation deterministic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/tool-catalog.md text eol=lf
+docs/tool-catalog.json text eol=lf

--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ Der automatisch erzeugte [`docs/tool-catalog.md`](docs/tool-catalog.md) ist die 
 
 | Aufgabe              | Befehle                                                              |                Safety |
 | -------------------- | -------------------------------------------------------------------- | --------------------: |
-| Setup & Profile      | `doctor`, `profiles`, `resources`, `secret`                          |                  `S0` |
+| Setup & Profile      | `doctor`, `profiles`, `resources`, `secret`                          |               `S0/S1` |
 | Discovery            | `discover-environment`, `resolve-object`, `inspect-object`, `joblog` |               `S0/S2` |
 | Quellen              | `fetch`, `fetch-member`, `copy-to-workspace`, `diff`                 |               `S1/S2` |
 | Analyse              | `analyze`, `investigate`, `workflow`, `workflow run`                 |               `S0/S1` |
@@ -962,7 +962,7 @@ The generated [`docs/tool-catalog.md`](docs/tool-catalog.md) is the **authoritat
 
 | Task                     | Commands                                                             |           Safety |
 | ------------------------ | -------------------------------------------------------------------- | ---------------: |
-| Setup and profiles       | `doctor`, `profiles`, `resources`, `secret`                          |             `S0` |
+| Setup and profiles       | `doctor`, `profiles`, `resources`, `secret`                          |          `S0/S1` |
 | Discovery                | `discover-environment`, `resolve-object`, `inspect-object`, `joblog` |          `S0/S2` |
 | Sources                  | `fetch`, `fetch-member`, `copy-to-workspace`, `diff`                 |          `S1/S2` |
 | Analysis                 | `analyze`, `investigate`, `workflow`, `workflow run`                 |          `S0/S1` |

--- a/cli/commands/generate-tool-catalog.js
+++ b/cli/commands/generate-tool-catalog.js
@@ -10,7 +10,11 @@ http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
+
+'use strict';
 
 const fs = require('fs');
 const path = require('path');
@@ -20,6 +24,7 @@ const {
 } = require('../../src/workflow/workflowPresetRegistry');
 const {
   COMMAND_METADATA,
+  COMMAND_CATALOG_CONTRACTS,
   COMMAND_ORDER,
   SAFETY_LEVELS,
   MANDATORY_AI_RULES,
@@ -28,368 +33,398 @@ const {
 
 const DEFAULT_MARKDOWN_OUTPUT = 'docs/tool-catalog.md';
 const DEFAULT_JSON_OUTPUT = 'docs/tool-catalog.json';
+const CATALOG_SCHEMA_VERSION = 1;
+const STATUS_VALUES = new Set(['stable', 'experimental', 'deprecated']);
+const NON_PUBLIC_CONTROL_ROUTES = new Set(['-h']);
 
-function pad2(value) {
-  return String(value).padStart(2, '0');
-}
-
-function formatTimestamp(date = new Date()) {
-  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`;
-}
-
-function formatDateOnly(date = new Date()) {
-  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
-}
-
-function readFileIfExists(filePath) {
-  if (!fs.existsSync(filePath)) {
-    return null;
+function readRequiredText(filePath, label) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    throw new Error(
+      `${label} is required: ${path.basename(filePath)} (${error.code || 'read error'})`
+    );
   }
-  return fs.readFileSync(filePath, 'utf8');
 }
 
-function listCommandSourceFiles(repoRoot) {
-  const files = [];
-  const cliEntry = path.resolve(repoRoot, 'cli', 'zeus.js');
-  files.push(cliEntry);
+function readPackageIdentity(repoRoot) {
+  const packagePath = path.join(repoRoot, 'package.json');
+  let packageJson;
+  try {
+    packageJson = JSON.parse(readRequiredText(packagePath, 'Package identity'));
+  } catch (error) {
+    throw new Error(`Invalid package identity: ${error.message}`);
+  }
+  if (!packageJson || typeof packageJson.name !== 'string' || !packageJson.name.trim()) {
+    throw new Error('Package identity requires a non-empty name.');
+  }
+  if (typeof packageJson.version !== 'string' || !packageJson.version.trim()) {
+    throw new Error('Package identity requires a non-empty version.');
+  }
+  return Object.freeze({ name: packageJson.name.trim(), version: packageJson.version.trim() });
+}
 
-  const commandsDir = path.resolve(repoRoot, 'cli', 'commands');
-  if (!fs.existsSync(commandsDir)) {
-    return files;
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function resolveGeneratedAt(repoRoot, env = process.env) {
+  if (Object.prototype.hasOwnProperty.call(env, 'SOURCE_DATE_EPOCH')) {
+    const raw = env.SOURCE_DATE_EPOCH;
+    if (typeof raw !== 'string' || !/^(0|[1-9]\d*)$/.test(raw)) {
+      throw new Error('SOURCE_DATE_EPOCH must be an unsigned integer number of UTC seconds.');
+    }
+    const milliseconds = Number(raw) * 1000;
+    if (!Number.isSafeInteger(milliseconds)) {
+      throw new Error('SOURCE_DATE_EPOCH is outside the supported date range.');
+    }
+    const date = new Date(milliseconds);
+    if (Number.isNaN(date.getTime())) {
+      throw new Error('SOURCE_DATE_EPOCH is outside the supported date range.');
+    }
+    return date.toISOString();
   }
 
-  const queue = [commandsDir];
-  while (queue.length > 0) {
-    const currentDir = queue.shift();
-    const entries = fs
-      .readdirSync(currentDir, { withFileTypes: true })
-      .sort((a, b) => a.name.localeCompare(b.name));
+  const packageIdentity = readPackageIdentity(repoRoot);
+  const changelog = readRequiredText(path.join(repoRoot, 'CHANGELOG.md'), 'Release changelog');
+  const releasePattern = new RegExp(
+    `^## \\[${escapeRegExp(packageIdentity.version)}\\] - (\\d{4}-\\d{2}-\\d{2})$`,
+    'gm'
+  );
+  const matches = [...changelog.matchAll(releasePattern)];
+  if (matches.length !== 1) {
+    throw new Error(
+      `CHANGELOG.md must contain exactly one release date for package version ${packageIdentity.version}.`
+    );
+  }
+  const generatedAt = `${matches[0][1]}T00:00:00.000Z`;
+  const parsedDate = new Date(generatedAt);
+  if (
+    Number.isNaN(parsedDate.getTime()) ||
+    parsedDate.toISOString().slice(0, 10) !== matches[0][1]
+  ) {
+    throw new Error(
+      `CHANGELOG.md contains an invalid release date for ${packageIdentity.version}.`
+    );
+  }
+  return generatedAt;
+}
 
-    for (const entry of entries) {
-      const fullPath = path.join(currentDir, entry.name);
-      if (entry.isDirectory()) {
-        queue.push(fullPath);
-        continue;
+function formatOutputLabel(repoRoot, targetPath) {
+  const relativePath = path.relative(repoRoot, targetPath);
+  if (
+    relativePath &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relativePath)
+  ) {
+    return relativePath.split(path.sep).join('/');
+  }
+  return '<external-output>';
+}
+
+function extractCliRoutes(cliSource) {
+  const routes = new Set();
+  for (const match of cliSource.matchAll(/\bcommand\s*===\s*'([^']+)'/g)) {
+    routes.add(match[1]);
+  }
+
+  const arrayDeclarations = new Map();
+  for (const match of cliSource.matchAll(/const\s+([A-Za-z_$][\w$]*)\s*=\s*\[([\s\S]*?)\];/g)) {
+    arrayDeclarations.set(match[1], match[2]);
+  }
+  for (const [identifier, contents] of arrayDeclarations) {
+    const includePattern = new RegExp(`\\b${escapeRegExp(identifier)}\\.includes\\(command\\)`);
+    if (!includePattern.test(cliSource)) continue;
+    for (const literal of contents.matchAll(/'([^']+)'/g)) routes.add(literal[1]);
+  }
+  return routes;
+}
+
+function routeName(value) {
+  return String(value).trim().split(/\s+/)[0];
+}
+
+function validateCatalogMetadata({
+  metadata = COMMAND_METADATA,
+  contracts = COMMAND_CATALOG_CONTRACTS,
+  order = COMMAND_ORDER,
+  cliSource,
+} = {}) {
+  const errors = [];
+  const metadataIds = Object.keys(metadata);
+  const contractIds = Object.keys(contracts);
+  const orderedIds = [...order];
+  const knownSafety = new Set(SAFETY_LEVELS.map(entry => entry.level));
+  const seenIds = new Set();
+  const publicNames = new Map();
+
+  for (const id of orderedIds) {
+    if (seenIds.has(id)) errors.push(`duplicate command order entry: ${id}`);
+    seenIds.add(id);
+    const commandMetadata = metadata[id];
+    const contract = contracts[id];
+    if (!commandMetadata) errors.push(`missing command metadata: ${id}`);
+    if (!contract) errors.push(`missing command catalog contract: ${id}`);
+    if (!commandMetadata || !contract) continue;
+
+    for (const field of ['safety', 'scope', 'purpose', 'example']) {
+      if (typeof commandMetadata[field] !== 'string' || !commandMetadata[field].trim()) {
+        errors.push(`${id}.${field} must be a non-empty string`);
       }
-      if (entry.isFile() && entry.name.endsWith('.js')) {
-        files.push(fullPath);
-      }
     }
-  }
-
-  return [...new Set(files)];
-}
-
-function extractCliCommands(cliSource) {
-  const commands = new Set();
-  const re = /if \(command === '([^']+)'\)/g;
-  for (const match of cliSource.matchAll(re)) {
-    commands.add(String(match[1]).trim());
-  }
-  return commands;
-}
-
-function extractUsageLines(cliSource) {
-  const usageLines = [];
-  const re = /console\.log\((['"`]) {2}zeus ([\s\S]*?)\1\);/g;
-  for (const match of cliSource.matchAll(re)) {
-    usageLines.push(String(match[2]).trim());
-  }
-  return usageLines;
-}
-
-function normalizeCommandFromUsage(usageLine) {
-  const cleaned = String(usageLine || '')
-    .replace(/\[[^\]]+\]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (!cleaned) {
-    return null;
-  }
-
-  const tokens = cleaned.split(' ');
-  const command = tokens[0] || '';
-  const subcommand = tokens[1] || '';
-
-  if (command === 'workflow' && subcommand === 'run') {
-    return 'workflow run';
-  }
-
-  if (command === 'docs' && subcommand === 'generate-catalog') {
-    return 'docs:generate-catalog';
-  }
-
-  return command;
-}
-
-function extractOptionsFromUsage(usageLine) {
-  return [...new Set(String(usageLine).match(/--[a-z0-9-]+/g) || [])];
-}
-
-function escapePipe(value) {
-  return String(value).replace(/\|/g, '\\|');
-}
-
-function collectCommandSurface(repoRoot) {
-  const sources = [];
-  for (const filePath of listCommandSourceFiles(repoRoot)) {
-    const source = readFileIfExists(filePath);
-    if (typeof source !== 'string') {
-      continue;
+    if (!knownSafety.has(commandMetadata.safety)) {
+      errors.push(`${id}.safety is not a declared safety level: ${commandMetadata.safety}`);
     }
-    sources.push({
-      filePath,
-      relativePath: path.relative(repoRoot, filePath),
-      source,
-    });
-  }
-  return sources;
-}
-
-function buildCatalogModel({ repoRoot }) {
-  const commandSources = collectCommandSurface(repoRoot);
-  const routedCommands = new Set();
-  const usageLines = [];
-
-  for (const sourceFile of commandSources) {
-    const relativePath = sourceFile.relativePath.split(path.sep).join('/');
-    if (relativePath === 'cli/zeus.js') {
-      for (const command of extractCliCommands(sourceFile.source)) {
-        routedCommands.add(command);
-      }
-    }
-    usageLines.push(...extractUsageLines(sourceFile.source));
-  }
-
-  const usageByCommand = new Map();
-  for (const usageLine of usageLines) {
-    const command = normalizeCommandFromUsage(usageLine);
-    if (!command) {
-      continue;
-    }
-    if (!usageByCommand.has(command)) {
-      usageByCommand.set(command, []);
-    }
-    usageByCommand.get(command).push(usageLine);
-  }
-
-  const commandsInCode = new Set();
-  for (const command of routedCommands) {
-    if (command === 'docs') {
-      commandsInCode.add('docs:generate-catalog');
-      continue;
-    }
-    commandsInCode.add(command);
-  }
-
-  const ordered = [];
-  for (const command of COMMAND_ORDER) {
-    if (command === 'workflow run') {
-      if (commandsInCode.has('workflow') || usageByCommand.has('workflow run')) {
-        ordered.push(command);
-      }
-      continue;
-    }
-
-    if (commandsInCode.has(command) || usageByCommand.has(command)) {
-      ordered.push(command);
-    }
-  }
-
-  const extras = [...commandsInCode]
-    .filter(command => !ordered.includes(command))
-    .sort((a, b) => a.localeCompare(b));
-  ordered.push(...extras);
-
-  const commandRows = ordered.map(command => {
-    let metadata = COMMAND_METADATA[command] || {
-      safety: 'S0',
-      scope: 'Local',
-      purpose: 'Command metadata missing; update src/docs/toolCatalogMetadata.js.',
-      example: `node cli/zeus.js ${command}`,
-    };
-
-    // Package 06: prefer capability registry as source of truth for foundation commands
-    try {
-      const { capabilities } = require('../src/api/zeusApi');
-      const capIdMap = {
-        doctor: 'configure.doctor',
-        profiles: 'configure.profiles',
-        resources: 'configure.resources',
-        'discover-environment': 'configure.discover-environment',
-        analyze: 'analysis.analyze',
-        workflow: 'analysis.workflow',
-        bundle: 'bundle.create',
-      };
-      const capId = capIdMap[command];
-      if (capId) {
-        const cap = capabilities && capabilities.resolve ? capabilities.resolve(capId) : null;
-        console.error('DEBUG cap for', command, 'capId', capId, 'found?', !!cap);
-        if (cap) {
-          metadata = {
-            safety: cap.safety && cap.safety.level ? cap.safety.level : metadata.safety,
-            scope: 'Local',
-            purpose: cap.description || cap.title || metadata.purpose,
-            example: (cap.docs && cap.docs.examples && cap.docs.examples[0]) || metadata.example,
-          };
+    if (!Array.isArray(contract.aliases)) errors.push(`${id}.aliases must be an array`);
+    if (!STATUS_VALUES.has(contract.status))
+      errors.push(`${id}.status is invalid: ${contract.status}`);
+    if (!contract.availability || typeof contract.availability !== 'object') {
+      errors.push(`${id}.availability must be an object`);
+    } else {
+      for (const surface of ['cli', 'api', 'mcp']) {
+        if (typeof contract.availability[surface] !== 'boolean') {
+          errors.push(`${id}.availability.${surface} must be boolean`);
         }
       }
-    } catch (e) {
-      // fall back to static metadata
+      if (contract.availability.cli !== true) {
+        errors.push(`${id} is not an implemented public CLI command`);
+      }
+    }
+    if (!Array.isArray(contract.sideEffects)) errors.push(`${id}.sideEffects must be an array`);
+    if (
+      contract.capabilityId !== null &&
+      (typeof contract.capabilityId !== 'string' || !contract.capabilityId.trim())
+    ) {
+      errors.push(`${id}.capabilityId must be null or a non-empty string`);
     }
 
-    const usage = usageByCommand.get(command) || [];
-    const options = [...new Set(usage.flatMap(extractOptionsFromUsage))];
+    for (const publicName of [id, ...(Array.isArray(contract.aliases) ? contract.aliases : [])]) {
+      if (typeof publicName !== 'string' || !publicName.trim()) {
+        errors.push(`${id} contains an empty public command name`);
+        continue;
+      }
+      const owner = publicNames.get(publicName);
+      if (owner) errors.push(`duplicate public command name: ${publicName} (${owner}, ${id})`);
+      else publicNames.set(publicName, id);
+    }
+  }
 
+  for (const id of metadataIds)
+    if (!seenIds.has(id)) errors.push(`unordered command metadata: ${id}`);
+  for (const id of contractIds)
+    if (!seenIds.has(id)) errors.push(`unordered command contract: ${id}`);
+
+  if (typeof cliSource === 'string') {
+    const detectedRoutes = extractCliRoutes(cliSource);
+    const declaredRoutes = new Set();
+    for (const id of orderedIds) {
+      const contract = contracts[id];
+      if (!contract || !contract.availability || !contract.availability.cli) continue;
+      declaredRoutes.add(routeName(id));
+      for (const alias of contract.aliases || []) declaredRoutes.add(routeName(alias));
+    }
+    for (const route of declaredRoutes) {
+      if (!detectedRoutes.has(route))
+        errors.push(`declared public CLI route is not implemented: ${route}`);
+    }
+    for (const route of detectedRoutes) {
+      if (!declaredRoutes.has(route) && !NON_PUBLIC_CONTROL_ROUTES.has(route)) {
+        errors.push(`implemented CLI route has no public catalog contract: ${route}`);
+      }
+    }
+  }
+
+  if (errors.length)
+    throw new Error(`Tool catalog metadata validation failed:\n- ${errors.join('\n- ')}`);
+  return true;
+}
+
+function buildCatalogModel({ repoRoot, env = process.env } = {}) {
+  if (typeof repoRoot !== 'string' || !repoRoot.trim()) {
+    throw new Error('repoRoot is required to build the tool catalog.');
+  }
+  const cliSource = readRequiredText(path.join(repoRoot, 'cli', 'zeus.js'), 'CLI route source');
+  validateCatalogMetadata({ cliSource });
+  const packageIdentity = readPackageIdentity(repoRoot);
+
+  const commandRows = COMMAND_ORDER.map(command => {
+    const metadata = COMMAND_METADATA[command];
+    const contract = COMMAND_CATALOG_CONTRACTS[command];
     return {
       command,
+      aliases: [...contract.aliases],
+      status: contract.status,
       safety: metadata.safety,
       scope: metadata.scope,
+      sideEffects: [...contract.sideEffects],
+      availability: { ...contract.availability },
+      capabilityId: contract.capabilityId,
       purpose: metadata.purpose,
       example: metadata.example,
-      usage,
-      options,
-      source: {
-        routeDetected: commandsInCode.has(command),
-        usageDetected: usage.length > 0,
-      },
     };
   });
 
   const workflowPresets = listWorkflowPresets()
     .map(preset => {
       const settings = resolveWorkflowPresetSettings(preset.name);
-      return {
-        name: preset.name,
-        analyzeMode: settings.analyzeMode,
-        goal: preset.description,
-      };
+      return { name: preset.name, analyzeMode: settings.analyzeMode, goal: preset.description };
     })
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
 
   return {
-    generatedAt: new Date().toISOString(),
+    schemaVersion: CATALOG_SCHEMA_VERSION,
+    package: packageIdentity,
+    generatedAt: resolveGeneratedAt(repoRoot, env),
+    cliFile: 'cli/zeus.js',
     commandRows,
     workflowPresets,
-    safetyLevels: SAFETY_LEVELS,
-    rules: MANDATORY_AI_RULES,
-    sequence: RECOMMENDED_AI_SEQUENCE,
-    repoRoot,
-    cliFile: 'cli/zeus.js',
+    safetyLevels: SAFETY_LEVELS.map(entry => ({ ...entry })),
+    rules: [...MANDATORY_AI_RULES],
+    sequence: [...RECOMMENDED_AI_SEQUENCE],
   };
 }
 
-function renderMarkdown(model, now = new Date()) {
-  const generatedTs = formatTimestamp(now);
-  const generatedDate = formatDateOnly(now);
+function escapePipe(value) {
+  return String(value).replace(/\|/g, '\\|');
+}
 
-  const lines = [];
-  lines.push('<!-- ');
-  lines.push('AUTO-GENERATED FILE – do not edit manually!');
-  lines.push('Regenerate with: zeus docs:generate-catalog');
-  lines.push(`Last generated: ${generatedTs}`);
-  lines.push('-->');
-  lines.push('');
-  lines.push('---');
-  lines.push('Title: Zeus RPG PromptKit Tool Catalog');
-  lines.push(
-    'Description: Verbindlicher, sicherheitsklassifizierter Katalog aller CLI-Befehle und Workflow-Presets fuer Menschen und KI-Assistenten.'
-  );
-  lines.push(`Last Updated: ${generatedDate}`);
-  lines.push('---');
-  lines.push('');
-  lines.push('# Zeus RPG PromptKit Tool Catalog');
-  lines.push('');
-  lines.push('This document is the authoritative tool reference for Zeus RPG PromptKit.');
-  lines.push(
-    'All AI assistants (GPT, Claude, Grok, Copilot, local agents) should treat this file as the single source of truth for command purpose, risk level, and usage.'
-  );
-  lines.push('');
-  lines.push('Related:');
-  lines.push('- [`index.md`](index.md)');
-  lines.push('- [`ai/session-prompt.md`](ai/session-prompt.md)');
-  lines.push('- [`cli/reference.md`](cli/reference.md)');
-  lines.push('');
-  lines.push('## Safety Levels');
-  lines.push('');
-  lines.push('| Level | Meaning | Typical Action |');
-  lines.push('|---|---|---|');
+function renderMarkdown(model) {
+  const generatedDate = model.generatedAt.slice(0, 10);
+  const lines = [
+    '<!-- ',
+    'AUTO-GENERATED FILE – do not edit manually!',
+    'Regenerate with: zeus docs:generate-catalog',
+    `Last generated: ${model.generatedAt}`,
+    '-->',
+    '',
+    '---',
+    'Title: Zeus RPG PromptKit Tool Catalog',
+    'Description: Verbindlicher, sicherheitsklassifizierter Katalog aller CLI-Befehle und Workflow-Presets fuer Menschen und KI-Assistenten.',
+    `Last Updated: ${generatedDate}`,
+    '---',
+    '',
+    '# Zeus RPG PromptKit Tool Catalog',
+    '',
+    `Package: \`${model.package.name}@${model.package.version}\``,
+    '',
+    'This document is the authoritative tool reference for Zeus RPG PromptKit.',
+    'All AI assistants (GPT, Claude, Grok, Copilot, local agents) should treat this file as the single source of truth for command purpose, risk level, and usage.',
+    '',
+    'Related:',
+    '- [`index.md`](index.md)',
+    '- [`ai/session-prompt.md`](ai/session-prompt.md)',
+    '- [`cli/reference.md`](cli/reference.md)',
+    '',
+    '## Safety Levels',
+    '',
+    '| Level | Meaning | Typical Action |',
+    '|---|---|---|',
+  ];
   for (const level of model.safetyLevels) {
     lines.push(
       `| \`${level.level}\` | ${escapePipe(level.meaning)} | ${escapePipe(level.typicalAction)} |`
     );
   }
-  lines.push('');
-  lines.push('## AI Execution Rules (Mandatory)');
-  lines.push('');
-  model.rules.forEach((rule, index) => {
-    lines.push(`${index + 1}. ${rule}`);
-  });
-  lines.push('');
-  lines.push('## CLI Command Catalog');
-  lines.push('');
-  lines.push('| Command | Safety | Scope | Purpose | Example |');
-  lines.push('|---|---|---|---|---|');
-  for (const row of model.commandRows) {
-    lines.push(
-      `| \`${escapePipe(row.command)}\` | \`${escapePipe(row.safety)}\` | ${escapePipe(row.scope)} | ${escapePipe(row.purpose)} | \`${escapePipe(row.example)}\` |`
-    );
-  }
-  lines.push('');
-  lines.push('## Workflow Presets');
-  lines.push('');
-  lines.push('| Preset | Analyze Mode | Goal |');
-  lines.push('|---|---|---|');
-  for (const preset of model.workflowPresets) {
-    lines.push(
-      `| \`${escapePipe(preset.name)}\` | \`${escapePipe(preset.analyzeMode)}\` | ${escapePipe(preset.goal)} |`
-    );
-  }
-  lines.push('');
-  lines.push('## Recommended AI Operating Sequence');
-  lines.push('');
-  model.sequence.forEach((step, index) => {
-    lines.push(`${index + 1}. ${step}`);
-  });
-  lines.push('');
-  lines.push('## How To Keep This File Up To Date');
-  lines.push('');
-  lines.push('- Regenerate with `zeus docs:generate-catalog` after CLI command-surface changes.');
-  lines.push('- Command metadata lives in `src/docs/toolCatalogMetadata.js`.');
+  lines.push('', '## AI Execution Rules (Mandatory)', '');
+  model.rules.forEach((rule, index) => lines.push(`${index + 1}. ${rule}`));
   lines.push(
-    '- Historical proposal is no longer needed; generation logic lives in `cli/commands/generate-tool-catalog.js`.'
+    '',
+    '## CLI Command Catalog',
+    '',
+    '| Command | Aliases | Status | Safety | Scope | Side Effects | Availability | Capability | Purpose | Example |',
+    '|---|---|---|---|---|---|---|---|---|---|'
   );
-  lines.push('');
-
-  return `${lines.join('\n')}`;
+  for (const row of model.commandRows) {
+    const aliases = row.aliases.length ? row.aliases.map(alias => `\`${alias}\``).join(', ') : '—';
+    const sideEffects = row.sideEffects.length ? row.sideEffects.join(', ') : 'none';
+    const availability = Object.entries(row.availability)
+      .filter(([, available]) => available)
+      .map(([surface]) => surface)
+      .join(', ');
+    lines.push(
+      `| \`${escapePipe(row.command)}\` | ${escapePipe(aliases)} | \`${row.status}\` | \`${row.safety}\` | ${escapePipe(row.scope)} | ${escapePipe(sideEffects)} | ${escapePipe(availability)} | ${row.capabilityId ? `\`${row.capabilityId}\`` : '—'} | ${escapePipe(row.purpose)} | \`${escapePipe(row.example)}\` |`
+    );
+  }
+  lines.push('', '## Workflow Presets', '', '| Preset | Analyze Mode | Goal |', '|---|---|---|');
+  for (const preset of model.workflowPresets) {
+    lines.push(`| \`${preset.name}\` | \`${preset.analyzeMode}\` | ${escapePipe(preset.goal)} |`);
+  }
+  lines.push('', '## Recommended AI Operating Sequence', '');
+  model.sequence.forEach((step, index) => lines.push(`${index + 1}. ${step}`));
+  lines.push(
+    '',
+    '## How To Keep This File Up To Date',
+    '',
+    '- Regenerate with `zeus docs:generate-catalog` after CLI command-surface changes.',
+    '- Public command contracts live in `src/docs/toolCatalogMetadata.js`.',
+    '- The generator validates public CLI routes against those declarative contracts and fails closed on drift.',
+    ''
+  );
+  return lines.join('\n');
 }
 
-function writeFileEnsuringDir(targetPath, content) {
+function renderJson(model) {
+  return `${JSON.stringify(model, null, 2)}\n`;
+}
+
+function validateRenderedCatalog(model, markdown, json) {
+  const parsed = JSON.parse(json);
+  if (JSON.stringify(parsed) !== JSON.stringify(model)) {
+    throw new Error('Rendered JSON does not preserve the in-memory catalog model.');
+  }
+  for (const row of model.commandRows) {
+    if (!markdown.includes(`| \`${row.command}\` |`)) {
+      throw new Error(`Rendered Markdown is missing command: ${row.command}`);
+    }
+  }
+  const forbiddenPatterns = [
+    /(?:^|[\s"'=(])\/(?!\/)[^\s"'`<>()]+/m,
+    /[A-Za-z]:\\[^\s"'`<>()]+/,
+    /"repoRoot"\s*:/,
+  ];
+  for (const content of [markdown, json]) {
+    for (const pattern of forbiddenPatterns) {
+      if (pattern.test(content))
+        throw new Error(`Catalog output contains forbidden local metadata: ${pattern}`);
+    }
+  }
+  return true;
+}
+
+function stageFile(targetPath, content) {
   fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-  fs.writeFileSync(targetPath, content, 'utf8');
+  const temporaryPath = `${targetPath}.tmp-${process.pid}`;
+  fs.writeFileSync(temporaryPath, content, { encoding: 'utf8', flag: 'wx' });
+  return temporaryPath;
 }
 
 function generateToolCatalog({
   repoRoot = process.cwd(),
   markdownOutputPath = DEFAULT_MARKDOWN_OUTPUT,
   jsonOutputPath = DEFAULT_JSON_OUTPUT,
+  env = process.env,
 } = {}) {
-  const model = buildCatalogModel({ repoRoot });
+  const model = buildCatalogModel({ repoRoot, env });
   const markdown = renderMarkdown(model);
+  const json = renderJson(model);
+  validateRenderedCatalog(model, markdown, json);
 
-  const markdownTarget = path.isAbsolute(markdownOutputPath)
-    ? markdownOutputPath
-    : path.resolve(repoRoot, markdownOutputPath);
-  writeFileEnsuringDir(markdownTarget, markdown);
+  const markdownTarget = path.resolve(repoRoot, markdownOutputPath);
+  const jsonTarget = jsonOutputPath ? path.resolve(repoRoot, jsonOutputPath) : null;
+  if (jsonTarget && markdownTarget === jsonTarget) {
+    throw new Error('Markdown and JSON output paths must be different.');
+  }
 
-  let jsonTarget = null;
-  if (jsonOutputPath) {
-    jsonTarget = path.isAbsolute(jsonOutputPath)
-      ? jsonOutputPath
-      : path.resolve(repoRoot, jsonOutputPath);
-    // Sanitize absolute repoRoot for committed/public catalog output
-    const jsonModel = { ...model, repoRoot: model.repoRoot ? path.basename(model.repoRoot) : null };
-    writeFileEnsuringDir(jsonTarget, `${JSON.stringify(jsonModel, null, 2)}\n`);
+  const staged = [];
+  try {
+    staged.push({ temporaryPath: stageFile(markdownTarget, markdown), targetPath: markdownTarget });
+    if (jsonTarget)
+      staged.push({ temporaryPath: stageFile(jsonTarget, json), targetPath: jsonTarget });
+    for (const entry of staged) fs.renameSync(entry.temporaryPath, entry.targetPath);
+  } catch (error) {
+    for (const entry of staged) fs.rmSync(entry.temporaryPath, { force: true });
+    throw error;
   }
 
   return {
@@ -406,27 +441,25 @@ async function runDocsGenerateCatalog(args) {
     if (!['markdown', 'json'].includes(format)) {
       throw new Error('Invalid --format value. Use markdown or json.');
     }
-
     const outputArg = args.output ? String(args.output).trim() : null;
     const jsonOutputArg = args['json-output'] ? String(args['json-output']).trim() : null;
-
     const markdownOutputPath =
       format === 'markdown' ? outputArg || DEFAULT_MARKDOWN_OUTPUT : DEFAULT_MARKDOWN_OUTPUT;
-
     const jsonOutputPath =
       format === 'json'
         ? outputArg || jsonOutputArg || DEFAULT_JSON_OUTPUT
         : jsonOutputArg || DEFAULT_JSON_OUTPUT;
-
     const result = generateToolCatalog({
       repoRoot: process.cwd(),
       markdownOutputPath,
       jsonOutputPath,
     });
-
-    console.log(`Tool catalog markdown written to: ${result.markdownPath}`);
+    const repoRoot = process.cwd();
+    console.log(
+      `Tool catalog markdown written to: ${formatOutputLabel(repoRoot, result.markdownPath)}`
+    );
     if (result.jsonPath) {
-      console.log(`Tool catalog json written to: ${result.jsonPath}`);
+      console.log(`Tool catalog json written to: ${formatOutputLabel(repoRoot, result.jsonPath)}`);
     }
     console.log(`Commands exported: ${result.commandCount}`);
     console.log(`Workflow presets exported: ${result.presetCount}`);
@@ -438,7 +471,13 @@ async function runDocsGenerateCatalog(args) {
 
 module.exports = {
   buildCatalogModel,
+  extractCliRoutes,
+  formatOutputLabel,
   generateToolCatalog,
+  renderJson,
   renderMarkdown,
+  resolveGeneratedAt,
   runDocsGenerateCatalog,
+  validateCatalogMetadata,
+  validateRenderedCatalog,
 };

--- a/docs/tool-catalog.json
+++ b/docs/tool-catalog.json
@@ -1,556 +1,816 @@
 {
-  "generatedAt": "2026-07-12T12:50:21.815Z",
+  "schemaVersion": 1,
+  "package": {
+    "name": "zeus-rpg-promptkit",
+    "version": "0.2.0-beta.2"
+  },
+  "generatedAt": "2026-07-12T00:00:00.000Z",
+  "cliFile": "cli/zeus.js",
   "commandRows": [
     {
       "command": "doctor",
+      "aliases": [],
+      "status": "stable",
       "safety": "S0",
       "scope": "Local",
+      "sideEffects": [],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "configure.doctor",
       "purpose": "Validate runtime, profiles, Java/runtime wiring, and env contracts.",
-      "example": "node cli/zeus.js doctor --profile default --show-resolved",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "profiles",
-      "safety": "S0",
-      "scope": "Local",
-      "purpose": "List profiles and show masked runtime defaults and resolved routing hints.",
-      "example": "node cli/zeus.js profiles --profile default --show-env",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "fetch",
-      "safety": "S2",
-      "scope": "IBM i read",
-      "purpose": "Fetch source members/IFS content into the local workspace. Supports --system <name> to select a named profile system at operator request without changing the loaded profile.",
-      "example": "node cli/zeus.js fetch --profile combined-fetch-and-query --system dev",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "fetch-member",
-      "safety": "S2",
-      "scope": "IBM i read",
-      "purpose": "Fetch one or more specific source members into a local output directory.",
-      "example": "node cli/zeus.js fetch-member --profile default --lib APPLIB --member ORDERPGM",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "analyze",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Analyze RPG/CL/DDS and generate evidence artifacts. Supports --optimize-context, --dense [lite|full|ultra] (rank-aware token reduction + compaction), --prompt-max-tokens, --skip-db2-metadata, --reproducible for large programs and CI stability.",
-      "example": "node cli/zeus.js analyze --source ./rpg_sources --program ORDERPGM --out ./output --optimize-context --dense ultra --prompt-max-tokens 4000",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "workflow",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Run preset-guided analyze and bundle flow. Supports --dense (forwarded to analyze steps).",
-      "example": "node cli/zeus.js workflow --preset architecture-review --source ./rpg_sources --program ORDERPGM --out ./output --dense ultra",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "workflow run",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Run workflow definitions from profile/runtime configuration. --dense [lite|full|ultra] is supported and forwarded to inner analyze steps (rank-aware token reduction & compaction).",
-      "example": "node cli/zeus.js workflow run --profile default --preset onboarding --out ./output --dense full",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": false,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "bundle",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Package analysis artifacts for sharing and review.",
-      "example": "node cli/zeus.js bundle --program ORDERPGM --source-output-root ./output --include-md --include-json",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "impact",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Build reverse-impact analysis by target or field.",
-      "example": "node cli/zeus.js impact --field RECORD_ID --program ORDERPGM --source ./rpg_sources --out ./output",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "assess-risk",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Produce a risk-oriented summary for a program.",
-      "example": "node cli/zeus.js assess-risk --program ORDERPGM --out ./output",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "generate-test",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Generate test plan or test template artifacts.",
-      "example": "node cli/zeus.js generate-test --program ORDERPGM --format markdown --out ./output",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "generate-checklist",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Generate deployment and change checklist artifacts.",
-      "example": "node cli/zeus.js generate-checklist --program ORDERPGM --type BOTH --impact HIGH --out ./output",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "query-table",
-      "safety": "S2",
-      "scope": "DB2 read",
-      "purpose": "Query DB2 table metadata. Supports --json for machine readable output.",
-      "example": "node cli/zeus.js query-table --profile default --table APP_TABLE_00 --schema APPDATA --json",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "resolve-object",
-      "safety": "S2",
-      "scope": "DB2 read",
-      "purpose": "Resolve SQL/system object names and optionally verify required columns.",
-      "example": "node cli/zeus.js resolve-object --profile default --table APP_TABLE_00 --require-column STATUS",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "joblog",
-      "safety": "S2",
-      "scope": "IBM i read",
-      "purpose": "Inspect IBM i joblog messages.",
-      "example": "node cli/zeus.js joblog --profile default --severity ERROR --max-messages 100",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "field-search",
-      "safety": "S0/S2",
-      "scope": "Local + IBM i read",
-      "purpose": "Find field/table usage in local sources and or remote members.",
-      "example": "node cli/zeus.js field-search --profile default --field FIELD_ALPHA --table APP_TABLE --source ./rpg_sources --mode all",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "search-source",
-      "safety": "S0",
-      "scope": "Local",
-      "purpose": "Search the local source tree by term, member, or table.",
-      "example": "node cli/zeus.js search-source --source-root ./rpg_sources --search-term \"CHAIN(\" --max-results 50",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "copy-to-workspace",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Copy fetched source members into the active workspace.",
-      "example": "node cli/zeus.js copy-to-workspace --profile default --members ORDERPGM,INVOICEPGM",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "diff",
-      "safety": "S2",
-      "scope": "IBM i read + local",
-      "purpose": "Compare local source members with IBM i members.",
-      "example": "node cli/zeus.js diff --profile default --member ORDERPGM",
-      "usage": [
-        "[--config <path>] diff --profile <name> --member <name>"
-      ],
-      "options": [
-        "--config",
-        "--profile",
-        "--member"
-      ],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": true
-      }
-    },
-    {
-      "command": "serve",
-      "safety": "S0",
-      "scope": "Local",
-      "purpose": "Start the optional local artifact viewer and experimental UI shell.",
-      "example": "node cli/zeus.js serve --source-output-root ./output --host 127.0.0.1 --port 4782",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "qa",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Render QA validations/checks to jira, markdown, or json.",
-      "example": "node cli/zeus.js qa --input ./output/ORDERPGM --format markdown --strict STRICT",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "inspect-object",
-      "safety": "S2",
-      "scope": "IBM i read",
-      "purpose": "Read object metadata and journaling details.",
-      "example": "node cli/zeus.js inspect-object --profile default --lib APPLIB --name APP_TABLE_00 --type *FILE --journal",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "test-run",
-      "safety": "S2/S1",
-      "scope": "DB2 read + local",
-      "purpose": "Capture before and after test snapshots plus rollback SQL text.",
-      "example": "node cli/zeus.js test-run start --profile default --program ORDERPGM --table APPLIB.APP_TABLE_00 --key ID=1",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "write-sql",
-      "safety": "S3",
-      "scope": "DB2 write",
-      "purpose": "Execute one or more guarded DML statements with confirmation, backup, and safety preflight options.",
-      "example": "node cli/zeus.js write-sql --profile default --sql \"DELETE FROM APPDATA.APP_TABLE_00 WHERE STATUS='X'\" --confirm --backup",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "upsert",
-      "safety": "S3",
-      "scope": "DB2 write",
-      "purpose": "DML wrapper for INSERT/UPDATE/DELETE/MERGE with guardrails.",
-      "example": "node cli/zeus.js upsert --profile default --sql \"UPDATE APPDATA.APP_TABLE_00 SET STATUS='X' WHERE ID=1\"",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "upsert-sql",
-      "safety": "S3",
-      "scope": "DB2 write",
-      "purpose": "Backward-compatible alias for the upsert flow.",
-      "example": "node cli/zeus.js upsert-sql --profile default --sql \"INSERT INTO APPDATA.APP_TABLE_00 (ID) VALUES (1)\"",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "insert",
-      "safety": "S3",
-      "scope": "DB2 write",
-      "purpose": "Strict insert-only DML command.",
-      "example": "node cli/zeus.js insert --profile default --sql \"INSERT INTO APPDATA.APP_TABLE_00 (ID) VALUES (1)\"",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "update",
-      "safety": "S3",
-      "scope": "DB2 write",
-      "purpose": "Strict update-only DML command.",
-      "example": "node cli/zeus.js update --profile default --sql \"UPDATE APPDATA.APP_TABLE_00 SET STATUS='Y' WHERE ID=1\"",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "delete",
-      "safety": "S3",
-      "scope": "DB2 write",
-      "purpose": "Strict delete-only DML command with the shared write-safety guardrails.",
-      "example": "node cli/zeus.js delete --profile default --sql \"DELETE FROM APPDATA.APP_TABLE_00 WHERE STATUS='X'\" --confirm --backup",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "analyses",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "List, register, inspect, and open locally tracked analysis artifacts.",
-      "example": "node cli/zeus.js analyses list --profile default",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "bridge",
-      "safety": "S4",
-      "scope": "Operator-gated",
-      "purpose": "Bridge planning/staging/apply/compile/report flow; never implicit.",
-      "example": "node cli/zeus.js bridge plan --profile default --help",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "pui-edit",
-      "safety": "S1",
-      "scope": "Local",
-      "purpose": "Apply structured UI edit operations to local display artifacts.",
-      "example": "node cli/zeus.js pui-edit --file ./display/DSPFILE.MBR --action plan --changes-file ./changes.json",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "docs:generate-catalog",
-      "safety": "S0",
-      "scope": "Local read-only",
-      "purpose": "Regenerate docs/tool-catalog.md (and optional JSON projection) from the CLI command surface; also callable as `zeus docs generate-catalog`.",
-      "example": "node cli/zeus.js docs:generate-catalog",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "mcp",
-      "safety": "S0",
-      "scope": "Local read-mostly",
-      "purpose": "Start local MCP stdio server for safe read-mostly Zeus tool exposure with allowlist policy gating, guarded write controls, and opaque cursor pagination on supported tools.",
-      "example": "node cli/zeus.js mcp serve --verbose --allow-tools zeus.health,zeus.version,zeus.profiles,zeus.doctor,zeus.help,zeus.onboarding,zeus.analyze,zeus.workflow,zeus.bundle,zeus.search-source,zeus.field-search,zeus.resolve-object,zeus.inspect-object,zeus.query-table,zeus.query-sql,zeus.impact,zeus.assess-risk,zeus.generate-test,zeus.generate-checklist,zeus.qa,zeus.validate-rpg-sql,zeus.analyses,zeus.fetch-member,zeus.diff,zeus.copy-to-workspace,zeus.joblog,zeus.docs-generate-catalog,zeus.serve,zeus.test-run",
-      "usage": [
-        "[--config <path>] mcp <serve|help> [--stdio true|false] [--verbose]"
-      ],
-      "options": [
-        "--config",
-        "--stdio",
-        "--verbose"
-      ],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": true
-      }
-    },
-    {
-      "command": "discover-environment",
-      "safety": "S0",
-      "scope": "Local",
-      "purpose": "Read-only auto-discovery of libraries/source-files/members/tables + resource suggestion.",
-      "example": "node cli/zeus.js discover-environment --profile dev --json",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "pui-inspect",
-      "safety": "S0",
-      "scope": "Local",
-      "purpose": "Command metadata missing; update src/docs/toolCatalogMetadata.js.",
-      "example": "node cli/zeus.js pui-inspect",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
-    },
-    {
-      "command": "resources",
-      "safety": "S0",
-      "scope": "Local",
-      "purpose": "Show resolved resource model (Source/Objects/Metadata/Data) per system.",
-      "example": "node cli/zeus.js resources --profile dev --json",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
+      "example": "node cli/zeus.js doctor --profile default --show-resolved"
     },
     {
       "command": "secret",
-      "safety": "S0",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
       "scope": "Local",
+      "sideEffects": [
+        "local-secret-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": false
+      },
+      "capabilityId": null,
       "purpose": "Manage encrypted credentials (Secret Vault). Create key (init-key [--windows] for DPAPI on Windows), encrypt/decrypt values (enc:v1:...) for .env or profiles. Transparent decryption at runtime. Never store plaintext passwords. Supports migrate, check (with --warn-only), status.",
-      "example": "node cli/zeus.js secret init-key --windows && node cli/zeus.js secret encrypt --value \"myDbPass\"",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
+      "example": "node cli/zeus.js secret init-key --windows && node cli/zeus.js secret encrypt --value \"myDbPass\""
     },
     {
-      "command": "sql",
+      "command": "profiles",
+      "aliases": [],
+      "status": "stable",
       "safety": "S0",
       "scope": "Local",
-      "purpose": "Command metadata missing; update src/docs/toolCatalogMetadata.js.",
-      "example": "node cli/zeus.js sql",
-      "usage": [
-        "sql (alias for query-sql, implies --repl if no --sql/--file)"
+      "sideEffects": [],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "configure.profiles",
+      "purpose": "List profiles and show masked runtime defaults and resolved routing hints.",
+      "example": "node cli/zeus.js profiles --profile default --show-env"
+    },
+    {
+      "command": "resources",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S0",
+      "scope": "Local",
+      "sideEffects": [],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "configure.resources",
+      "purpose": "Show resolved resource model (Source/Objects/Metadata/Data) per system.",
+      "example": "node cli/zeus.js resources --profile dev --json"
+    },
+    {
+      "command": "discover-environment",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "IBM i read",
+      "sideEffects": [
+        "remote-read"
       ],
-      "options": [
-        "--repl",
-        "--sql",
-        "--file"
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "configure.discover-environment",
+      "purpose": "Read-only auto-discovery of libraries/source-files/members/tables + resource suggestion.",
+      "example": "node cli/zeus.js discover-environment --profile dev --json"
+    },
+    {
+      "command": "fetch",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "IBM i read",
+      "sideEffects": [
+        "remote-read",
+        "local-artifact-write"
       ],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": true
-      }
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Fetch source members/IFS content into the local workspace. Supports --system <name> to select a named profile system at operator request without changing the loaded profile.",
+      "example": "node cli/zeus.js fetch --profile combined-fetch-and-query --system dev"
+    },
+    {
+      "command": "fetch-member",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "IBM i read",
+      "sideEffects": [
+        "remote-read",
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Fetch one or more specific source members into a local output directory.",
+      "example": "node cli/zeus.js fetch-member --profile default --lib APPLIB --member ORDERPGM"
+    },
+    {
+      "command": "analyze",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "analysis.analyze",
+      "purpose": "Analyze RPG/CL/DDS and generate evidence artifacts. Supports --optimize-context, --dense [lite|full|ultra] (rank-aware token reduction + compaction), --prompt-max-tokens, --skip-db2-metadata, --reproducible for large programs and CI stability.",
+      "example": "node cli/zeus.js analyze --source ./rpg_sources --program ORDERPGM --out ./output --optimize-context --dense ultra --prompt-max-tokens 4000"
+    },
+    {
+      "command": "investigate",
+      "aliases": [
+        "investigation"
+      ],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": false
+      },
+      "capabilityId": "investigation.investigate",
+      "purpose": "Start or resume a focused investigation session on top of existing analysis artifacts. Enables scoped, iterative deep-dives (focus, search, impact, generate-prompt) with persistent state through the CLI and in-process API.",
+      "example": "node cli/zeus.js investigate --program ORDERPGM --profile dev --goal \"Focus on error paths\" --focus \"error paths\" --search \"dynamic sql\" --generate-prompt"
+    },
+    {
+      "command": "workflow",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "analysis.workflow",
+      "purpose": "Run preset-guided analyze and bundle flow. Supports --dense (forwarded to analyze steps).",
+      "example": "node cli/zeus.js workflow --preset architecture-review --source ./rpg_sources --program ORDERPGM --out ./output --dense ultra"
+    },
+    {
+      "command": "workflow run",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": false
+      },
+      "capabilityId": null,
+      "purpose": "Run workflow definitions from profile/runtime configuration. --dense [lite|full|ultra] is supported and forwarded to inner analyze steps (rank-aware token reduction & compaction).",
+      "example": "node cli/zeus.js workflow run --profile default --preset onboarding --out ./output --dense full"
+    },
+    {
+      "command": "bundle",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "bundle.create",
+      "purpose": "Package analysis artifacts for sharing and review.",
+      "example": "node cli/zeus.js bundle --program ORDERPGM --source-output-root ./output --include-md --include-json"
+    },
+    {
+      "command": "impact",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "investigation.impact",
+      "purpose": "Build reverse-impact analysis by target or field.",
+      "example": "node cli/zeus.js impact --field RECORD_ID --program ORDERPGM --source ./rpg_sources --out ./output"
+    },
+    {
+      "command": "assess-risk",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "investigation.assess-risk",
+      "purpose": "Produce a risk-oriented summary for a program.",
+      "example": "node cli/zeus.js assess-risk --program ORDERPGM --out ./output"
+    },
+    {
+      "command": "generate-test",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "investigation.generate-test",
+      "purpose": "Generate test plan or test template artifacts.",
+      "example": "node cli/zeus.js generate-test --program ORDERPGM --format markdown --out ./output"
+    },
+    {
+      "command": "generate-checklist",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "investigation.generate-checklist",
+      "purpose": "Generate deployment and change checklist artifacts.",
+      "example": "node cli/zeus.js generate-checklist --program ORDERPGM --type BOTH --impact HIGH --out ./output"
+    },
+    {
+      "command": "query-table",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "DB2 read",
+      "sideEffects": [
+        "remote-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Query DB2 table metadata. Supports --json for machine readable output.",
+      "example": "node cli/zeus.js query-table --profile default --table APP_TABLE_00 --schema APPDATA --json"
+    },
+    {
+      "command": "resolve-object",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "DB2 read",
+      "sideEffects": [
+        "remote-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Resolve SQL/system object names and optionally verify required columns.",
+      "example": "node cli/zeus.js resolve-object --profile default --table APP_TABLE_00 --require-column STATUS"
+    },
+    {
+      "command": "query-sql",
+      "aliases": [
+        "sql"
+      ],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "DB2 read",
+      "sideEffects": [
+        "remote-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Run one or more read-only SQL statements (SELECT/WITH). Semicolon-separated --sql and --file batches execute through one DB2 runner call.",
+      "example": "node cli/zeus.js query-sql --profile default --sql \"SELECT * FROM QSYS2.SYSTABLES FETCH FIRST 10 ROWS ONLY; SELECT CURRENT_USER FROM SYSIBM.SYSDUMMY1\""
+    },
+    {
+      "command": "joblog",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "IBM i read",
+      "sideEffects": [
+        "remote-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Inspect IBM i joblog messages.",
+      "example": "node cli/zeus.js joblog --profile default --severity ERROR --max-messages 100"
+    },
+    {
+      "command": "field-search",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "Local + IBM i read",
+      "sideEffects": [
+        "local-read",
+        "remote-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "investigation.field-search",
+      "purpose": "Find field/table usage in local sources and or remote members.",
+      "example": "node cli/zeus.js field-search --profile default --field FIELD_ALPHA --table APP_TABLE --source ./rpg_sources --mode all"
     },
     {
       "command": "trace",
-      "safety": "S0",
-      "scope": "Local",
-      "purpose": "Command metadata missing; update src/docs/toolCatalogMetadata.js.",
-      "example": "node cli/zeus.js trace",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "Local + IBM i read",
+      "sideEffects": [
+        "local-read",
+        "remote-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": false
+      },
+      "capabilityId": "investigation.trace",
+      "purpose": "Trace data and value lineage across programs and tables.",
+      "example": "node cli/zeus.js trace --value 123 --start-table ORDERS --profile default"
     },
     {
       "command": "xref",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "Local + IBM i read",
+      "sideEffects": [
+        "local-read",
+        "remote-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": false
+      },
+      "capabilityId": "investigation.xref",
+      "purpose": "Build a who-calls or who-uses cross-reference for programs and tables.",
+      "example": "node cli/zeus.js xref --program ORDERPGM --profile default"
+    },
+    {
+      "command": "validate-rpg-sql",
+      "aliases": [
+        "validate-rpgsql"
+      ],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Validate embedded SQL in RPG sources for cursor/fetch mismatches, dynamic SQL patterns and host variable issues. Uses scanner + sqlRpgValidator.",
+      "example": "node cli/zeus.js validate-rpg-sql --source ./rpg_sources --program ORDERPGM --format markdown --out ./output"
+    },
+    {
+      "command": "onboarding",
+      "aliases": [
+        "wizard",
+        "onboard",
+        "zeus-onboarding-wizard"
+      ],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-config-write",
+        "remote-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Interactive zeus-onboarding-wizard. Guides through profile setup, doctor checks, source/object discovery, first fetch and analyze for a new IBM i system.",
+      "example": "node cli/zeus.js onboarding"
+    },
+    {
+      "command": "search-source",
+      "aliases": [],
+      "status": "stable",
       "safety": "S0",
       "scope": "Local",
-      "purpose": "Command metadata missing; update src/docs/toolCatalogMetadata.js.",
-      "example": "node cli/zeus.js xref",
-      "usage": [],
-      "options": [],
-      "source": {
-        "routeDetected": true,
-        "usageDetected": false
-      }
+      "sideEffects": [
+        "local-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "investigation.search-source",
+      "purpose": "Search the local source tree by term, member, or table.",
+      "example": "node cli/zeus.js search-source --source-root ./rpg_sources --search-term \"CHAIN(\" --max-results 50"
+    },
+    {
+      "command": "copy-to-workspace",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Copy fetched source members into the active workspace.",
+      "example": "node cli/zeus.js copy-to-workspace --profile default --members ORDERPGM,INVOICEPGM"
+    },
+    {
+      "command": "diff",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "IBM i read + local",
+      "sideEffects": [
+        "remote-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Compare local source members with IBM i members.",
+      "example": "node cli/zeus.js diff --profile default --member ORDERPGM"
+    },
+    {
+      "command": "serve",
+      "aliases": [],
+      "status": "experimental",
+      "safety": "S0",
+      "scope": "Local",
+      "sideEffects": [
+        "local-listener"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Start the optional local artifact viewer and experimental UI shell.",
+      "example": "node cli/zeus.js serve --source-output-root ./output --host 127.0.0.1 --port 4782"
+    },
+    {
+      "command": "qa",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": true,
+        "mcp": true
+      },
+      "capabilityId": "investigation.qa",
+      "purpose": "Render QA validations/checks to jira, markdown, or json.",
+      "example": "node cli/zeus.js qa --input ./output/ORDERPGM --format markdown --strict STRICT"
+    },
+    {
+      "command": "inspect-object",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "IBM i read",
+      "sideEffects": [
+        "remote-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Read object metadata and journaling details.",
+      "example": "node cli/zeus.js inspect-object --profile default --lib APPLIB --name APP_TABLE_00 --type *FILE --journal"
+    },
+    {
+      "command": "test-run",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S2",
+      "scope": "DB2 read + local",
+      "sideEffects": [
+        "remote-read",
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Capture before and after test snapshots plus rollback SQL text.",
+      "example": "node cli/zeus.js test-run start --profile default --program ORDERPGM --table APPLIB.APP_TABLE_00 --key ID=1"
+    },
+    {
+      "command": "write-sql",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S3",
+      "scope": "DB2 write",
+      "sideEffects": [
+        "remote-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Execute one or more guarded DML statements with confirmation, backup, and safety preflight options.",
+      "example": "node cli/zeus.js write-sql --profile default --sql \"DELETE FROM APPDATA.APP_TABLE_00 WHERE STATUS='X'\" --confirm --backup"
+    },
+    {
+      "command": "upsert",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S3",
+      "scope": "DB2 write",
+      "sideEffects": [
+        "remote-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": false
+      },
+      "capabilityId": null,
+      "purpose": "DML wrapper for INSERT/UPDATE/DELETE/MERGE with guardrails.",
+      "example": "node cli/zeus.js upsert --profile default --sql \"UPDATE APPDATA.APP_TABLE_00 SET STATUS='X' WHERE ID=1\""
+    },
+    {
+      "command": "upsert-sql",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S3",
+      "scope": "DB2 write",
+      "sideEffects": [
+        "remote-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": false
+      },
+      "capabilityId": null,
+      "purpose": "Backward-compatible alias for the upsert flow.",
+      "example": "node cli/zeus.js upsert-sql --profile default --sql \"INSERT INTO APPDATA.APP_TABLE_00 (ID) VALUES (1)\""
+    },
+    {
+      "command": "insert",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S3",
+      "scope": "DB2 write",
+      "sideEffects": [
+        "remote-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": false
+      },
+      "capabilityId": null,
+      "purpose": "Strict insert-only DML command.",
+      "example": "node cli/zeus.js insert --profile default --sql \"INSERT INTO APPDATA.APP_TABLE_00 (ID) VALUES (1)\""
+    },
+    {
+      "command": "update",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S3",
+      "scope": "DB2 write",
+      "sideEffects": [
+        "remote-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": false
+      },
+      "capabilityId": null,
+      "purpose": "Strict update-only DML command.",
+      "example": "node cli/zeus.js update --profile default --sql \"UPDATE APPDATA.APP_TABLE_00 SET STATUS='Y' WHERE ID=1\""
+    },
+    {
+      "command": "delete",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S3",
+      "scope": "DB2 write",
+      "sideEffects": [
+        "remote-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": false
+      },
+      "capabilityId": null,
+      "purpose": "Strict delete-only DML command with the shared write-safety guardrails.",
+      "example": "node cli/zeus.js delete --profile default --sql \"DELETE FROM APPDATA.APP_TABLE_00 WHERE STATUS='X'\" --confirm --backup"
+    },
+    {
+      "command": "analyses",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "List, register, inspect, and open locally tracked analysis artifacts.",
+      "example": "node cli/zeus.js analyses list --profile default"
+    },
+    {
+      "command": "bridge",
+      "aliases": [],
+      "status": "experimental",
+      "safety": "S4",
+      "scope": "Operator-gated",
+      "sideEffects": [
+        "operator-gated"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Bridge planning/staging/apply/compile/report flow; never implicit.",
+      "example": "node cli/zeus.js bridge plan --profile default --help"
+    },
+    {
+      "command": "pui-edit",
+      "aliases": [],
+      "status": "experimental",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Apply structured UI edit operations to local display artifacts.",
+      "example": "node cli/zeus.js pui-edit --file ./display/DSPFILE.MBR --action plan --changes-file ./changes.json"
+    },
+    {
+      "command": "pui-inspect",
+      "aliases": [],
+      "status": "experimental",
+      "safety": "S0",
+      "scope": "Local",
+      "sideEffects": [
+        "local-read"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Inspect a local Profound UI display-file projection and optionally trace field bindings.",
+      "example": "node cli/zeus.js pui-inspect --file ./display/DSPFILE.MBR --json"
+    },
+    {
+      "command": "docs:generate-catalog",
+      "aliases": [
+        "docs generate-catalog"
+      ],
+      "status": "stable",
+      "safety": "S1",
+      "scope": "Local",
+      "sideEffects": [
+        "local-artifact-write"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": true
+      },
+      "capabilityId": null,
+      "purpose": "Regenerate docs/tool-catalog.md (and optional JSON projection) from the CLI command surface; also callable as `zeus docs generate-catalog`.",
+      "example": "node cli/zeus.js docs:generate-catalog"
+    },
+    {
+      "command": "mcp",
+      "aliases": [],
+      "status": "stable",
+      "safety": "S0",
+      "scope": "Local read-mostly",
+      "sideEffects": [
+        "local-process-stdio"
+      ],
+      "availability": {
+        "cli": true,
+        "api": false,
+        "mcp": false
+      },
+      "capabilityId": null,
+      "purpose": "Start local MCP stdio server for safe read-mostly Zeus tool exposure with allowlist policy gating, guarded write controls, and opaque cursor pagination on supported tools.",
+      "example": "node cli/zeus.js mcp serve --verbose --allow-tools zeus.health,zeus.version,zeus.profiles,zeus.doctor,zeus.help,zeus.onboarding,zeus.analyze,zeus.workflow,zeus.bundle,zeus.search-source,zeus.field-search,zeus.resolve-object,zeus.inspect-object,zeus.query-table,zeus.query-sql,zeus.impact,zeus.assess-risk,zeus.generate-test,zeus.generate-checklist,zeus.qa,zeus.validate-rpg-sql,zeus.analyses,zeus.fetch-member,zeus.diff,zeus.copy-to-workspace,zeus.joblog,zeus.docs-generate-catalog,zeus.serve,zeus.test-run"
     }
   ],
   "workflowPresets": [
@@ -633,7 +893,5 @@
     "generated artifacts and `bundle` for review/sharing; optional `serve` for local viewing",
     "`upsert`/`upsert-sql`/`insert`/`update` only after explicit user approval",
     "`bridge` only in operator-gated, explicitly approved flows"
-  ],
-  "repoRoot": "zeus-rpg-promptkit",
-  "cliFile": "cli/zeus.js"
+  ]
 }

--- a/docs/tool-catalog.md
+++ b/docs/tool-catalog.md
@@ -1,7 +1,7 @@
 <!-- 
 AUTO-GENERATED FILE – do not edit manually!
 Regenerate with: zeus docs:generate-catalog
-Last generated: 2026-07-12 13:32:58
+Last generated: 2026-07-12T00:00:00.000Z
 -->
 
 ---
@@ -11,6 +11,8 @@ Last Updated: 2026-07-12
 ---
 
 # Zeus RPG PromptKit Tool Catalog
+
+Package: `zeus-rpg-promptkit@0.2.0-beta.2`
 
 This document is the authoritative tool reference for Zeus RPG PromptKit.
 All AI assistants (GPT, Claude, Grok, Copilot, local agents) should treat this file as the single source of truth for command purpose, risk level, and usage.
@@ -40,51 +42,52 @@ Related:
 
 ## CLI Command Catalog
 
-| Command | Safety | Scope | Purpose | Example |
-|---|---|---|---|---|
-| `doctor` | `S0` | Local | Validate runtime, profiles, Java/runtime wiring, and env contracts. | `node cli/zeus.js doctor --profile default --show-resolved` |
-| `profiles` | `S0` | Local | List profiles and show masked runtime defaults and resolved routing hints. | `node cli/zeus.js profiles --profile default --show-env` |
-| `fetch` | `S2` | IBM i read | Fetch source members/IFS content into the local workspace. Supports --system <name> to select a named profile system at operator request without changing the loaded profile. | `node cli/zeus.js fetch --profile combined-fetch-and-query --system dev` |
-| `fetch-member` | `S2` | IBM i read | Fetch one or more specific source members into a local output directory. | `node cli/zeus.js fetch-member --profile default --lib APPLIB --member ORDERPGM` |
-| `analyze` | `S1` | Local | Analyze RPG/CL/DDS and generate evidence artifacts. Supports --optimize-context, --dense [lite\|full\|ultra] (rank-aware token reduction + compaction), --prompt-max-tokens, --skip-db2-metadata, --reproducible for large programs and CI stability. | `node cli/zeus.js analyze --source ./rpg_sources --program ORDERPGM --out ./output --optimize-context --dense ultra --prompt-max-tokens 4000` |
-| `investigate` | `S0` | Local | Start or resume a focused investigation session on top of existing analysis artifacts. Enables scoped, iterative deep-dives (focus, search, impact, generate-prompt) with persistent state. Designed for interactive use and MCP agents. | `node cli/zeus.js investigate --program ORDERPGM --profile dev --goal "Focus on error paths" --focus "error paths" --search "dynamic sql" --generate-prompt` |
-| `workflow` | `S1` | Local | Run preset-guided analyze and bundle flow. Supports --dense (forwarded to analyze steps). | `node cli/zeus.js workflow --preset architecture-review --source ./rpg_sources --program ORDERPGM --out ./output --dense ultra` |
-| `workflow run` | `S1` | Local | Run workflow definitions from profile/runtime configuration. --dense [lite\|full\|ultra] is supported and forwarded to inner analyze steps (rank-aware token reduction & compaction). | `node cli/zeus.js workflow run --profile default --preset onboarding --out ./output --dense full` |
-| `bundle` | `S1` | Local | Package analysis artifacts for sharing and review. | `node cli/zeus.js bundle --program ORDERPGM --source-output-root ./output --include-md --include-json` |
-| `impact` | `S1` | Local | Build reverse-impact analysis by target or field. | `node cli/zeus.js impact --field RECORD_ID --program ORDERPGM --source ./rpg_sources --out ./output` |
-| `assess-risk` | `S1` | Local | Produce a risk-oriented summary for a program. | `node cli/zeus.js assess-risk --program ORDERPGM --out ./output` |
-| `generate-test` | `S1` | Local | Generate test plan or test template artifacts. | `node cli/zeus.js generate-test --program ORDERPGM --format markdown --out ./output` |
-| `generate-checklist` | `S1` | Local | Generate deployment and change checklist artifacts. | `node cli/zeus.js generate-checklist --program ORDERPGM --type BOTH --impact HIGH --out ./output` |
-| `query-table` | `S2` | DB2 read | Query DB2 table metadata. Supports --json for machine readable output. | `node cli/zeus.js query-table --profile default --table APP_TABLE_00 --schema APPDATA --json` |
-| `resolve-object` | `S2` | DB2 read | Resolve SQL/system object names and optionally verify required columns. | `node cli/zeus.js resolve-object --profile default --table APP_TABLE_00 --require-column STATUS` |
-| `query-sql` | `S2` | DB2 read | Run one or more read-only SQL statements (SELECT/WITH). Semicolon-separated --sql and --file batches execute through one DB2 runner call. | `node cli/zeus.js query-sql --profile default --sql "SELECT * FROM QSYS2.SYSTABLES FETCH FIRST 10 ROWS ONLY; SELECT CURRENT_USER FROM SYSIBM.SYSDUMMY1"` |
-| `joblog` | `S2` | IBM i read | Inspect IBM i joblog messages. | `node cli/zeus.js joblog --profile default --severity ERROR --max-messages 100` |
-| `field-search` | `S0/S2` | Local + IBM i read | Find field/table usage in local sources and or remote members. | `node cli/zeus.js field-search --profile default --field FIELD_ALPHA --table APP_TABLE --source ./rpg_sources --mode all` |
-| `search-source` | `S0` | Local | Search the local source tree by term, member, or table. | `node cli/zeus.js search-source --source-root ./rpg_sources --search-term "CHAIN(" --max-results 50` |
-| `copy-to-workspace` | `S1` | Local | Copy fetched source members into the active workspace. | `node cli/zeus.js copy-to-workspace --profile default --members ORDERPGM,INVOICEPGM` |
-| `diff` | `S2` | IBM i read + local | Compare local source members with IBM i members. | `node cli/zeus.js diff --profile default --member ORDERPGM` |
-| `serve` | `S0` | Local | Start the optional local artifact viewer and experimental UI shell. | `node cli/zeus.js serve --source-output-root ./output --host 127.0.0.1 --port 4782` |
-| `qa` | `S1` | Local | Render QA validations/checks to jira, markdown, or json. | `node cli/zeus.js qa --input ./output/ORDERPGM --format markdown --strict STRICT` |
-| `inspect-object` | `S2` | IBM i read | Read object metadata and journaling details. | `node cli/zeus.js inspect-object --profile default --lib APPLIB --name APP_TABLE_00 --type *FILE --journal` |
-| `test-run` | `S2/S1` | DB2 read + local | Capture before and after test snapshots plus rollback SQL text. | `node cli/zeus.js test-run start --profile default --program ORDERPGM --table APPLIB.APP_TABLE_00 --key ID=1` |
-| `write-sql` | `S3` | DB2 write | Execute one or more guarded DML statements with confirmation, backup, and safety preflight options. | `node cli/zeus.js write-sql --profile default --sql "DELETE FROM APPDATA.APP_TABLE_00 WHERE STATUS='X'" --confirm --backup` |
-| `upsert` | `S3` | DB2 write | DML wrapper for INSERT/UPDATE/DELETE/MERGE with guardrails. | `node cli/zeus.js upsert --profile default --sql "UPDATE APPDATA.APP_TABLE_00 SET STATUS='X' WHERE ID=1"` |
-| `upsert-sql` | `S3` | DB2 write | Backward-compatible alias for the upsert flow. | `node cli/zeus.js upsert-sql --profile default --sql "INSERT INTO APPDATA.APP_TABLE_00 (ID) VALUES (1)"` |
-| `insert` | `S3` | DB2 write | Strict insert-only DML command. | `node cli/zeus.js insert --profile default --sql "INSERT INTO APPDATA.APP_TABLE_00 (ID) VALUES (1)"` |
-| `update` | `S3` | DB2 write | Strict update-only DML command. | `node cli/zeus.js update --profile default --sql "UPDATE APPDATA.APP_TABLE_00 SET STATUS='Y' WHERE ID=1"` |
-| `delete` | `S3` | DB2 write | Strict delete-only DML command with the shared write-safety guardrails. | `node cli/zeus.js delete --profile default --sql "DELETE FROM APPDATA.APP_TABLE_00 WHERE STATUS='X'" --confirm --backup` |
-| `analyses` | `S1` | Local | List, register, inspect, and open locally tracked analysis artifacts. | `node cli/zeus.js analyses list --profile default` |
-| `bridge` | `S4` | Operator-gated | Bridge planning/staging/apply/compile/report flow; never implicit. | `node cli/zeus.js bridge plan --profile default --help` |
-| `pui-edit` | `S1` | Local | Apply structured UI edit operations to local display artifacts. | `node cli/zeus.js pui-edit --file ./display/DSPFILE.MBR --action plan --changes-file ./changes.json` |
-| `docs:generate-catalog` | `S0` | Local read-only | Regenerate docs/tool-catalog.md (and optional JSON projection) from the CLI command surface; also callable as `zeus docs generate-catalog`. | `node cli/zeus.js docs:generate-catalog` |
-| `mcp` | `S0` | Local read-mostly | Start local MCP stdio server for safe read-mostly Zeus tool exposure with allowlist policy gating, guarded write controls, and opaque cursor pagination on supported tools. | `node cli/zeus.js mcp serve --verbose --allow-tools zeus.health,zeus.version,zeus.profiles,zeus.doctor,zeus.help,zeus.onboarding,zeus.analyze,zeus.workflow,zeus.bundle,zeus.search-source,zeus.field-search,zeus.resolve-object,zeus.inspect-object,zeus.query-table,zeus.query-sql,zeus.impact,zeus.assess-risk,zeus.generate-test,zeus.generate-checklist,zeus.qa,zeus.validate-rpg-sql,zeus.analyses,zeus.fetch-member,zeus.diff,zeus.copy-to-workspace,zeus.joblog,zeus.docs-generate-catalog,zeus.serve,zeus.test-run` |
-| `discover-environment` | `S0` | Local | Read-only auto-discovery of libraries/source-files/members/tables + resource suggestion. | `node cli/zeus.js discover-environment --profile dev --json` |
-| `pui-inspect` | `S0` | Local | Command metadata missing; update src/docs/toolCatalogMetadata.js. | `node cli/zeus.js pui-inspect` |
-| `resources` | `S0` | Local | Show resolved resource model (Source/Objects/Metadata/Data) per system. | `node cli/zeus.js resources --profile dev --json` |
-| `secret` | `S0` | Local | Manage encrypted credentials (Secret Vault). Create key (init-key [--windows] for DPAPI on Windows), encrypt/decrypt values (enc:v1:...) for .env or profiles. Transparent decryption at runtime. Never store plaintext passwords. Supports migrate, check (with --warn-only), status. | `node cli/zeus.js secret init-key --windows && node cli/zeus.js secret encrypt --value "myDbPass"` |
-| `sql` | `S0` | Local | Command metadata missing; update src/docs/toolCatalogMetadata.js. | `node cli/zeus.js sql` |
-| `trace` | `S0` | Local | Command metadata missing; update src/docs/toolCatalogMetadata.js. | `node cli/zeus.js trace` |
-| `xref` | `S0` | Local | Command metadata missing; update src/docs/toolCatalogMetadata.js. | `node cli/zeus.js xref` |
+| Command | Aliases | Status | Safety | Scope | Side Effects | Availability | Capability | Purpose | Example |
+|---|---|---|---|---|---|---|---|---|---|
+| `doctor` | — | `stable` | `S0` | Local | none | cli, api, mcp | `configure.doctor` | Validate runtime, profiles, Java/runtime wiring, and env contracts. | `node cli/zeus.js doctor --profile default --show-resolved` |
+| `secret` | — | `stable` | `S1` | Local | local-secret-write | cli | — | Manage encrypted credentials (Secret Vault). Create key (init-key [--windows] for DPAPI on Windows), encrypt/decrypt values (enc:v1:...) for .env or profiles. Transparent decryption at runtime. Never store plaintext passwords. Supports migrate, check (with --warn-only), status. | `node cli/zeus.js secret init-key --windows && node cli/zeus.js secret encrypt --value "myDbPass"` |
+| `profiles` | — | `stable` | `S0` | Local | none | cli, api, mcp | `configure.profiles` | List profiles and show masked runtime defaults and resolved routing hints. | `node cli/zeus.js profiles --profile default --show-env` |
+| `resources` | — | `stable` | `S0` | Local | none | cli, api, mcp | `configure.resources` | Show resolved resource model (Source/Objects/Metadata/Data) per system. | `node cli/zeus.js resources --profile dev --json` |
+| `discover-environment` | — | `stable` | `S2` | IBM i read | remote-read | cli, api, mcp | `configure.discover-environment` | Read-only auto-discovery of libraries/source-files/members/tables + resource suggestion. | `node cli/zeus.js discover-environment --profile dev --json` |
+| `fetch` | — | `stable` | `S2` | IBM i read | remote-read, local-artifact-write | cli, mcp | — | Fetch source members/IFS content into the local workspace. Supports --system <name> to select a named profile system at operator request without changing the loaded profile. | `node cli/zeus.js fetch --profile combined-fetch-and-query --system dev` |
+| `fetch-member` | — | `stable` | `S2` | IBM i read | remote-read, local-artifact-write | cli, mcp | — | Fetch one or more specific source members into a local output directory. | `node cli/zeus.js fetch-member --profile default --lib APPLIB --member ORDERPGM` |
+| `analyze` | — | `stable` | `S1` | Local | local-artifact-write | cli, api, mcp | `analysis.analyze` | Analyze RPG/CL/DDS and generate evidence artifacts. Supports --optimize-context, --dense [lite\|full\|ultra] (rank-aware token reduction + compaction), --prompt-max-tokens, --skip-db2-metadata, --reproducible for large programs and CI stability. | `node cli/zeus.js analyze --source ./rpg_sources --program ORDERPGM --out ./output --optimize-context --dense ultra --prompt-max-tokens 4000` |
+| `investigate` | `investigation` | `stable` | `S1` | Local | local-artifact-write | cli, api | `investigation.investigate` | Start or resume a focused investigation session on top of existing analysis artifacts. Enables scoped, iterative deep-dives (focus, search, impact, generate-prompt) with persistent state through the CLI and in-process API. | `node cli/zeus.js investigate --program ORDERPGM --profile dev --goal "Focus on error paths" --focus "error paths" --search "dynamic sql" --generate-prompt` |
+| `workflow` | — | `stable` | `S1` | Local | local-artifact-write | cli, api, mcp | `analysis.workflow` | Run preset-guided analyze and bundle flow. Supports --dense (forwarded to analyze steps). | `node cli/zeus.js workflow --preset architecture-review --source ./rpg_sources --program ORDERPGM --out ./output --dense ultra` |
+| `workflow run` | — | `stable` | `S1` | Local | local-artifact-write | cli | — | Run workflow definitions from profile/runtime configuration. --dense [lite\|full\|ultra] is supported and forwarded to inner analyze steps (rank-aware token reduction & compaction). | `node cli/zeus.js workflow run --profile default --preset onboarding --out ./output --dense full` |
+| `bundle` | — | `stable` | `S1` | Local | local-artifact-write | cli, api, mcp | `bundle.create` | Package analysis artifacts for sharing and review. | `node cli/zeus.js bundle --program ORDERPGM --source-output-root ./output --include-md --include-json` |
+| `impact` | — | `stable` | `S1` | Local | local-artifact-write | cli, api, mcp | `investigation.impact` | Build reverse-impact analysis by target or field. | `node cli/zeus.js impact --field RECORD_ID --program ORDERPGM --source ./rpg_sources --out ./output` |
+| `assess-risk` | — | `stable` | `S1` | Local | local-artifact-write | cli, api, mcp | `investigation.assess-risk` | Produce a risk-oriented summary for a program. | `node cli/zeus.js assess-risk --program ORDERPGM --out ./output` |
+| `generate-test` | — | `stable` | `S1` | Local | local-artifact-write | cli, api, mcp | `investigation.generate-test` | Generate test plan or test template artifacts. | `node cli/zeus.js generate-test --program ORDERPGM --format markdown --out ./output` |
+| `generate-checklist` | — | `stable` | `S1` | Local | local-artifact-write | cli, api, mcp | `investigation.generate-checklist` | Generate deployment and change checklist artifacts. | `node cli/zeus.js generate-checklist --program ORDERPGM --type BOTH --impact HIGH --out ./output` |
+| `query-table` | — | `stable` | `S2` | DB2 read | remote-read | cli, mcp | — | Query DB2 table metadata. Supports --json for machine readable output. | `node cli/zeus.js query-table --profile default --table APP_TABLE_00 --schema APPDATA --json` |
+| `resolve-object` | — | `stable` | `S2` | DB2 read | remote-read | cli, mcp | — | Resolve SQL/system object names and optionally verify required columns. | `node cli/zeus.js resolve-object --profile default --table APP_TABLE_00 --require-column STATUS` |
+| `query-sql` | `sql` | `stable` | `S2` | DB2 read | remote-read | cli, mcp | — | Run one or more read-only SQL statements (SELECT/WITH). Semicolon-separated --sql and --file batches execute through one DB2 runner call. | `node cli/zeus.js query-sql --profile default --sql "SELECT * FROM QSYS2.SYSTABLES FETCH FIRST 10 ROWS ONLY; SELECT CURRENT_USER FROM SYSIBM.SYSDUMMY1"` |
+| `joblog` | — | `stable` | `S2` | IBM i read | remote-read | cli, mcp | — | Inspect IBM i joblog messages. | `node cli/zeus.js joblog --profile default --severity ERROR --max-messages 100` |
+| `field-search` | — | `stable` | `S2` | Local + IBM i read | local-read, remote-read | cli, api, mcp | `investigation.field-search` | Find field/table usage in local sources and or remote members. | `node cli/zeus.js field-search --profile default --field FIELD_ALPHA --table APP_TABLE --source ./rpg_sources --mode all` |
+| `trace` | — | `stable` | `S2` | Local + IBM i read | local-read, remote-read | cli, api | `investigation.trace` | Trace data and value lineage across programs and tables. | `node cli/zeus.js trace --value 123 --start-table ORDERS --profile default` |
+| `xref` | — | `stable` | `S2` | Local + IBM i read | local-read, remote-read | cli, api | `investigation.xref` | Build a who-calls or who-uses cross-reference for programs and tables. | `node cli/zeus.js xref --program ORDERPGM --profile default` |
+| `validate-rpg-sql` | `validate-rpgsql` | `stable` | `S1` | Local | local-artifact-write | cli, mcp | — | Validate embedded SQL in RPG sources for cursor/fetch mismatches, dynamic SQL patterns and host variable issues. Uses scanner + sqlRpgValidator. | `node cli/zeus.js validate-rpg-sql --source ./rpg_sources --program ORDERPGM --format markdown --out ./output` |
+| `onboarding` | `wizard`, `onboard`, `zeus-onboarding-wizard` | `stable` | `S1` | Local | local-config-write, remote-read | cli, mcp | — | Interactive zeus-onboarding-wizard. Guides through profile setup, doctor checks, source/object discovery, first fetch and analyze for a new IBM i system. | `node cli/zeus.js onboarding` |
+| `search-source` | — | `stable` | `S0` | Local | local-read | cli, api, mcp | `investigation.search-source` | Search the local source tree by term, member, or table. | `node cli/zeus.js search-source --source-root ./rpg_sources --search-term "CHAIN(" --max-results 50` |
+| `copy-to-workspace` | — | `stable` | `S1` | Local | local-artifact-write | cli, mcp | — | Copy fetched source members into the active workspace. | `node cli/zeus.js copy-to-workspace --profile default --members ORDERPGM,INVOICEPGM` |
+| `diff` | — | `stable` | `S2` | IBM i read + local | remote-read | cli, mcp | — | Compare local source members with IBM i members. | `node cli/zeus.js diff --profile default --member ORDERPGM` |
+| `serve` | — | `experimental` | `S0` | Local | local-listener | cli, mcp | — | Start the optional local artifact viewer and experimental UI shell. | `node cli/zeus.js serve --source-output-root ./output --host 127.0.0.1 --port 4782` |
+| `qa` | — | `stable` | `S1` | Local | local-artifact-write | cli, api, mcp | `investigation.qa` | Render QA validations/checks to jira, markdown, or json. | `node cli/zeus.js qa --input ./output/ORDERPGM --format markdown --strict STRICT` |
+| `inspect-object` | — | `stable` | `S2` | IBM i read | remote-read | cli, mcp | — | Read object metadata and journaling details. | `node cli/zeus.js inspect-object --profile default --lib APPLIB --name APP_TABLE_00 --type *FILE --journal` |
+| `test-run` | — | `stable` | `S2` | DB2 read + local | remote-read, local-artifact-write | cli, mcp | — | Capture before and after test snapshots plus rollback SQL text. | `node cli/zeus.js test-run start --profile default --program ORDERPGM --table APPLIB.APP_TABLE_00 --key ID=1` |
+| `write-sql` | — | `stable` | `S3` | DB2 write | remote-write | cli, mcp | — | Execute one or more guarded DML statements with confirmation, backup, and safety preflight options. | `node cli/zeus.js write-sql --profile default --sql "DELETE FROM APPDATA.APP_TABLE_00 WHERE STATUS='X'" --confirm --backup` |
+| `upsert` | — | `stable` | `S3` | DB2 write | remote-write | cli | — | DML wrapper for INSERT/UPDATE/DELETE/MERGE with guardrails. | `node cli/zeus.js upsert --profile default --sql "UPDATE APPDATA.APP_TABLE_00 SET STATUS='X' WHERE ID=1"` |
+| `upsert-sql` | — | `stable` | `S3` | DB2 write | remote-write | cli | — | Backward-compatible alias for the upsert flow. | `node cli/zeus.js upsert-sql --profile default --sql "INSERT INTO APPDATA.APP_TABLE_00 (ID) VALUES (1)"` |
+| `insert` | — | `stable` | `S3` | DB2 write | remote-write | cli | — | Strict insert-only DML command. | `node cli/zeus.js insert --profile default --sql "INSERT INTO APPDATA.APP_TABLE_00 (ID) VALUES (1)"` |
+| `update` | — | `stable` | `S3` | DB2 write | remote-write | cli | — | Strict update-only DML command. | `node cli/zeus.js update --profile default --sql "UPDATE APPDATA.APP_TABLE_00 SET STATUS='Y' WHERE ID=1"` |
+| `delete` | — | `stable` | `S3` | DB2 write | remote-write | cli | — | Strict delete-only DML command with the shared write-safety guardrails. | `node cli/zeus.js delete --profile default --sql "DELETE FROM APPDATA.APP_TABLE_00 WHERE STATUS='X'" --confirm --backup` |
+| `analyses` | — | `stable` | `S1` | Local | local-artifact-write | cli, mcp | — | List, register, inspect, and open locally tracked analysis artifacts. | `node cli/zeus.js analyses list --profile default` |
+| `bridge` | — | `experimental` | `S4` | Operator-gated | operator-gated | cli, mcp | — | Bridge planning/staging/apply/compile/report flow; never implicit. | `node cli/zeus.js bridge plan --profile default --help` |
+| `pui-edit` | — | `experimental` | `S1` | Local | local-artifact-write | cli, mcp | — | Apply structured UI edit operations to local display artifacts. | `node cli/zeus.js pui-edit --file ./display/DSPFILE.MBR --action plan --changes-file ./changes.json` |
+| `pui-inspect` | — | `experimental` | `S0` | Local | local-read | cli, mcp | — | Inspect a local Profound UI display-file projection and optionally trace field bindings. | `node cli/zeus.js pui-inspect --file ./display/DSPFILE.MBR --json` |
+| `docs:generate-catalog` | `docs generate-catalog` | `stable` | `S1` | Local | local-artifact-write | cli, mcp | — | Regenerate docs/tool-catalog.md (and optional JSON projection) from the CLI command surface; also callable as `zeus docs generate-catalog`. | `node cli/zeus.js docs:generate-catalog` |
+| `mcp` | — | `stable` | `S0` | Local read-mostly | local-process-stdio | cli | — | Start local MCP stdio server for safe read-mostly Zeus tool exposure with allowlist policy gating, guarded write controls, and opaque cursor pagination on supported tools. | `node cli/zeus.js mcp serve --verbose --allow-tools zeus.health,zeus.version,zeus.profiles,zeus.doctor,zeus.help,zeus.onboarding,zeus.analyze,zeus.workflow,zeus.bundle,zeus.search-source,zeus.field-search,zeus.resolve-object,zeus.inspect-object,zeus.query-table,zeus.query-sql,zeus.impact,zeus.assess-risk,zeus.generate-test,zeus.generate-checklist,zeus.qa,zeus.validate-rpg-sql,zeus.analyses,zeus.fetch-member,zeus.diff,zeus.copy-to-workspace,zeus.joblog,zeus.docs-generate-catalog,zeus.serve,zeus.test-run` |
 
 ## Workflow Presets
 
@@ -112,5 +115,5 @@ Related:
 ## How To Keep This File Up To Date
 
 - Regenerate with `zeus docs:generate-catalog` after CLI command-surface changes.
-- Command metadata lives in `src/docs/toolCatalogMetadata.js`.
-- Historical proposal is no longer needed; generation logic lives in `cli/commands/generate-tool-catalog.js`.
+- Public command contracts live in `src/docs/toolCatalogMetadata.js`.
+- The generator validates public CLI routes against those declarative contracts and fails closed on drift.

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -14,6 +14,7 @@ module.exports = {
       'tests/fetch-readability-contract.test.js',
       'tests/schema-registry.test.js',
       'tests/task-oriented-analysis-index.test.js',
+      'tests/tool-catalog-generator.test.js',
       'tests/workflow-presets.test.js',
     ],
     smoke: [

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -216,7 +216,11 @@ try {
     description:
       'Read-only auto-discovery of libraries/source-files/members/tables + resource suggestion.',
     category: 'configure',
-    safety: { level: 'S0', sideEffects: [], requiresExplicitApproval: false },
+    safety: {
+      level: 'S2',
+      sideEffects: ['remote-read'],
+      requiresExplicitApproval: false,
+    },
     aliases: ['discover-environment'],
     inputContract: null,
     outputContract: null,
@@ -548,7 +552,11 @@ try {
       title: 'Search Source',
       description: 'Searches local source files for term/member/table matches (read-only).',
       category: 'investigation',
-      safety: { level: 'S0', sideEffects: [], requiresExplicitApproval: false },
+      safety: {
+        level: 'S0',
+        sideEffects: ['local-read'],
+        requiresExplicitApproval: false,
+      },
       aliases: ['search-source'],
       inputContract: null,
       outputContract: null,
@@ -567,7 +575,11 @@ try {
       title: 'Field Search',
       description: 'Find field/table usage in local sources and or remote members.',
       category: 'investigation',
-      safety: { level: 'S0', sideEffects: [], requiresExplicitApproval: false },
+      safety: {
+        level: 'S2',
+        sideEffects: ['local-read', 'remote-read'],
+        requiresExplicitApproval: false,
+      },
       aliases: ['field-search'],
       inputContract: null,
       outputContract: null,
@@ -589,11 +601,15 @@ try {
       title: 'Trace Lineage',
       description: 'Trace data/value lineage across programs and tables.',
       category: 'investigation',
-      safety: { level: 'S0', sideEffects: [], requiresExplicitApproval: false },
+      safety: {
+        level: 'S2',
+        sideEffects: ['local-read', 'remote-read'],
+        requiresExplicitApproval: false,
+      },
       aliases: ['trace'],
       inputContract: null,
       outputContract: null,
-      availability: { cli: true, mcp: true, api: true, viewer: false, vscode: true },
+      availability: { cli: true, mcp: false, api: true, viewer: false, vscode: true },
       docs: { examples: ['zeus trace --value 123 --start-table ORDERS'], notes: [] },
       execute: (context, input) => {
         const args = { ...(context && context.args ? context.args : {}), ...input, _cap: true };
@@ -608,11 +624,15 @@ try {
       title: 'Cross Reference',
       description: 'Fast who-calls / who-uses cross-reference.',
       category: 'investigation',
-      safety: { level: 'S0', sideEffects: [], requiresExplicitApproval: false },
+      safety: {
+        level: 'S2',
+        sideEffects: ['local-read', 'remote-read'],
+        requiresExplicitApproval: false,
+      },
       aliases: ['xref'],
       inputContract: null,
       outputContract: null,
-      availability: { cli: true, mcp: true, api: true, viewer: false, vscode: true },
+      availability: { cli: true, mcp: false, api: true, viewer: false, vscode: true },
       docs: { examples: ['zeus xref --program MYPROG'], notes: [] },
       execute: (context, input) => {
         const args = { ...(context && context.args ? context.args : {}), ...input, _cap: true };

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -628,11 +628,15 @@ try {
       title: 'Investigation',
       description: 'Start or continue a focused, stateful investigation.',
       category: 'investigation',
-      safety: { level: 'S0', sideEffects: [], requiresExplicitApproval: false },
+      safety: {
+        level: 'S1',
+        sideEffects: ['local-artifact-write'],
+        requiresExplicitApproval: false,
+      },
       aliases: ['investigate', 'investigation'],
       inputContract: null,
       outputContract: null,
-      availability: { cli: true, mcp: true, api: true, viewer: false, vscode: true },
+      availability: { cli: true, mcp: false, api: true, viewer: false, vscode: true },
       docs: {
         examples: [
           'zeus investigate --program MYPROG --goal "understand orders" --search "customer"',

--- a/src/docs/toolCatalogGenerator.js
+++ b/src/docs/toolCatalogGenerator.js
@@ -14,12 +14,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 const {
   buildCatalogModel,
+  extractCliRoutes,
+  formatOutputLabel,
   generateToolCatalog,
+  renderJson,
   renderMarkdown,
+  resolveGeneratedAt,
+  validateCatalogMetadata,
+  validateRenderedCatalog,
 } = require('../../cli/commands/generate-tool-catalog');
 
 module.exports = {
   buildCatalogModel,
+  extractCliRoutes,
+  formatOutputLabel,
   generateToolCatalog,
+  renderJson,
   renderMarkdown,
+  resolveGeneratedAt,
+  validateCatalogMetadata,
+  validateRenderedCatalog,
 };

--- a/src/docs/toolCatalogMetadata.js
+++ b/src/docs/toolCatalogMetadata.js
@@ -20,7 +20,7 @@ const COMMAND_METADATA = Object.freeze({
     example: 'node cli/zeus.js doctor --profile default --show-resolved',
   }),
   secret: Object.freeze({
-    safety: 'S0',
+    safety: 'S1',
     scope: 'Local',
     purpose:
       'Manage encrypted credentials (Secret Vault). Create key (init-key [--windows] for DPAPI on Windows), encrypt/decrypt values (enc:v1:...) for .env or profiles. Transparent decryption at runtime. Never store plaintext passwords. Supports migrate, check (with --warn-only), status.',
@@ -40,8 +40,8 @@ const COMMAND_METADATA = Object.freeze({
     example: 'node cli/zeus.js resources --profile dev --json',
   }),
   'discover-environment': Object.freeze({
-    safety: 'S0',
-    scope: 'Local',
+    safety: 'S2',
+    scope: 'IBM i read',
     purpose:
       'Read-only auto-discovery of libraries/source-files/members/tables + resource suggestion.',
     example: 'node cli/zeus.js discover-environment --profile dev --json',
@@ -84,10 +84,10 @@ const COMMAND_METADATA = Object.freeze({
       'node cli/zeus.js workflow run --profile default --preset onboarding --out ./output --dense full',
   }),
   investigate: Object.freeze({
-    safety: 'S0',
+    safety: 'S1',
     scope: 'Local',
     purpose:
-      'Start or resume a focused investigation session on top of existing analysis artifacts. Enables scoped, iterative deep-dives (focus, search, impact, generate-prompt) with persistent state. Designed for interactive use and MCP agents.',
+      'Start or resume a focused investigation session on top of existing analysis artifacts. Enables scoped, iterative deep-dives (focus, search, impact, generate-prompt) with persistent state through the CLI and in-process API.',
     example:
       'node cli/zeus.js investigate --program ORDERPGM --profile dev --goal "Focus on error paths" --focus "error paths" --search "dynamic sql" --generate-prompt',
   }),
@@ -153,7 +153,7 @@ const COMMAND_METADATA = Object.freeze({
     example: 'node cli/zeus.js joblog --profile default --severity ERROR --max-messages 100',
   }),
   'field-search': Object.freeze({
-    safety: 'S0/S2',
+    safety: 'S2',
     scope: 'Local + IBM i read',
     purpose: 'Find field/table usage in local sources and or remote members.',
     example:
@@ -190,6 +190,18 @@ const COMMAND_METADATA = Object.freeze({
     purpose: 'Render QA validations/checks to jira, markdown, or json.',
     example: 'node cli/zeus.js qa --input ./output/ORDERPGM --format markdown --strict STRICT',
   }),
+  trace: Object.freeze({
+    safety: 'S2',
+    scope: 'Local + IBM i read',
+    purpose: 'Trace data and value lineage across programs and tables.',
+    example: 'node cli/zeus.js trace --value 123 --start-table ORDERS --profile default',
+  }),
+  xref: Object.freeze({
+    safety: 'S2',
+    scope: 'Local + IBM i read',
+    purpose: 'Build a who-calls or who-uses cross-reference for programs and tables.',
+    example: 'node cli/zeus.js xref --program ORDERPGM --profile default',
+  }),
   'validate-rpg-sql': Object.freeze({
     safety: 'S1',
     scope: 'Local',
@@ -199,17 +211,11 @@ const COMMAND_METADATA = Object.freeze({
       'node cli/zeus.js validate-rpg-sql --source ./rpg_sources --program ORDERPGM --format markdown --out ./output',
   }),
   onboarding: Object.freeze({
-    safety: 'S0',
+    safety: 'S1',
     scope: 'Local',
     purpose:
       'Interactive zeus-onboarding-wizard. Guides through profile setup, doctor checks, source/object discovery, first fetch and analyze for a new IBM i system.',
     example: 'node cli/zeus.js onboarding',
-  }),
-  wizard: Object.freeze({
-    safety: 'S0',
-    scope: 'Local',
-    purpose: 'Alias for the zeus-onboarding-wizard.',
-    example: 'node cli/zeus.js wizard',
   }),
   'inspect-object': Object.freeze({
     safety: 'S2',
@@ -219,7 +225,7 @@ const COMMAND_METADATA = Object.freeze({
       'node cli/zeus.js inspect-object --profile default --lib APPLIB --name APP_TABLE_00 --type *FILE --journal',
   }),
   'test-run': Object.freeze({
-    safety: 'S2/S1',
+    safety: 'S2',
     scope: 'DB2 read + local',
     purpose: 'Capture before and after test snapshots plus rollback SQL text.',
     example:
@@ -287,19 +293,19 @@ const COMMAND_METADATA = Object.freeze({
     example:
       'node cli/zeus.js pui-edit --file ./display/DSPFILE.MBR --action plan --changes-file ./changes.json',
   }),
-  'docs:generate-catalog': Object.freeze({
-    safety: 'S0',
-    scope: 'Local read-only',
-    purpose:
-      'Regenerate docs/tool-catalog.md (and optional JSON projection) from the CLI command surface; also callable as `zeus docs generate-catalog`.',
-    example: 'node cli/zeus.js docs:generate-catalog',
-  }),
-  help: Object.freeze({
+  'pui-inspect': Object.freeze({
     safety: 'S0',
     scope: 'Local',
     purpose:
-      'Structured help for any command or overview of MCP-safe capabilities for AI agents. Returns purpose, safety, examples and agent guidance.',
-    example: 'node cli/zeus.js help --command analyze  (or via MCP zeus.help)',
+      'Inspect a local Profound UI display-file projection and optionally trace field bindings.',
+    example: 'node cli/zeus.js pui-inspect --file ./display/DSPFILE.MBR --json',
+  }),
+  'docs:generate-catalog': Object.freeze({
+    safety: 'S1',
+    scope: 'Local',
+    purpose:
+      'Regenerate docs/tool-catalog.md (and optional JSON projection) from the CLI command surface; also callable as `zeus docs generate-catalog`.',
+    example: 'node cli/zeus.js docs:generate-catalog',
   }),
   mcp: Object.freeze({
     safety: 'S0',
@@ -311,10 +317,340 @@ const COMMAND_METADATA = Object.freeze({
   }),
 });
 
+function catalogContract({ aliases, status, availability, sideEffects, capabilityId }) {
+  return Object.freeze({
+    aliases: Object.freeze([...aliases]),
+    status,
+    availability: Object.freeze({ ...availability }),
+    sideEffects: Object.freeze([...sideEffects]),
+    capabilityId,
+  });
+}
+
+const CLI_ONLY = Object.freeze({ cli: true, api: false, mcp: false });
+const CLI_API = Object.freeze({ cli: true, api: true, mcp: false });
+const CLI_MCP = Object.freeze({ cli: true, api: false, mcp: true });
+const ALL_PUBLIC_SURFACES = Object.freeze({ cli: true, api: true, mcp: true });
+
+// Authoritative public command projection. Generator output must never infer or
+// repair these contracts from runtime registries, help text, or file-system order.
+const COMMAND_CATALOG_CONTRACTS = Object.freeze({
+  doctor: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: [],
+    capabilityId: 'configure.doctor',
+  }),
+  secret: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_ONLY,
+    sideEffects: ['local-secret-write'],
+    capabilityId: null,
+  }),
+  profiles: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: [],
+    capabilityId: 'configure.profiles',
+  }),
+  resources: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: [],
+    capabilityId: 'configure.resources',
+  }),
+  'discover-environment': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['remote-read'],
+    capabilityId: 'configure.discover-environment',
+  }),
+  fetch: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['remote-read', 'local-artifact-write'],
+    capabilityId: null,
+  }),
+  'fetch-member': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['remote-read', 'local-artifact-write'],
+    capabilityId: null,
+  }),
+  analyze: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: 'analysis.analyze',
+  }),
+  workflow: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: 'analysis.workflow',
+  }),
+  'workflow run': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_ONLY,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: null,
+  }),
+  investigate: catalogContract({
+    aliases: ['investigation'],
+    status: 'stable',
+    availability: CLI_API,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: 'investigation.investigate',
+  }),
+  bundle: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: 'bundle.create',
+  }),
+  impact: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: 'investigation.impact',
+  }),
+  'assess-risk': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: 'investigation.assess-risk',
+  }),
+  'generate-test': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: 'investigation.generate-test',
+  }),
+  'generate-checklist': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: 'investigation.generate-checklist',
+  }),
+  'query-table': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['remote-read'],
+    capabilityId: null,
+  }),
+  'resolve-object': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['remote-read'],
+    capabilityId: null,
+  }),
+  'query-sql': catalogContract({
+    aliases: ['sql'],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['remote-read'],
+    capabilityId: null,
+  }),
+  joblog: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['remote-read'],
+    capabilityId: null,
+  }),
+  'field-search': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['local-read', 'remote-read'],
+    capabilityId: 'investigation.field-search',
+  }),
+  'search-source': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['local-read'],
+    capabilityId: 'investigation.search-source',
+  }),
+  'copy-to-workspace': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: null,
+  }),
+  diff: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['remote-read'],
+    capabilityId: null,
+  }),
+  serve: catalogContract({
+    aliases: [],
+    status: 'experimental',
+    availability: CLI_MCP,
+    sideEffects: ['local-listener'],
+    capabilityId: null,
+  }),
+  qa: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: ALL_PUBLIC_SURFACES,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: 'investigation.qa',
+  }),
+  trace: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_API,
+    sideEffects: ['local-read', 'remote-read'],
+    capabilityId: 'investigation.trace',
+  }),
+  xref: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_API,
+    sideEffects: ['local-read', 'remote-read'],
+    capabilityId: 'investigation.xref',
+  }),
+  'validate-rpg-sql': catalogContract({
+    aliases: ['validate-rpgsql'],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: null,
+  }),
+  onboarding: catalogContract({
+    aliases: ['wizard', 'onboard', 'zeus-onboarding-wizard'],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['local-config-write', 'remote-read'],
+    capabilityId: null,
+  }),
+  'inspect-object': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['remote-read'],
+    capabilityId: null,
+  }),
+  'test-run': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['remote-read', 'local-artifact-write'],
+    capabilityId: null,
+  }),
+  'write-sql': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['remote-write'],
+    capabilityId: null,
+  }),
+  upsert: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_ONLY,
+    sideEffects: ['remote-write'],
+    capabilityId: null,
+  }),
+  'upsert-sql': catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_ONLY,
+    sideEffects: ['remote-write'],
+    capabilityId: null,
+  }),
+  insert: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_ONLY,
+    sideEffects: ['remote-write'],
+    capabilityId: null,
+  }),
+  update: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_ONLY,
+    sideEffects: ['remote-write'],
+    capabilityId: null,
+  }),
+  delete: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_ONLY,
+    sideEffects: ['remote-write'],
+    capabilityId: null,
+  }),
+  analyses: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: null,
+  }),
+  bridge: catalogContract({
+    aliases: [],
+    status: 'experimental',
+    availability: CLI_MCP,
+    sideEffects: ['operator-gated'],
+    capabilityId: null,
+  }),
+  'pui-edit': catalogContract({
+    aliases: [],
+    status: 'experimental',
+    availability: CLI_MCP,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: null,
+  }),
+  'pui-inspect': catalogContract({
+    aliases: [],
+    status: 'experimental',
+    availability: CLI_MCP,
+    sideEffects: ['local-read'],
+    capabilityId: null,
+  }),
+  'docs:generate-catalog': catalogContract({
+    aliases: ['docs generate-catalog'],
+    status: 'stable',
+    availability: CLI_MCP,
+    sideEffects: ['local-artifact-write'],
+    capabilityId: null,
+  }),
+  mcp: catalogContract({
+    aliases: [],
+    status: 'stable',
+    availability: CLI_ONLY,
+    sideEffects: ['local-process-stdio'],
+    capabilityId: null,
+  }),
+});
+
 const COMMAND_ORDER = Object.freeze([
   'doctor',
+  'secret',
   'profiles',
-  'help',
+  'resources',
+  'discover-environment',
   'fetch',
   'fetch-member',
   'analyze',
@@ -331,6 +667,10 @@ const COMMAND_ORDER = Object.freeze([
   'query-sql',
   'joblog',
   'field-search',
+  'trace',
+  'xref',
+  'validate-rpg-sql',
+  'onboarding',
   'search-source',
   'copy-to-workspace',
   'diff',
@@ -347,6 +687,7 @@ const COMMAND_ORDER = Object.freeze([
   'analyses',
   'bridge',
   'pui-edit',
+  'pui-inspect',
   'docs:generate-catalog',
   'mcp',
 ]);
@@ -400,6 +741,7 @@ const RECOMMENDED_AI_SEQUENCE = Object.freeze([
 
 module.exports = {
   COMMAND_METADATA,
+  COMMAND_CATALOG_CONTRACTS,
   COMMAND_ORDER,
   SAFETY_LEVELS,
   MANDATORY_AI_RULES,

--- a/tests/capability-registry.test.js
+++ b/tests/capability-registry.test.js
@@ -94,7 +94,7 @@ test('investigation capability declares its local writes and actual public surfa
   const searchSource = capabilities.resolve('investigation.search-source');
   assert.ok(searchSource);
   assert.equal(searchSource.safety.level, 'S0');
-  assert.deepEqual(searchSource.safety.sideEffects, []);
+  assert.deepEqual(searchSource.safety.sideEffects, ['local-read']);
   assert.equal(searchSource.availability.mcp, true);
 
   const capability = capabilities.resolve('investigation.investigate');

--- a/tests/capability-registry.test.js
+++ b/tests/capability-registry.test.js
@@ -89,6 +89,23 @@ test('capability registry supports filtering', () => {
   assert.ok(listed.length >= 1);
 });
 
+test('investigation capability declares its local writes and actual public surfaces', () => {
+  const { capabilities } = require('../src/api/zeusApi');
+  const searchSource = capabilities.resolve('investigation.search-source');
+  assert.ok(searchSource);
+  assert.equal(searchSource.safety.level, 'S0');
+  assert.deepEqual(searchSource.safety.sideEffects, []);
+  assert.equal(searchSource.availability.mcp, true);
+
+  const capability = capabilities.resolve('investigation.investigate');
+  assert.ok(capability);
+  assert.equal(capability.safety.level, 'S1');
+  assert.deepEqual(capability.safety.sideEffects, ['local-artifact-write']);
+  assert.equal(capability.availability.cli, true);
+  assert.equal(capability.availability.api, true);
+  assert.equal(capability.availability.mcp, false);
+});
+
 test('capability registry can be sealed', () => {
   const reg = createCapabilityRegistry();
   reg.seal();

--- a/tests/mcp-server.test.js
+++ b/tests/mcp-server.test.js
@@ -850,20 +850,18 @@ test('mcp tools call docs-generate-catalog writes bounded outputs and returns de
   fs.mkdirSync(path.join(tempRoot, 'cli', 'commands'), { recursive: true });
   fs.mkdirSync(path.join(tempRoot, 'src', 'docs'), { recursive: true });
   fs.mkdirSync(path.join(tempRoot, 'src', 'workflow'), { recursive: true });
-  fs.writeFileSync(
-    path.join(tempRoot, 'cli', 'zeus.js'),
-    `
-const command = process.argv[2];
-if (command === 'doctor') {}
-if (command === 'docs:generate-catalog') {}
-console.log('  zeus doctor --profile default');
-console.log('  zeus docs:generate-catalog');
-`,
-    'utf8'
+  fs.copyFileSync(
+    path.resolve(__dirname, '..', 'cli', 'zeus.js'),
+    path.join(tempRoot, 'cli', 'zeus.js')
   );
   fs.writeFileSync(
     path.join(tempRoot, 'package.json'),
-    `${JSON.stringify({ version: '9.9.9-test' }, null, 2)}\n`,
+    `${JSON.stringify({ name: 'zeus-test-export', version: '9.9.9-test' }, null, 2)}\n`,
+    'utf8'
+  );
+  fs.writeFileSync(
+    path.join(tempRoot, 'CHANGELOG.md'),
+    '# Changelog\n\n## [9.9.9-test] - 2026-07-16\n',
     'utf8'
   );
 

--- a/tests/tool-catalog-generator.test.js
+++ b/tests/tool-catalog-generator.test.js
@@ -32,7 +32,7 @@ function sha256(content) {
 function makeExportFixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-tool-catalog-export-'));
   fs.mkdirSync(path.join(root, 'cli'), { recursive: true });
-  for (const relativePath of ['package.json', 'CHANGELOG.md', 'cli/zeus.js']) {
+  for (const relativePath of ['.gitattributes', 'package.json', 'CHANGELOG.md', 'cli/zeus.js']) {
     fs.copyFileSync(path.join(projectRoot, relativePath), path.join(root, relativePath));
   }
   return root;
@@ -176,6 +176,13 @@ test('generation works in an exported tree without Git metadata', () => {
     const model = buildCatalogModel({ repoRoot: root, env: {} });
     assert.equal(model.generatedAt, '2026-07-12T00:00:00.000Z');
     assert.equal(model.commandRows.length, COMMAND_ORDER.length);
+    const attributes = new Set(
+      fs.readFileSync(path.join(root, '.gitattributes'), 'utf8').split(/\r?\n/).filter(Boolean)
+    );
+    assert.ok(attributes.has('docs/tool-catalog.md text eol=lf'));
+    assert.ok(attributes.has('docs/tool-catalog.json text eol=lf'));
+    assert.doesNotMatch(renderMarkdown(model), /\r/);
+    assert.doesNotMatch(renderJson(model), /\r/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/tests/tool-catalog-generator.test.js
+++ b/tests/tool-catalog-generator.test.js
@@ -67,6 +67,31 @@ test('catalog model is deterministic and preserves the public command contracts'
   }
 });
 
+test('catalog capability projections exactly match runtime descriptors', () => {
+  const { capabilities } = require('../src/api/zeusApi');
+  const model = buildCatalogModel({ repoRoot: projectRoot, env: {} });
+
+  for (const row of model.commandRows.filter(entry => entry.capabilityId !== null)) {
+    const descriptor = capabilities.resolve(row.capabilityId);
+    assert.ok(descriptor, `missing runtime capability ${row.capabilityId}`);
+    assert.equal(descriptor.safety.level, row.safety, `${row.command} safety mismatch`);
+    assert.deepEqual(
+      descriptor.safety.sideEffects,
+      row.sideEffects,
+      `${row.command} side-effects mismatch`
+    );
+    assert.deepEqual(
+      {
+        cli: descriptor.availability.cli,
+        api: descriptor.availability.api,
+        mcp: descriptor.availability.mcp,
+      },
+      row.availability,
+      `${row.command} availability mismatch`
+    );
+  }
+});
+
 test('SOURCE_DATE_EPOCH is strict, deterministic, and independent from the local clock', () => {
   assert.equal(
     resolveGeneratedAt(projectRoot, { SOURCE_DATE_EPOCH: '0' }),

--- a/tests/tool-catalog-generator.test.js
+++ b/tests/tool-catalog-generator.test.js
@@ -1,25 +1,293 @@
+'use strict';
+
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { buildCatalogModel, renderMarkdown } = require('../src/docs/toolCatalogGenerator');
+const { spawnSync } = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  buildCatalogModel,
+  formatOutputLabel,
+  generateToolCatalog,
+  renderJson,
+  renderMarkdown,
+  resolveGeneratedAt,
+  validateCatalogMetadata,
+  validateRenderedCatalog,
+} = require('../src/docs/toolCatalogGenerator');
+const {
+  COMMAND_METADATA,
+  COMMAND_CATALOG_CONTRACTS,
+  COMMAND_ORDER,
+} = require('../src/docs/toolCatalogMetadata');
 
-const projectRoot = require('path').resolve(__dirname, '..');
+const projectRoot = path.resolve(__dirname, '..');
 
-test('tool catalog model includes docs generator command with S0 safety', () => {
-  const model = buildCatalogModel({ repoRoot: projectRoot });
-  const row = model.commandRows.find(entry => entry.command === 'docs:generate-catalog');
-  assert.ok(row, 'docs:generate-catalog row should exist');
-  assert.equal(row.safety, 'S0');
-  assert.match(row.purpose, /Regenerate docs\/tool-catalog\.md/i);
+function sha256(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function makeExportFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-tool-catalog-export-'));
+  fs.mkdirSync(path.join(root, 'cli'), { recursive: true });
+  for (const relativePath of ['package.json', 'CHANGELOG.md', 'cli/zeus.js']) {
+    fs.copyFileSync(path.join(projectRoot, relativePath), path.join(root, relativePath));
+  }
+  return root;
+}
+
+test('catalog model is deterministic and preserves the public command contracts', () => {
+  const first = buildCatalogModel({ repoRoot: projectRoot, env: {} });
+  const second = buildCatalogModel({ repoRoot: projectRoot, env: {} });
+  assert.deepEqual(first, second);
+  assert.equal(first.generatedAt, '2026-07-12T00:00:00.000Z');
+  assert.deepEqual(first.package, { name: 'zeus-rpg-promptkit', version: '0.2.0-beta.2' });
+
+  const investigate = first.commandRows.find(entry => entry.command === 'investigate');
+  assert.deepEqual(investigate.aliases, ['investigation']);
+  assert.equal(investigate.safety, 'S1');
+  assert.deepEqual(investigate.sideEffects, ['local-artifact-write']);
+  assert.equal(investigate.capabilityId, 'investigation.investigate');
+
+  const querySql = first.commandRows.find(entry => entry.command === 'query-sql');
+  assert.deepEqual(querySql.aliases, ['sql']);
+  assert.equal(querySql.safety, 'S2');
+  assert.equal(
+    first.commandRows.some(entry => entry.command === 'help'),
+    false
+  );
+  assert.ok(first.commandRows.every(entry => entry.availability.cli === true));
+  for (const command of ['validate-rpg-sql', 'onboarding', 'trace', 'xref', 'pui-inspect']) {
+    assert.ok(
+      first.commandRows.some(entry => entry.command === command),
+      `missing ${command}`
+    );
+  }
 });
 
-test('tool catalog markdown contains auto-generated notice and required sections', () => {
-  const model = buildCatalogModel({ repoRoot: projectRoot });
-  const markdown = renderMarkdown(model, new Date('2026-05-17T08:55:42Z'));
+test('SOURCE_DATE_EPOCH is strict, deterministic, and independent from the local clock', () => {
+  assert.equal(
+    resolveGeneratedAt(projectRoot, { SOURCE_DATE_EPOCH: '0' }),
+    '1970-01-01T00:00:00.000Z'
+  );
+  assert.equal(
+    resolveGeneratedAt(projectRoot, { SOURCE_DATE_EPOCH: '1784160000' }),
+    '2026-07-16T00:00:00.000Z'
+  );
+  for (const invalid of ['', ' 0', '-1', '1.5', 'not-a-date']) {
+    assert.throws(
+      () => resolveGeneratedAt(projectRoot, { SOURCE_DATE_EPOCH: invalid }),
+      /SOURCE_DATE_EPOCH/
+    );
+  }
+});
 
-  assert.match(markdown, /AUTO-GENERATED FILE/);
-  assert.match(markdown, /Regenerate with: zeus docs:generate-catalog/);
-  assert.match(markdown, /Last generated: 2026-05-17 \d{2}:\d{2}:42/);
-  assert.match(markdown, /## Safety Levels/);
-  assert.match(markdown, /## CLI Command Catalog/);
-  assert.match(markdown, /\| `docs:generate-catalog` \| `S0` \|/);
+test('release-date fallback rejects calendar dates that JavaScript would normalize', () => {
+  const root = makeExportFixture();
+  try {
+    fs.writeFileSync(
+      path.join(root, 'CHANGELOG.md'),
+      '# Changelog\n\n## [0.2.0-beta.2] - 2026-02-30\n',
+      'utf8'
+    );
+    assert.throws(() => resolveGeneratedAt(root, {}), /invalid release date/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('CLI output labels never expose absolute local paths', () => {
+  assert.equal(
+    formatOutputLabel(projectRoot, path.join(projectRoot, 'docs', 'tool-catalog.md')),
+    'docs/tool-catalog.md'
+  );
+  assert.equal(
+    formatOutputLabel(projectRoot, path.join(os.tmpdir(), 'private-user', 'catalog.md')),
+    '<external-output>'
+  );
+
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-catalog-cli-output-'));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        'cli/zeus.js',
+        'docs:generate-catalog',
+        '--output',
+        path.join(root, 'catalog.md'),
+        '--json-output',
+        path.join(root, 'catalog.json'),
+      ],
+      { cwd: projectRoot, encoding: 'utf8' }
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Tool catalog markdown written to: <external-output>/);
+    assert.match(result.stdout, /Tool catalog json written to: <external-output>/);
+    assert.doesNotMatch(result.stdout, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.doesNotMatch(
+      result.stdout,
+      new RegExp(projectRoot.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('generation is byte-identical on repeat and matches committed Markdown and JSON', () => {
+  const root = makeExportFixture();
+  try {
+    const markdownPath = path.join(root, 'catalog.md');
+    const jsonPath = path.join(root, 'catalog.json');
+    generateToolCatalog({
+      repoRoot: root,
+      markdownOutputPath: markdownPath,
+      jsonOutputPath: jsonPath,
+      env: {},
+    });
+    const firstMarkdown = fs.readFileSync(markdownPath, 'utf8');
+    const firstJson = fs.readFileSync(jsonPath, 'utf8');
+    generateToolCatalog({
+      repoRoot: root,
+      markdownOutputPath: markdownPath,
+      jsonOutputPath: jsonPath,
+      env: {},
+    });
+    assert.equal(sha256(fs.readFileSync(markdownPath)), sha256(firstMarkdown));
+    assert.equal(sha256(fs.readFileSync(jsonPath)), sha256(firstJson));
+    assert.equal(
+      firstMarkdown,
+      fs.readFileSync(path.join(projectRoot, 'docs/tool-catalog.md'), 'utf8')
+    );
+    assert.equal(
+      firstJson,
+      fs.readFileSync(path.join(projectRoot, 'docs/tool-catalog.json'), 'utf8')
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('generation works in an exported tree without Git metadata', () => {
+  const root = makeExportFixture();
+  try {
+    assert.equal(fs.existsSync(path.join(root, '.git')), false);
+    const model = buildCatalogModel({ repoRoot: root, env: {} });
+    assert.equal(model.generatedAt, '2026-07-12T00:00:00.000Z');
+    assert.equal(model.commandRows.length, COMMAND_ORDER.length);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('metadata validation is stable across object registration order and fails closed on drift', () => {
+  const cliSource = fs.readFileSync(path.join(projectRoot, 'cli/zeus.js'), 'utf8');
+  const reversedMetadata = Object.fromEntries(Object.entries(COMMAND_METADATA).reverse());
+  const reversedContracts = Object.fromEntries(Object.entries(COMMAND_CATALOG_CONTRACTS).reverse());
+  assert.equal(
+    validateCatalogMetadata({
+      metadata: reversedMetadata,
+      contracts: reversedContracts,
+      order: COMMAND_ORDER,
+      cliSource,
+    }),
+    true
+  );
+
+  const missing = { ...COMMAND_METADATA };
+  delete missing['query-sql'];
+  assert.throws(
+    () => validateCatalogMetadata({ metadata: missing, cliSource }),
+    /missing command metadata: query-sql/
+  );
+  assert.throws(
+    () => validateCatalogMetadata({ order: [...COMMAND_ORDER, COMMAND_ORDER[0]], cliSource }),
+    /duplicate command order entry/
+  );
+  assert.throws(
+    () =>
+      validateCatalogMetadata({ cliSource: `${cliSource}\nif (command === 'private-only') {}` }),
+    /implemented CLI route has no public catalog contract: private-only/
+  );
+  const withoutQuerySql = cliSource.replace(
+    /command === 'query-sql'/g,
+    "command === 'removed-query-sql'"
+  );
+  assert.throws(
+    () => validateCatalogMetadata({ cliSource: withoutQuerySql }),
+    /declared public CLI route is not implemented: query-sql/
+  );
+});
+
+test('metadata validation rejects duplicate aliases and incomplete required contracts', () => {
+  const cliSource = fs.readFileSync(path.join(projectRoot, 'cli/zeus.js'), 'utf8');
+  const duplicateAliasContracts = {
+    ...COMMAND_CATALOG_CONTRACTS,
+    'query-sql': { ...COMMAND_CATALOG_CONTRACTS['query-sql'], aliases: ['doctor'] },
+  };
+  assert.throws(
+    () => validateCatalogMetadata({ contracts: duplicateAliasContracts, cliSource }),
+    /duplicate public command name: doctor/
+  );
+  const mcpOnlyContract = {
+    ...COMMAND_CATALOG_CONTRACTS,
+    doctor: {
+      ...COMMAND_CATALOG_CONTRACTS.doctor,
+      availability: { ...COMMAND_CATALOG_CONTRACTS.doctor.availability, cli: false },
+    },
+  };
+  assert.throws(
+    () => validateCatalogMetadata({ contracts: mcpOnlyContract, cliSource }),
+    /doctor is not an implemented public CLI command/
+  );
+  const incompleteMetadata = {
+    ...COMMAND_METADATA,
+    doctor: { ...COMMAND_METADATA.doctor, purpose: '' },
+  };
+  assert.throws(
+    () => validateCatalogMetadata({ metadata: incompleteMetadata, cliSource }),
+    /doctor\.purpose must be a non-empty string/
+  );
+});
+
+test('Markdown and JSON are projections of one model and reject divergence or local paths', () => {
+  const model = buildCatalogModel({ repoRoot: projectRoot, env: {} });
+  const markdown = renderMarkdown(model);
+  const json = renderJson(model);
+  assert.equal(validateRenderedCatalog(model, markdown, json), true);
+  const commandTable = markdown.split('## CLI Command Catalog')[1].split('## Workflow Presets')[0];
+  assert.deepEqual(
+    [...commandTable.matchAll(/^\| `([^`]+)` \|/gm)].map(match => match[1]),
+    model.commandRows.map(entry => entry.command)
+  );
+  assert.throws(
+    () =>
+      validateRenderedCatalog(model, markdown.replace('| `investigate` |', '| `omitted` |'), json),
+    /missing command: investigate/
+  );
+  assert.throws(
+    () => validateRenderedCatalog(model, `${markdown}\n/home/example/private.txt`, json),
+    /forbidden local metadata/
+  );
+  assert.doesNotMatch(json, /(?:password|token|api[_-]?key)\s*[=:]\s*[^,}\s]+/i);
+});
+
+test('generator rejects colliding output targets before writing', () => {
+  const root = makeExportFixture();
+  try {
+    assert.throws(
+      () =>
+        generateToolCatalog({
+          repoRoot: root,
+          markdownOutputPath: 'same-output',
+          jsonOutputPath: './same-output',
+          env: {},
+        }),
+      /must be different/
+    );
+    assert.equal(fs.existsSync(path.join(root, 'same-output')), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
- derive catalog timestamps deterministically from SOURCE_DATE_EPOCH or the package release date
- define and validate the public CLI catalog contract against implemented routes
- keep Markdown and JSON projections byte-stable and complete, including investigate and query-sql
- correct investigate safety and availability metadata

## Validation
- full required local validation matrix passed
- generator executed twice with identical Markdown and JSON hashes
- exact commit reproduced from a git archive without Git metadata
- six required negative mutations failed closed and were fully reverted

This baseline correction is separate from Iteration 27 and contains no provider contracts.