### PR TITLE
fix(security): upgrade adm-zip and verify archive boundaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0-beta.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "adm-zip": "^0.5.16",
+        "adm-zip": "^0.6.0",
         "basic-ftp": "^5.0.5",
         "glob": "^13.0.6",
         "ssh2-sftp-client": "^11.0.0",
@@ -722,12 +722,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:cli-help": "node --test tests/cli-help.test.js && npm run package:smoke"
   },
   "dependencies": {
-    "adm-zip": "^0.5.16",
+    "adm-zip": "^0.6.0",
     "basic-ftp": "^5.0.5",
     "glob": "^13.0.6",
     "ssh2-sftp-client": "^11.0.0",

--- a/tests/adm-zip-security.test.js
+++ b/tests/adm-zip-security.test.js
@@ -1,0 +1,239 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const AdmZip = require('adm-zip');
+
+const {
+  buildOutputBundle,
+  BUNDLE_MANIFEST_SCHEMA_VERSION,
+} = require('../src/bundle/outputBundleBuilder');
+
+function installedAdmZipVersion() {
+  const pkgPath = require.resolve('adm-zip/package.json');
+  return JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
+}
+
+function u16(n) {
+  const b = Buffer.alloc(2);
+  b.writeUInt16LE(n >>> 0);
+  return b;
+}
+
+function u32(n) {
+  const b = Buffer.alloc(4);
+  b.writeUInt32LE(n >>> 0);
+  return b;
+}
+
+/**
+ * Craft a single-entry ZIP that declares a huge uncompressed size while carrying
+ * only a few payload bytes (CVE-2026-39244 / GHSA-xcpc-8h2w-3j85 regression shape).
+ */
+function craftDeclaredSizeBomb(declaredSize, method, content) {
+  const name = Buffer.from('a');
+  const crc = 0;
+  const lfh = Buffer.concat([
+    u32(0x04034b50),
+    u16(20),
+    u16(0),
+    u16(method),
+    u16(0),
+    u16(0),
+    u32(crc),
+    u32(content.length),
+    u32(declaredSize),
+    u16(name.length),
+    u16(0),
+    name,
+    content,
+  ]);
+  const cd = Buffer.concat([
+    u32(0x02014b50),
+    u16(20),
+    u16(20),
+    u16(0),
+    u16(method),
+    u16(0),
+    u16(0),
+    u32(crc),
+    u32(content.length),
+    u32(declaredSize),
+    u16(name.length),
+    u16(0),
+    u16(0),
+    u16(0),
+    u16(0),
+    u32(0),
+    u32(0),
+    name,
+  ]);
+  const eocd = Buffer.concat([
+    u32(0x06054b50),
+    u16(0),
+    u16(0),
+    u16(1),
+    u16(1),
+    u32(cd.length),
+    u32(lfh.length),
+    u16(0),
+  ]);
+  return Buffer.concat([lfh, cd, eocd]);
+}
+
+function createTempBundleProject(program = 'ORDERPGM') {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-adm-zip-sec-'));
+  const outputRoot = path.join(tempRoot, 'output');
+  const bundleRoot = path.join(tempRoot, 'bundles');
+  const programOutputDir = path.join(outputRoot, program);
+  fs.mkdirSync(programOutputDir, { recursive: true });
+  return { tempRoot, outputRoot, bundleRoot, programOutputDir, program };
+}
+
+test('installed adm-zip satisfies the GHSA-xcpc-8h2w-3j85 patched range', () => {
+  const version = installedAdmZipVersion();
+  const [major, minor] = version.split('.').map(part => Number(part));
+  assert.ok(major > 0 || (major === 0 && minor >= 6), `expected adm-zip >= 0.6.0, got ${version}`);
+  assert.equal(require('../package.json').dependencies['adm-zip'], '^0.6.0');
+});
+
+test('CVE-2026-39244: crafted STORED bomb does not allocate declared size', () => {
+  const DECLARED = 3 * 1024 * 1024 * 1024;
+  const zip = new AdmZip(craftDeclaredSizeBomb(DECLARED, 0, Buffer.from('A')));
+  const before = process.memoryUsage().rss;
+  assert.throws(() => zip.getEntries()[0].getData(), /CRC|crc|BAD/i);
+  const grewMB = (process.memoryUsage().rss - before) / (1024 * 1024);
+  assert.ok(grewMB < 256, `RSS grew ${grewMB.toFixed(1)} MB; allocation must stay bounded`);
+});
+
+test('CVE-2026-39244: crafted DEFLATED bomb does not allocate declared size', () => {
+  const DECLARED = 3 * 1024 * 1024 * 1024;
+  const zip = new AdmZip(craftDeclaredSizeBomb(DECLARED, 8, Buffer.from([0x00])));
+  const before = process.memoryUsage().rss;
+  assert.throws(() => zip.getEntries()[0].getData());
+  const grewMB = (process.memoryUsage().rss - before) / (1024 * 1024);
+  assert.ok(grewMB < 256, `RSS grew ${grewMB.toFixed(1)} MB; allocation must stay bounded`);
+});
+
+test('empty archive and truncated archive fail closed for entry data access', () => {
+  const empty = new AdmZip();
+  assert.deepEqual(empty.getEntries(), []);
+
+  assert.throws(() => {
+    // truncated local header / missing EOCD
+    const broken = new AdmZip(Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x00]));
+    void broken;
+  });
+});
+
+test('round-trip multi-entry archive preserves nested relative paths and content', () => {
+  const zip = new AdmZip();
+  zip.addFile('root.txt', Buffer.from('root\n', 'utf8'));
+  zip.addFile('nested/dir/file.txt', Buffer.from('nested\n', 'utf8'));
+  zip.addFile('safe-sharing/report.md', Buffer.from('# report\n', 'utf8'));
+  const buf = zip.toBuffer();
+  const round = new AdmZip(buf);
+  const names = round
+    .getEntries()
+    .filter(entry => !entry.isDirectory)
+    .map(entry => entry.entryName)
+    .sort();
+  assert.deepEqual(names, ['nested/dir/file.txt', 'root.txt', 'safe-sharing/report.md']);
+  assert.equal(round.readAsText('nested/dir/file.txt'), 'nested\n');
+});
+
+test('entry names with traversal, absolute, and windows drive forms remain names only', () => {
+  const zip = new AdmZip();
+  zip.addFile('../escape.txt', Buffer.from('no\n', 'utf8'));
+  zip.addFile('..\\win-escape.txt', Buffer.from('no\n', 'utf8'));
+  zip.addFile('/abs/path.txt', Buffer.from('no\n', 'utf8'));
+  zip.addFile('C:/windows/system32/evil.txt', Buffer.from('no\n', 'utf8'));
+  zip.addFile('C:\\windows\\system32\\evil2.txt', Buffer.from('no\n', 'utf8'));
+  const names = zip.getEntries().map(entry => entry.entryName);
+  assert.ok(names.some(name => name.includes('escape') || name.includes('evil')));
+  // Production Zeus never extractAllTo untrusted archives; assert we still only hold names.
+  for (const entry of zip.getEntries()) {
+    assert.equal(typeof entry.entryName, 'string');
+    assert.ok(Buffer.isBuffer(entry.getData()));
+  }
+});
+
+test('duplicate entry names remain readable without silent merge of content', () => {
+  const zip = new AdmZip();
+  zip.addFile('dup.txt', Buffer.from('first', 'utf8'));
+  zip.addFile('dup.txt', Buffer.from('second', 'utf8'));
+  const matches = zip.getEntries().filter(entry => entry.entryName === 'dup.txt');
+  assert.ok(matches.length >= 1);
+  const data = zip.readAsText('dup.txt');
+  assert.ok(data === 'first' || data === 'second');
+});
+
+test('buildOutputBundle still writes stable multi-file zip with manifest checksums', () => {
+  const { tempRoot, outputRoot, bundleRoot, programOutputDir, program } = createTempBundleProject();
+  try {
+    fs.writeFileSync(path.join(programOutputDir, 'context.json'), '{"program":"ORDERPGM"}\n');
+    fs.writeFileSync(path.join(programOutputDir, 'report.md'), '# Report\n');
+    fs.writeFileSync(
+      path.join(programOutputDir, 'analyze-run-manifest.json'),
+      `${JSON.stringify(
+        {
+          run: { status: 'succeeded', completedAt: '2026-03-16T10:00:00.000Z' },
+          inputs: {
+            sourceSnapshot: { fingerprint: 'abc123' },
+          },
+          artifacts: [{ path: 'context.json' }, { path: 'report.md' }],
+        },
+        null,
+        2
+      )}\n`
+    );
+
+    const result = buildOutputBundle({
+      program,
+      sourceOutputRoot: outputRoot,
+      bundleOutputRoot: bundleRoot,
+      reproducibility: {
+        enabled: true,
+        timestamp: '2026-03-16T10:00:00.000Z',
+      },
+    });
+
+    assert.equal(result.manifest.schemaVersion, BUNDLE_MANIFEST_SCHEMA_VERSION);
+    assert.ok(fs.existsSync(result.zipPath));
+    const zip = new AdmZip(result.zipPath);
+    const entryNames = zip
+      .getEntries()
+      .map(entry => entry.entryName)
+      .sort();
+    assert.deepEqual(entryNames, [
+      'README.txt',
+      'analyze-run-manifest.json',
+      'context.json',
+      'manifest.json',
+      'report.md',
+    ]);
+    for (const artifact of result.manifest.artifacts) {
+      assert.match(artifact.sha256, /^[a-f0-9]{64}$/);
+      assert.ok(Number.isFinite(artifact.sizeBytes));
+    }
+    const manifestEntry = zip.getEntry('manifest.json');
+    assert.ok(manifestEntry);
+    const inside = JSON.parse(manifestEntry.getData().toString('utf8'));
+    assert.equal(inside.program, 'ORDERPGM');
+    assert.equal(inside.summary.totalFiles, result.manifest.summary.totalFiles);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('production bundle API does not extract archives to the workspace', () => {
+  const source = fs.readFileSync(require.resolve('../src/bundle/outputBundleBuilder.js'), 'utf8');
+  assert.equal(source.includes('extractAllTo'), false);
+  assert.equal(source.includes('extractEntryTo'), false);
+  assert.match(source, /new AdmZip\(\)/);
+  assert.match(source, /writeZip/);
+  assert.match(source, /addFile/);
+});


### PR DESCRIPTION
## Summary

- Upgrade the direct production dependency `adm-zip` from locked `0.5.17` (`^0.5.16`) to `0.6.0` (`^0.6.0`) to remediate **GHSA-xcpc-8h2w-3j85 / CVE-2026-39244** (unbounded `Buffer.alloc` from attacker-declared uncompressed size).
- Add offline regression coverage in `tests/adm-zip-security.test.js` for decompression bombs, multi-entry/nested path round-trips, corrupt/empty archives, entry-name edge cases, and existing bundle manifest/checksum behavior.
- No production API or extraction-path changes: Zeus still only **creates** bundles via `addFile` / `writeZip` and never calls `extractAllTo` / `extractEntryTo`.

## Dependency analysis

| Item | Value |
|---|---|
| Relationship | **Direct** production dependency |
| Previous lock | `0.5.17` |
| Selected safe version | **`0.6.0`** (smallest version accepted by npm audit range `<0.6.0` and GHSA patched versions) |
| Note on `0.5.18` | Exists, but does **not** clear the audit range; CVE fix shipped in `0.6.0` ([release notes](https://github.com/cthackers/adm-zip/releases/tag/v0.6.0), [fix commit](https://github.com/cthackers/adm-zip/commit/2450dcf417aa29df49270237d18c5245794da3e2)) |
| Node engines | `adm-zip@0.6.0` requires `>=14`; Zeus requires `>=20` |

## 0.6.0 behavioral notes relevant to Zeus

- CVE allocation bound by real data (read path / `getData`)
- `extractEntryTo` subdirectory preservation — **unused by Zeus production**
- `utimes` best-effort on extract — **unused by Zeus production**
- No other lockfile packages changed

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:discovery` (130/130)
- Focused ZIP/bundle suite (multiple runs)
- `npm run test:quality`
- `npm run test:benchmark`
- `npm run package:smoke`
- `npm run docs:check`
- `npm run demo:safety-check`
- `npm run check:public-knowledge-claims`
- `npm run check:repo-portability`
- `npm audit --omit=dev --audit-level=high` → **0 vulnerabilities**
- `git diff --check` (staged)
- `npm pack --dry-run`
- Negative proof: lock back to `0.5.17` reopens the high audit finding; mutated bomb assertion fails closed

## Scope boundary

- Iteration 29 **not** started
- No commercial, provider, or general dependency churn