### PR TITLE
feat(provider): add opt-in local model adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Damit beantwortet Zeus Fragen wie:
 
 Zeus ist KI-anbieterneutral. Die erzeugten Artefakte können in klassischen Reviews oder mit ChatGPT, GitHub Copilot, Claude, lokalen Modellen und anderen Werkzeugen verwendet werden.
 
+Die Programmatic API enthält zusätzlich opt-in Adapter für lokale/private Modell-Endpunkte
+(derzeit Ollama sowie OpenAI-kompatible private/vLLM-artige HTTP-Endpunkte). Sie bleiben
+außerhalb des Standardpfads deaktiviert, verwenden keine automatische Probe/Fallback-Logik und
+erzwingen Ziel-Guardrails wie Credential-Verbot in URLs, SSRF-Schutz, Redirect-Neuvalidierung,
+Timeout/Cancellation sowie standardmäßige Sperre für Public Internet.
+
 ## 🧱 Wie Zeus arbeitet
 
 ```mermaid
@@ -510,10 +516,12 @@ const policy = providers.policy.createEgressPolicy([
 
 Ohne Registrierung arbeitet Zeus unverändert weiter. Jede Verarbeitung – auch lokal – benötigt
 eine genaue Klassifikations-/Trust-Zone-Regel; `secret` wird immer abgelehnt. Providerantworten sind
-nur beratend und niemals Evidenz oder Source of Truth. Diese Version enthält keine reale Modell-
-oder Netzwerk-Integration, keine automatische Auswahl oder Prüfung und keine kommerzielle
-Providerverwaltung. `providers.testing` enthält ausschließlich deterministische Offline-Doubles
-für Vertrags- und Integrationstests. Architektur und API-Grenzen: [`ADR-007`](docs/architecture/adr-007-provider-neutral-contracts.md).
+nur beratend und niemals Evidenz oder Source of Truth. Reale lokale/private HTTP-Adapter stehen
+zusätzlich unter `providers.adapters` opt-in bereit; sie verbinden sich nur bei expliziter
+Registrierung und Invocation, nie automatisch. Es gibt weiterhin keine automatische Auswahl,
+keine automatische Probe/Fallback-Logik und keine kommerzielle Providerverwaltung.
+`providers.testing` enthält ausschließlich deterministische Offline-Doubles für Vertrags- und
+Integrationstests. Architektur und API-Grenzen: [`ADR-007`](docs/architecture/adr-007-provider-neutral-contracts.md).
 
 Die Knowledge API bleibt absichtlich deaktiviert, bis ein finaler, projektneutraler Katalog alle Privacy-Gates bestanden hat.
 
@@ -1100,10 +1108,11 @@ const policy = providers.policy.createEgressPolicy([
 
 Zeus continues to work unchanged without registration. Every processing operation, including local
 processing, needs an exact classification/trust-zone rule; `secret` is always denied. Provider
-responses are advisory only and are never evidence or a source of truth. This version includes no
-real model or network integration, automatic selection or probing, or commercial provider
-management. `providers.testing` contains deterministic offline doubles exclusively for contract and
-integration tests. Architecture and API boundary: [`ADR-007`](docs/architecture/adr-007-provider-neutral-contracts.md).
+responses are advisory only and are never evidence or a source of truth. Real local/private HTTP
+adapters are additionally exposed under `providers.adapters`, but they remain strictly opt-in:
+no automatic registration, selection, probing, fallback, or commercial provider management.
+`providers.testing` contains deterministic offline doubles exclusively for contract and integration
+tests. Architecture and API boundary: [`ADR-007`](docs/architecture/adr-007-provider-neutral-contracts.md).
 
 The Knowledge API intentionally remains disabled until a final project-neutral catalog has passed all privacy gates.
 

--- a/docs/architecture/adr-007-provider-neutral-contracts.md
+++ b/docs/architecture/adr-007-provider-neutral-contracts.md
@@ -1,7 +1,7 @@
 ---
 Title: ADR-007 Provider-Neutral AI Contracts
 Description: Versioned offline provider contracts, explicit trusted registration, private-by-default egress policy, redaction, and optional test doubles.
-Last Updated: 2026-07-16
+Last Updated: 2026-07-17
 ---
 
 # ADR-007: Provider-Neutral AI Contracts
@@ -129,9 +129,27 @@ functionality under Apache-2.0. No commercial provider management, central organ
 Fleet Health, audit/team workflow, generation assurance, repair, model comparison, Db2 Test
 Intelligence, entitlement, deployment, telemetry, or hidden premium implementation is included.
 
+## Opt-in local/private adapters
+
+Version 1 may include additive opt-in adapters above the existing registry and contracts as long as
+they preserve the same public invocation boundary. Local/private HTTP adapters are registration-time
+helpers only; they do not widen the provider request contract, egress-policy contract, or registry
+API shape. Destination policy remains trusted adapter/transport configuration rather than
+user-supplied invocation data.
+
+Allowed adapter behavior:
+
+- explicit registration only; never automatic discovery, probing, fallback, download, or polling;
+- explicit health/capability checks only, never run automatically, and never send source/evidence;
+- private-by-default network transport with URL credential rejection, auth redaction, DNS/IP
+  validation, SSRF guards for metadata/link-local/disallowed targets, redirect revalidation,
+  bounded response size, timeout/cancellation support, and normal TLS verification;
+- public internet denied by default; loopback or private-network destinations require explicit
+  adapter policy opt-in.
+
 ## Non-goals
 
-- no Ollama, vLLM, OpenAI-compatible, cloud, or internet adapter;
+- no cloud SDKs or public-internet-by-default adapters;
 - no model discovery, download, automatic selection, fallback, or polling;
 - no required embedding or vector retrieval path;
 - no AI-generated code change or repair loop;

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -36,7 +36,7 @@ All subsequent implementation and agent guidance must be consistent with these d
 - External modules and capabilities must follow the open-core ownership, explicit registration,
   compatibility, failure-isolation, and artifact-portability rules in ADR-006.
 - Optional AI adapters must follow the versioned contracts, explicit provider identity,
-  private-by-default policy, redaction, and evidence-separation rules in ADR-007.
+  private-by-default transport policy, redaction, and evidence-separation rules in ADR-007.
 
 ## Regenerating Supporting Artifacts
 

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -16,6 +16,7 @@ module.exports = {
       'tests/task-oriented-analysis-index.test.js',
       'tests/tool-catalog-generator.test.js',
       'tests/provider-contracts.test.js',
+      'tests/provider-local-adapters.test.js',
       'tests/workflow-presets.test.js',
     ],
     smoke: [

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -20,6 +20,7 @@ const { createProviderRegistry } = require('../providers/providerRegistry');
 const providerPolicy = require('../providers/egressPolicy');
 const providerRedaction = require('../providers/redaction');
 const providerTesting = require('../providers/testing');
+const providerAdapters = require('../providers/adapters');
 const { executeQueryTable } = require('../core/queryService');
 const {
   executeListRuns,
@@ -117,6 +118,7 @@ function createProviderNamespace() {
     policy: providerPolicy,
     redaction: providerRedaction,
     testing: providerTesting,
+    adapters: providerAdapters,
   });
 }
 const providers = createProviderNamespace();

--- a/src/providers/adapters/index.js
+++ b/src/providers/adapters/index.js
@@ -1,0 +1,18 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*/
+'use strict';
+
+const { createPrivateHttpJsonTransport } = require('./privateHttpTransport');
+const { createOllamaModelAdapter } = require('./ollama');
+const { createOpenAICompatibleModelAdapter } = require('./openaiCompatible');
+
+module.exports = Object.freeze({
+  createPrivateHttpJsonTransport,
+  createOllamaModelAdapter,
+  createOpenAICompatibleModelAdapter,
+});

--- a/src/providers/adapters/ollama.js
+++ b/src/providers/adapters/ollama.js
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*/
+'use strict';
+
+const { createPrivateHttpJsonTransport } = require('./privateHttpTransport');
+const { baseDescriptor, baseResponse, requestPrompt } = require('./shared');
+
+function normalizeModels(models) {
+  if (
+    !Array.isArray(models) ||
+    models.length === 0 ||
+    models.some(model => typeof model !== 'string')
+  ) {
+    throw new Error('adapter models are required');
+  }
+  return [...new Set(models)].sort();
+}
+
+function createOllamaModelAdapter({
+  id = 'local.ollama',
+  displayName = 'Ollama (local/private opt-in)',
+  modelId,
+  models = modelId ? [modelId] : undefined,
+  endpoint = 'http://127.0.0.1:11434',
+  destinationPolicy = { allowLoopback: true },
+  configProvenance,
+  maxResponseBytes,
+  timeoutMs,
+} = {}) {
+  const declaredModels = normalizeModels(models);
+  const transport = createPrivateHttpJsonTransport({
+    endpoint,
+    destinationPolicy,
+    maxResponseBytes,
+    timeoutMs,
+  });
+  const descriptor = {
+    ...baseDescriptor(
+      'model',
+      id,
+      displayName,
+      destinationPolicy.allowLoopback ? 'local' : 'private-network',
+      ['local-http', 'opt-in', 'structured-output']
+    ),
+    models: declaredModels,
+  };
+
+  async function invoke(context, request) {
+    const response = await transport.requestJson({
+      method: 'POST',
+      path: '/api/generate',
+      signal: context.signal,
+      body: {
+        model: request.modelId,
+        prompt: requestPrompt(request.input.content),
+        stream: false,
+      },
+    });
+    const body = response.body || {};
+    const message = typeof body.response === 'string' ? body.response : '';
+    return baseResponse(
+      'model',
+      request,
+      {
+        message,
+        done: body.done === true,
+        finishReason: typeof body.done_reason === 'string' ? body.done_reason : null,
+      },
+      {
+        inputUnits: Number.isInteger(body.prompt_eval_count) ? body.prompt_eval_count : 0,
+        outputUnits: Number.isInteger(body.eval_count) ? body.eval_count : 0,
+        totalUnits:
+          (Number.isInteger(body.prompt_eval_count) ? body.prompt_eval_count : 0) +
+          (Number.isInteger(body.eval_count) ? body.eval_count : 0),
+      }
+    );
+  }
+
+  async function listRemoteModels({ signal } = {}) {
+    const response = await transport.requestJson({ method: 'GET', path: '/api/tags', signal });
+    const models = Array.isArray(response.body && response.body.models)
+      ? response.body.models
+          .map(model => model && (model.model || model.name))
+          .filter(value => typeof value === 'string')
+          .sort()
+      : [];
+    return Object.freeze({ ok: true, models });
+  }
+
+  async function checkHealth({ signal } = {}) {
+    const result = await listRemoteModels({ signal });
+    return Object.freeze({
+      ok: true,
+      status: result.models.length >= 0 ? 'healthy' : 'unknown',
+      modelCount: result.models.length,
+    });
+  }
+
+  return Object.freeze({
+    descriptor: Object.freeze(descriptor),
+    registration: Object.freeze({
+      descriptor: Object.freeze(descriptor),
+      invoke,
+      ...(configProvenance ? { configProvenance } : {}),
+    }),
+    invoke,
+    listRemoteModels,
+    checkHealth,
+  });
+}
+
+module.exports = { createOllamaModelAdapter };

--- a/src/providers/adapters/openaiCompatible.js
+++ b/src/providers/adapters/openaiCompatible.js
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*/
+'use strict';
+
+const { createPrivateHttpJsonTransport } = require('./privateHttpTransport');
+const { baseDescriptor, baseResponse, requestPrompt } = require('./shared');
+
+function normalizeModels(models) {
+  if (
+    !Array.isArray(models) ||
+    models.length === 0 ||
+    models.some(model => typeof model !== 'string')
+  ) {
+    throw new Error('adapter models are required');
+  }
+  return [...new Set(models)].sort();
+}
+
+function authorizationHeaders(apiKey) {
+  if (apiKey === undefined) return {};
+  if (typeof apiKey !== 'string' || !apiKey.trim()) {
+    throw new Error('adapter apiKey is invalid');
+  }
+  return { authorization: `Bearer ${apiKey}` };
+}
+
+function trustZoneForPolicy(destinationPolicy) {
+  if (destinationPolicy.allowLoopback) return 'local';
+  return 'private-network';
+}
+
+function createOpenAICompatibleModelAdapter({
+  id = 'private.openai-compatible',
+  displayName = 'OpenAI-compatible local/private endpoint (opt-in)',
+  modelId,
+  models = modelId ? [modelId] : undefined,
+  endpoint,
+  apiKey,
+  destinationPolicy = { allowPrivate: true },
+  configProvenance,
+  maxResponseBytes,
+  timeoutMs,
+} = {}) {
+  const declaredModels = normalizeModels(models);
+  const transport = createPrivateHttpJsonTransport({
+    endpoint,
+    destinationPolicy,
+    maxResponseBytes,
+    timeoutMs,
+    headers: authorizationHeaders(apiKey),
+  });
+  const descriptor = {
+    ...baseDescriptor('model', id, displayName, trustZoneForPolicy(destinationPolicy), [
+      'local-http',
+      'openai-compatible',
+      'structured-output',
+    ]),
+    models: declaredModels,
+  };
+
+  async function invoke(context, request) {
+    const response = await transport.requestJson({
+      method: 'POST',
+      path: '/v1/chat/completions',
+      signal: context.signal,
+      body: {
+        model: request.modelId,
+        stream: false,
+        messages: [{ role: 'user', content: requestPrompt(request.input.content) }],
+      },
+    });
+    const body = response.body || {};
+    const choice =
+      Array.isArray(body.choices) && body.choices.length > 0 && body.choices[0]
+        ? body.choices[0]
+        : {};
+    const message =
+      choice && choice.message && typeof choice.message.content === 'string'
+        ? choice.message.content
+        : '';
+    const usage = body.usage || {};
+    return baseResponse(
+      'model',
+      request,
+      {
+        message,
+        finishReason: typeof choice.finish_reason === 'string' ? choice.finish_reason : null,
+      },
+      {
+        inputUnits: Number.isInteger(usage.prompt_tokens) ? usage.prompt_tokens : 0,
+        outputUnits: Number.isInteger(usage.completion_tokens) ? usage.completion_tokens : 0,
+        totalUnits: Number.isInteger(usage.total_tokens)
+          ? usage.total_tokens
+          : (Number.isInteger(usage.prompt_tokens) ? usage.prompt_tokens : 0) +
+            (Number.isInteger(usage.completion_tokens) ? usage.completion_tokens : 0),
+      }
+    );
+  }
+
+  async function listRemoteModels({ signal } = {}) {
+    const response = await transport.requestJson({ method: 'GET', path: '/v1/models', signal });
+    const models = Array.isArray(response.body && response.body.data)
+      ? response.body.data
+          .map(model => model && model.id)
+          .filter(value => typeof value === 'string')
+          .sort()
+      : [];
+    return Object.freeze({ ok: true, models });
+  }
+
+  async function checkHealth({ signal } = {}) {
+    const result = await listRemoteModels({ signal });
+    return Object.freeze({
+      ok: true,
+      status: 'healthy',
+      modelCount: result.models.length,
+    });
+  }
+
+  return Object.freeze({
+    descriptor: Object.freeze(descriptor),
+    registration: Object.freeze({
+      descriptor: Object.freeze(descriptor),
+      invoke,
+      ...(configProvenance ? { configProvenance } : {}),
+    }),
+    invoke,
+    listRemoteModels,
+    checkHealth,
+  });
+}
+
+module.exports = { createOpenAICompatibleModelAdapter };

--- a/src/providers/adapters/privateHttpTransport.js
+++ b/src/providers/adapters/privateHttpTransport.js
@@ -1,0 +1,379 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*/
+'use strict';
+
+const http = require('node:http');
+const https = require('node:https');
+const dns = require('node:dns');
+const net = require('node:net');
+
+const MAX_RESPONSE_BYTES = 128 * 1024;
+const MAX_REDIRECTS = 2;
+const DEFAULT_TIMEOUT_MS = 5000;
+const METADATA_HOST_PATTERNS = [
+  /^metadata$/i,
+  /^metadata\./i,
+  /^metadata\.google\.internal$/i,
+  /^169\.254\.169\.254$/,
+];
+
+function fixedError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function parseEndpoint(endpoint) {
+  let url;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    throw fixedError('TRANSPORT_CONFIG_INVALID', 'adapter endpoint is invalid');
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw fixedError('TRANSPORT_CONFIG_INVALID', 'adapter endpoint protocol is unsupported');
+  }
+  if (url.username || url.password) {
+    throw fixedError('TRANSPORT_CONFIG_INVALID', 'adapter endpoint credentials are not allowed');
+  }
+  if (!url.hostname) {
+    throw fixedError('TRANSPORT_CONFIG_INVALID', 'adapter endpoint host is required');
+  }
+  return url;
+}
+
+function normalizeHeaders(headers) {
+  if (!headers) return Object.freeze({});
+  if (typeof headers !== 'object' || Array.isArray(headers)) {
+    throw fixedError('TRANSPORT_CONFIG_INVALID', 'adapter headers are invalid');
+  }
+  const normalized = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value !== 'string' || !key || /[\r\n]/.test(key) || /[\r\n]/.test(value)) {
+      throw fixedError('TRANSPORT_CONFIG_INVALID', 'adapter headers are invalid');
+    }
+    normalized[key] = value;
+  }
+  return Object.freeze(normalized);
+}
+
+function normalizeDestinationPolicy(policy = {}) {
+  if (!policy || typeof policy !== 'object' || Array.isArray(policy)) {
+    throw fixedError('TRANSPORT_CONFIG_INVALID', 'destination policy is invalid');
+  }
+  return Object.freeze({
+    allowLoopback: policy.allowLoopback === true,
+    allowPrivate: policy.allowPrivate === true,
+    allowPublic: policy.allowPublic === true,
+  });
+}
+
+function isMetadataHostname(hostname) {
+  return METADATA_HOST_PATTERNS.some(pattern => pattern.test(hostname));
+}
+
+function classifyIpv4(address) {
+  const parts = address.split('.').map(part => Number.parseInt(part, 10));
+  if (
+    parts.length !== 4 ||
+    parts.some(value => !Number.isInteger(value) || value < 0 || value > 255)
+  )
+    return 'invalid';
+  const [a, b] = parts;
+  if (a === 127) return 'loopback';
+  if (a === 10) return 'private';
+  if (a === 172 && b >= 16 && b <= 31) return 'private';
+  if (a === 192 && b === 168) return 'private';
+  if (a === 169 && b === 254) return 'link-local';
+  if (a === 0 || a >= 224) return 'disallowed';
+  return 'public';
+}
+
+function classifyIpv6(address) {
+  const normalized = address.toLowerCase();
+  if (normalized === '::1') return 'loopback';
+  if (
+    normalized.startsWith('fe8') ||
+    normalized.startsWith('fe9') ||
+    normalized.startsWith('fea') ||
+    normalized.startsWith('feb')
+  ) {
+    return 'link-local';
+  }
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) return 'private';
+  if (normalized === '::' || normalized.startsWith('ff')) return 'disallowed';
+  return 'public';
+}
+
+function classifyAddress(address) {
+  const family = net.isIP(address);
+  if (family === 4) return classifyIpv4(address);
+  if (family === 6) return classifyIpv6(address);
+  return 'invalid';
+}
+
+function assertAddressAllowed(address, policy) {
+  const classification = classifyAddress(address);
+  if (classification === 'loopback') {
+    if (!policy.allowLoopback) {
+      throw fixedError(
+        'TRANSPORT_DESTINATION_DENIED',
+        'loopback destinations require explicit opt-in'
+      );
+    }
+    return classification;
+  }
+  if (classification === 'private') {
+    if (!policy.allowPrivate) {
+      throw fixedError(
+        'TRANSPORT_DESTINATION_DENIED',
+        'private-network destinations require explicit opt-in'
+      );
+    }
+    return classification;
+  }
+  if (classification === 'public') {
+    if (!policy.allowPublic) {
+      throw fixedError(
+        'TRANSPORT_DESTINATION_DENIED',
+        'public internet destinations are denied by default'
+      );
+    }
+    return classification;
+  }
+  if (classification === 'link-local') {
+    throw fixedError(
+      'TRANSPORT_DESTINATION_DENIED',
+      'link-local and metadata destinations are denied'
+    );
+  }
+  throw fixedError('TRANSPORT_DESTINATION_DENIED', 'destination address is denied');
+}
+
+async function resolveDestination(url, policy) {
+  if (isMetadataHostname(url.hostname)) {
+    throw fixedError('TRANSPORT_DESTINATION_DENIED', 'metadata destinations are denied');
+  }
+  if (net.isIP(url.hostname)) {
+    return {
+      hostname: url.hostname,
+      family: net.isIP(url.hostname),
+      trustClass: assertAddressAllowed(url.hostname, policy),
+    };
+  }
+  let addresses;
+  try {
+    addresses = await dns.promises.lookup(url.hostname, { all: true, verbatim: true });
+  } catch {
+    throw fixedError('TRANSPORT_DNS_FAILED', 'destination name resolution failed');
+  }
+  if (!Array.isArray(addresses) || addresses.length === 0) {
+    throw fixedError('TRANSPORT_DNS_FAILED', 'destination name resolution failed');
+  }
+  let chosen = null;
+  for (const address of addresses) {
+    const trustClass = assertAddressAllowed(address.address, policy);
+    if (!chosen) {
+      chosen = { hostname: address.address, family: address.family, trustClass };
+    }
+  }
+  return chosen;
+}
+
+function buildRequestOptions(url, method, headers, resolvedAddress, signal) {
+  const isTls = url.protocol === 'https:';
+  return {
+    protocol: url.protocol,
+    hostname: url.hostname,
+    port: url.port || (isTls ? 443 : 80),
+    path: `${url.pathname}${url.search}`,
+    method,
+    headers,
+    signal,
+    lookup(hostname, options, callback) {
+      callback(null, resolvedAddress.hostname, resolvedAddress.family);
+    },
+    ...(isTls ? { servername: url.hostname } : {}),
+  };
+}
+
+function parseRedirect(baseUrl, location) {
+  let redirected;
+  try {
+    redirected = new URL(location, baseUrl);
+  } catch {
+    throw fixedError('TRANSPORT_REDIRECT_INVALID', 'redirect target is invalid');
+  }
+  if (redirected.username || redirected.password) {
+    throw fixedError('TRANSPORT_REDIRECT_INVALID', 'redirect target credentials are not allowed');
+  }
+  return redirected;
+}
+
+async function requestJson(options, state, redirectCount = 0) {
+  const {
+    endpoint,
+    defaultHeaders,
+    maxResponseBytes,
+    maxRedirects,
+    timeoutMs,
+    destinationPolicy,
+    body,
+    method,
+    path,
+    signal,
+  } = options;
+  const requestUrl = new URL(path, endpoint);
+  if (requestUrl.origin !== endpoint.origin) {
+    throw fixedError('TRANSPORT_CONFIG_INVALID', 'request path escaped the configured endpoint');
+  }
+  const resolvedAddress = await resolveDestination(requestUrl, destinationPolicy);
+  const bodyBuffer = body === undefined ? null : Buffer.from(JSON.stringify(body), 'utf8');
+  const headers = {
+    accept: 'application/json',
+    ...defaultHeaders,
+    ...(bodyBuffer
+      ? { 'content-type': 'application/json', 'content-length': String(bodyBuffer.length) }
+      : {}),
+  };
+  const requestOptions = buildRequestOptions(requestUrl, method, headers, resolvedAddress, signal);
+  const transport = requestUrl.protocol === 'https:' ? https : http;
+
+  const response = await new Promise((resolve, reject) => {
+    const req = transport.request(requestOptions, resolve);
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(fixedError('TRANSPORT_TIMEOUT', 'transport request timed out'));
+    });
+    req.on('error', error => {
+      if (error && (error.name === 'AbortError' || error.code === 'ABORT_ERR')) {
+        reject(fixedError('TRANSPORT_ABORTED', 'transport request was cancelled'));
+        return;
+      }
+      if (error && error.code === 'TRANSPORT_TIMEOUT') {
+        reject(error);
+        return;
+      }
+      reject(fixedError('TRANSPORT_REQUEST_FAILED', 'transport request failed'));
+    });
+    if (bodyBuffer) req.write(bodyBuffer);
+    req.end();
+  });
+
+  if ([301, 302, 303, 307, 308].includes(response.statusCode || 0)) {
+    response.resume();
+    if (redirectCount >= maxRedirects) {
+      throw fixedError('TRANSPORT_REDIRECT_LIMIT', 'redirect limit exceeded');
+    }
+    const location = response.headers.location;
+    if (typeof location !== 'string' || !location.trim()) {
+      throw fixedError('TRANSPORT_REDIRECT_INVALID', 'redirect target is invalid');
+    }
+    const redirected = parseRedirect(requestUrl, location);
+    return requestJson(
+      {
+        ...options,
+        endpoint: new URL(`${redirected.origin}${endpoint.pathname}`),
+        path: `${redirected.pathname}${redirected.search}`,
+        method: response.statusCode === 303 ? 'GET' : method,
+        body: response.statusCode === 303 ? undefined : body,
+      },
+      state,
+      redirectCount + 1
+    );
+  }
+
+  const chunks = [];
+  let bytes = 0;
+  await new Promise((resolve, reject) => {
+    response.on('data', chunk => {
+      bytes += chunk.length;
+      if (bytes > maxResponseBytes) {
+        response.destroy(fixedError('TRANSPORT_RESPONSE_LIMIT', 'response size limit exceeded'));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    response.on('end', resolve);
+    response.on('error', error => {
+      if (error && error.code === 'TRANSPORT_RESPONSE_LIMIT') {
+        reject(error);
+        return;
+      }
+      reject(fixedError('TRANSPORT_REQUEST_FAILED', 'transport request failed'));
+    });
+  });
+
+  const raw = Buffer.concat(chunks).toString('utf8');
+  let parsed = null;
+  if (raw.length) {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw fixedError('TRANSPORT_RESPONSE_INVALID', 'response body is not valid JSON');
+    }
+  }
+  if ((response.statusCode || 500) >= 400) {
+    const error = fixedError('TRANSPORT_HTTP_ERROR', 'transport returned an error status');
+    error.statusCode = response.statusCode;
+    throw error;
+  }
+  return {
+    statusCode: response.statusCode || 200,
+    headers: response.headers,
+    body: parsed,
+    trustClass: resolvedAddress.trustClass,
+  };
+}
+
+function createPrivateHttpJsonTransport({
+  endpoint,
+  headers,
+  destinationPolicy,
+  maxResponseBytes = MAX_RESPONSE_BYTES,
+  maxRedirects = MAX_REDIRECTS,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  const baseEndpoint = parseEndpoint(endpoint);
+  const defaultHeaders = normalizeHeaders(headers);
+  const normalizedPolicy = normalizeDestinationPolicy(destinationPolicy);
+  if (
+    !Number.isInteger(maxResponseBytes) ||
+    maxResponseBytes < 1 ||
+    maxResponseBytes > 1024 * 1024
+  ) {
+    throw fixedError('TRANSPORT_CONFIG_INVALID', 'response size limit is invalid');
+  }
+  if (!Number.isInteger(maxRedirects) || maxRedirects < 0 || maxRedirects > 5) {
+    throw fixedError('TRANSPORT_CONFIG_INVALID', 'redirect limit is invalid');
+  }
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 30000) {
+    throw fixedError('TRANSPORT_CONFIG_INVALID', 'timeout is invalid');
+  }
+  return Object.freeze({
+    endpoint: baseEndpoint.origin,
+    async requestJson({ method = 'GET', path = '/', body, signal } = {}) {
+      return requestJson(
+        {
+          endpoint: baseEndpoint,
+          defaultHeaders,
+          maxResponseBytes,
+          maxRedirects,
+          timeoutMs,
+          destinationPolicy: normalizedPolicy,
+          body,
+          method,
+          path,
+          signal,
+        },
+        {}
+      );
+    },
+  });
+}
+
+module.exports = { createPrivateHttpJsonTransport };

--- a/src/providers/adapters/shared.js
+++ b/src/providers/adapters/shared.js
@@ -1,0 +1,59 @@
+/*
+Copyright 2026 gzeuner - tiny-tool.de
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+*/
+'use strict';
+
+const { KIND_CONTRACTS, contractRef, descriptorRef } = require('../contracts');
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  return `{${Object.keys(value)
+    .sort()
+    .map(key => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+    .join(',')}}`;
+}
+
+function requestPrompt(content) {
+  if (typeof content === 'string') return content;
+  return canonicalJson(content);
+}
+
+function baseDescriptor(kind, id, displayName, trustZone, capabilities) {
+  const descriptorContract = KIND_CONTRACTS[kind].descriptor;
+  return Object.freeze({
+    schemaVersion: 1,
+    contract: contractRef(descriptorContract),
+    descriptorVersion: descriptorRef(descriptorContract),
+    kind,
+    id,
+    displayName,
+    trustZone,
+    capabilities,
+  });
+}
+
+function baseResponse(kind, request, output, usage) {
+  const response = {
+    schemaVersion: 1,
+    contract: contractRef(KIND_CONTRACTS[kind].response),
+    providerId: request.providerId,
+    correlationId: request.correlationId,
+    advisory: true,
+    sourceOfTruth: false,
+    evidenceReferences: request.evidenceReferences.map(reference => ({
+      id: reference.id,
+      contract: reference.contract,
+    })),
+    output,
+  };
+  if (kind === 'model' || kind === 'embedding') response.modelId = request.modelId;
+  if (usage) response.usage = usage;
+  return response;
+}
+
+module.exports = { baseDescriptor, baseResponse, canonicalJson, requestPrompt };

--- a/tests/provider-local-adapters.test.js
+++ b/tests/provider-local-adapters.test.js
@@ -1,0 +1,366 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+
+const { providers } = require('../src/api/zeusApi');
+const { contractRef, CONTRACTS } = providers.contracts;
+
+function request(providerId, modelId, overrides = {}) {
+  const classification = overrides.classification || 'public-metadata';
+  return {
+    schemaVersion: 1,
+    contract: contractRef(CONTRACTS.MODEL_REQUEST),
+    providerId,
+    correlationId: overrides.correlationId || 'local-adapter-1',
+    classification,
+    evidenceReferences: overrides.evidenceReferences || [],
+    input: {
+      classification,
+      content: overrides.input || { prompt: 'hello' },
+    },
+    modelId,
+    ...(overrides.maxOutputBytes ? { maxOutputBytes: overrides.maxOutputBytes } : {}),
+  };
+}
+
+function allow(zone = 'local') {
+  return providers.policy.createEgressPolicy([
+    { classification: 'public-metadata', trustZone: zone, allow: true },
+  ]);
+}
+
+async function withServer(routes, run) {
+  const calls = [];
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const bodyText = Buffer.concat(chunks).toString('utf8');
+    const body = bodyText ? JSON.parse(bodyText) : null;
+    calls.push({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body,
+    });
+    const handler = routes[`${req.method} ${req.url}`];
+    if (!handler) {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'missing route' }));
+      return;
+    }
+    const response = await handler({ req, body, calls });
+    res.writeHead(
+      response.statusCode || 200,
+      response.headers || { 'content-type': 'application/json' }
+    );
+    res.end(response.body === undefined ? '' : JSON.stringify(response.body));
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  try {
+    await run({
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      calls,
+    });
+  } finally {
+    await new Promise((resolve, reject) =>
+      server.close(error => (error ? reject(error) : resolve()))
+    );
+  }
+}
+
+test('ollama adapter is opt-in, does not auto-probe, and invokes through the registry', async () => {
+  await withServer(
+    {
+      'POST /api/generate': ({ body }) => ({
+        body: {
+          model: body.model,
+          response: `echo:${body.prompt}`,
+          done: true,
+          done_reason: 'stop',
+          prompt_eval_count: 4,
+          eval_count: 2,
+        },
+      }),
+      'GET /api/tags': () => ({
+        body: {
+          models: [{ model: 'llama3.1' }],
+        },
+      }),
+    },
+    async ({ baseUrl, calls }) => {
+      const adapter = providers.adapters.createOllamaModelAdapter({
+        id: 'local.ollama-test',
+        modelId: 'llama3.1',
+        endpoint: baseUrl,
+        destinationPolicy: { allowLoopback: true },
+      });
+      assert.equal(calls.length, 0);
+
+      const registry = providers.createRegistry();
+      registry.register(adapter.registration);
+      const result = await registry.invoke(
+        adapter.descriptor.id,
+        request(adapter.descriptor.id, 'llama3.1', { input: { z: 1, a: 'two' } }),
+        { policy: allow('local') }
+      );
+
+      assert.equal(result.ok, true);
+      assert.equal(result.response.output.message, 'echo:{"a":"two","z":1}');
+      assert.deepEqual(result.response.usage, { inputUnits: 4, outputUnits: 2, totalUnits: 6 });
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].url, '/api/generate');
+      assert.deepEqual(calls[0].body, {
+        model: 'llama3.1',
+        prompt: '{"a":"two","z":1}',
+        stream: false,
+      });
+
+      const health = await adapter.checkHealth();
+      assert.deepEqual(health, { ok: true, status: 'healthy', modelCount: 1 });
+      const capabilities = await adapter.listRemoteModels();
+      assert.deepEqual(capabilities, { ok: true, models: ['llama3.1'] });
+      assert.equal(calls.length, 3);
+      assert.equal(calls[1].url, '/api/tags');
+      assert.equal(calls[2].url, '/api/tags');
+    }
+  );
+});
+
+test('openai-compatible adapter sends only prompt content and uses explicit auth without leaking it', async () => {
+  await withServer(
+    {
+      'POST /v1/chat/completions': ({ body, req }) => ({
+        body: {
+          id: 'cmpl-1',
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              finish_reason: 'stop',
+              message: { role: 'assistant', content: `reply:${body.messages[0].content}` },
+            },
+          ],
+          usage: {
+            prompt_tokens: 7,
+            completion_tokens: 3,
+            total_tokens: 10,
+          },
+          authSeen: req.headers.authorization,
+        },
+      }),
+      'GET /v1/models': ({ req }) => ({
+        body: {
+          data: [{ id: 'private-vllm' }],
+          authSeen: req.headers.authorization,
+        },
+      }),
+    },
+    async ({ baseUrl, calls }) => {
+      const adapter = providers.adapters.createOpenAICompatibleModelAdapter({
+        id: 'private.vllm-test',
+        endpoint: baseUrl,
+        apiKey: 'top-secret-token',
+        models: ['private-vllm'],
+        destinationPolicy: { allowLoopback: true },
+      });
+      const registry = providers.createRegistry();
+      registry.register(adapter.registration);
+
+      const response = await registry.invoke(
+        adapter.descriptor.id,
+        request(adapter.descriptor.id, 'private-vllm', {
+          input: { source: 'SELECT * FROM ORDERS' },
+          evidenceReferences: [{ id: 'evidence-1', contract: 'zeus.evidence@1' }],
+        }),
+        { policy: allow('local') }
+      );
+      assert.equal(response.ok, true);
+      assert.equal(response.response.output.message, 'reply:{"source":"SELECT * FROM ORDERS"}');
+      assert.deepEqual(response.response.usage, {
+        inputUnits: 7,
+        outputUnits: 3,
+        totalUnits: 10,
+      });
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0].headers.authorization, 'Bearer top-secret-token');
+      assert.deepEqual(calls[0].body, {
+        model: 'private-vllm',
+        stream: false,
+        messages: [{ role: 'user', content: '{"source":"SELECT * FROM ORDERS"}' }],
+      });
+
+      const models = await adapter.listRemoteModels();
+      assert.deepEqual(models, { ok: true, models: ['private-vllm'] });
+      assert.equal(calls[1].headers.authorization, 'Bearer top-secret-token');
+    }
+  );
+});
+
+test('transport denies loopback, metadata, and public destinations unless explicitly allowed', async () => {
+  assert.throws(
+    () =>
+      providers.adapters.createOllamaModelAdapter({
+        endpoint: 'http://user:pass@127.0.0.1:11434',
+        modelId: 'llama3.1',
+      }),
+    /credentials are not allowed/
+  );
+
+  const deniedLoopback = providers.adapters.createOpenAICompatibleModelAdapter({
+    endpoint: 'http://127.0.0.1:9999',
+    models: ['private-vllm'],
+    destinationPolicy: {},
+  });
+  await assert.rejects(
+    () => deniedLoopback.checkHealth(),
+    error => {
+      assert.equal(error.code, 'TRANSPORT_DESTINATION_DENIED');
+      return true;
+    }
+  );
+
+  const deniedPublic = providers.adapters.createOpenAICompatibleModelAdapter({
+    endpoint: 'http://93.184.216.34:8080',
+    models: ['private-vllm'],
+    destinationPolicy: {},
+  });
+  await assert.rejects(
+    () => deniedPublic.checkHealth(),
+    error => {
+      assert.equal(error.code, 'TRANSPORT_DESTINATION_DENIED');
+      return true;
+    }
+  );
+
+  const deniedMetadata = providers.adapters.createOpenAICompatibleModelAdapter({
+    endpoint: 'http://169.254.169.254',
+    models: ['private-vllm'],
+    destinationPolicy: { allowPrivate: true },
+  });
+  await assert.rejects(
+    () => deniedMetadata.checkHealth(),
+    error => {
+      assert.equal(error.code, 'TRANSPORT_DESTINATION_DENIED');
+      return true;
+    }
+  );
+});
+
+test('redirects are revalidated and oversized responses fail closed', async () => {
+  await withServer(
+    {
+      'GET /v1/models': () => ({
+        statusCode: 302,
+        headers: { location: 'http://169.254.169.254/v1/models' },
+        body: { ignored: true },
+      }),
+    },
+    async ({ baseUrl }) => {
+      const adapter = providers.adapters.createOpenAICompatibleModelAdapter({
+        endpoint: baseUrl,
+        models: ['private-vllm'],
+        destinationPolicy: { allowLoopback: true },
+      });
+      await assert.rejects(
+        () => adapter.checkHealth(),
+        error => {
+          assert.equal(error.code, 'TRANSPORT_DESTINATION_DENIED');
+          return true;
+        }
+      );
+    }
+  );
+
+  await withServer(
+    {
+      'POST /api/generate': () => ({
+        body: {
+          response: 'x'.repeat(150 * 1024),
+          done: true,
+          prompt_eval_count: 1,
+          eval_count: 1,
+        },
+      }),
+    },
+    async ({ baseUrl }) => {
+      const adapter = providers.adapters.createOllamaModelAdapter({
+        id: 'local.ollama-oversize',
+        modelId: 'llama3.1',
+        endpoint: baseUrl,
+        destinationPolicy: { allowLoopback: true },
+        maxResponseBytes: 16 * 1024,
+      });
+      const registry = providers.createRegistry();
+      registry.register(adapter.registration);
+      const result = await registry.invoke(
+        adapter.descriptor.id,
+        request(adapter.descriptor.id, 'llama3.1'),
+        { policy: allow('local') }
+      );
+      assert.equal(result.ok, false);
+      assert.equal(result.error.code, 'PROVIDER_EXECUTION_FAILED');
+    }
+  );
+});
+
+test('registry timeout/cancellation propagate through adapter transport without auto-retries', async () => {
+  await withServer(
+    {
+      'POST /v1/chat/completions': async () => {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        return {
+          body: {
+            choices: [{ message: { content: 'late' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          },
+        };
+      },
+    },
+    async ({ baseUrl, calls }) => {
+      const adapter = providers.adapters.createOpenAICompatibleModelAdapter({
+        endpoint: baseUrl,
+        models: ['private-vllm'],
+        destinationPolicy: { allowLoopback: true },
+      });
+      const registry = providers.createRegistry();
+      registry.register(adapter.registration);
+      const timedOut = await registry.invoke(
+        adapter.descriptor.id,
+        request(adapter.descriptor.id, 'private-vllm'),
+        { policy: allow('local'), timeoutMs: 5 }
+      );
+      assert.equal(timedOut.error.code, 'PROVIDER_TIMEOUT');
+      assert.equal(calls.length, 1);
+    }
+  );
+});
+
+test('explicit health checks are bounded by transport timeout and do not auto-retry', async () => {
+  await withServer(
+    {
+      'GET /api/tags': async () => {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        return { body: { models: [{ model: 'llama3.1' }] } };
+      },
+    },
+    async ({ baseUrl, calls }) => {
+      const adapter = providers.adapters.createOllamaModelAdapter({
+        endpoint: baseUrl,
+        modelId: 'llama3.1',
+        destinationPolicy: { allowLoopback: true },
+        timeoutMs: 5,
+      });
+      await assert.rejects(
+        () => adapter.checkHealth(),
+        error => {
+          assert.equal(error.code, 'TRANSPORT_TIMEOUT');
+          return true;
+        }
+      );
+      assert.equal(calls.length, 1);
+    }
+  );
+});

--- a/tests/provider-offline.test.js
+++ b/tests/provider-offline.test.js
@@ -77,6 +77,8 @@ test('Zeus API starts with an empty optional provider registry and no automatic 
   assert.deepEqual(zeus.providers.registry.list(), []);
   assert.equal(typeof zeus.analyze, 'function');
   assert.equal(typeof zeus.capabilities.list, 'function');
+  assert.equal(typeof providers.adapters.createOllamaModelAdapter, 'function');
+  assert.equal(typeof providers.adapters.createOpenAICompatibleModelAdapter, 'function');
 });
 
 test('offline provider subtree has no transport, process, clock, random, filesystem, or dynamic import', () => {


### PR DESCRIPTION
## Summary

Adds opt-in local/private model adapters on top of the existing provider-neutral contracts.

- adds Ollama and OpenAI-compatible local/private model adapters under `providers.adapters`
- adds shared private-by-default HTTP transport guardrails for destination policy, redirects, credentials, timeout, cancellation, and bounded responses
- adds offline mock-server coverage for adapter invocation, health checks, redirect revalidation, and fail-closed destination denial
- updates ADR-007 and README wording to describe the new Community adapter scope truthfully

## Non-goals kept out of scope

- no automatic provider registration, probing, fallback, polling, or download
- no public-internet-by-default behavior
- no commercial provider administration, org policy, audit, fleet, entitlement, or support logic
- no CLI or MCP expansion for adapter management

## Validation

- `npm ci`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:discovery`
- `npm test`
- `npm run test:quality`
- `npm run test:benchmark`
- `npm run package:smoke`
- `npm run docs:check`
- `npm run demo:safety-check`
- `npm run check:public-knowledge-claims`
- `npm run check:repo-portability`
- `npm audit --omit=dev --audit-level=high`
- `git diff --check`
- `npm pack --dry-run`
