### PR TITLE
feat(validation): add safe generation candidate validation

### DIFF
--- a/docs/architecture/adr-008-generation-validation-foundation.md
+++ b/docs/architecture/adr-008-generation-validation-foundation.md
@@ -1,0 +1,75 @@
+---
+Title: ADR-008 Generation Validation Foundation
+Description: Community offline validation of structured generation candidates as review artifacts without source mutation or commercial repair loops.
+Last Updated: 2026-07-19
+---
+
+# ADR-008: Generation Validation Foundation
+
+**Status:** Accepted and implemented as Community safety baseline
+
+## Context
+
+Zeus can prepare evidence and may later accept model-produced change proposals. Those proposals must
+not become evidence, must not mutate the analyzed source workspace automatically, and must not ship
+a commercial Generation Assurance / repair loop in the Apache-2.0 core.
+
+## Decision
+
+### Versioned contracts
+
+The core registers:
+
+- `zeus.generation-candidate@1`
+- `zeus.generation-validation-report@1`
+- `zeus.external-linter-adapter@1` (neutral optional descriptor only; no network default)
+
+Candidates declare evidence references, assumptions, uncertainties, and explicit `proposedFiles`
+only. Undeclared markdown fences, free-text paths, or side-channel file lists are not accepted as
+changes. Hidden chain-of-thought fields are rejected.
+
+### Validator registry
+
+A dedicated Generation Validator Registry is separate from Capability, Provider, and future module
+registries. Built-in validators cover schema, contract version, workspace paths, file types, size
+limits, duplicate targets, declared scope, evidence references, policy, and a light static source
+classification check. Order is deterministic (`order` then id). Validator failures are isolated.
+
+### Status model
+
+Overall status values:
+
+| Status                       | Meaning                                         |
+| ---------------------------- | ----------------------------------------------- |
+| `invalid`                    | Schema/contract structure failed                |
+| `denied`                     | Local safety policy denied the candidate        |
+| `validation-failed`          | Blocking or error diagnostics from validators   |
+| `unsupported`                | Reserved for hard unsupported local checks      |
+| `internal-validator-failure` | Validator threw or report failed its own schema |
+| `review-ready`               | All required checks passed                      |
+
+**`review-ready` never means compiled, functionally correct, IBM i tested, approved, or deployable.**
+
+### Workspace safety
+
+Path checks use `path.resolve` containment against an authorized workspace root. Absolute paths,
+Windows drive prefixes, UNC, `..` traversal, control characters, reserved device names, and scope
+expansion fail closed. Review artifacts may only be written to an explicit `reviewArtifactRoot`
+that is not inside the source workspace.
+
+### API surface
+
+Iteration 29 exposes a programmatic API under `zeus.generationValidation` / package
+`generationValidation`. CLI and MCP remain thin and are not required for this foundation.
+
+### Commercial boundary
+
+Reserved for commercial modules: AI repair loops, advanced RPG/CL/DDS validator packs, ranking,
+organization policy/approval, comparative quality reports, compiler validation, and differential
+execution. The public core must not contain dormant paid implementations.
+
+## Consequences
+
+- Offline mock validation is fully testable without providers or IBM i.
+- Later commercial Generation Assurance can attach to the same candidate/report contracts without
+  rewriting the Community safety baseline.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -21,6 +21,7 @@ All subsequent implementation and agent guidance must be consistent with these d
 | [005](adr-005-safety-trust-zones.md)                | Safety Trust Zones                | Accepted               |
 | [006](adr-006-commercial-extension-architecture.md) | Commercial Extension Architecture | Accepted specification |
 | [007](adr-007-provider-neutral-contracts.md)        | Provider-Neutral AI Contracts     | Accepted               |
+| [008](adr-008-generation-validation-foundation.md)  | Generation Validation Foundation  | Accepted               |
 
 ## Related Reviews
 
@@ -37,6 +38,8 @@ All subsequent implementation and agent guidance must be consistent with these d
   compatibility, failure-isolation, and artifact-portability rules in ADR-006.
 - Optional AI adapters must follow the versioned contracts, explicit provider identity,
   private-by-default transport policy, redaction, and evidence-separation rules in ADR-007.
+- Structured generation candidates must follow the offline validation, path/scope safety,
+  evidence-reference, and non-mutation rules in ADR-008. `review-ready` is never compile readiness.
 
 ## Regenerating Supporting Artifacts
 

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -21,6 +21,7 @@ const providerPolicy = require('../providers/egressPolicy');
 const providerRedaction = require('../providers/redaction');
 const providerTesting = require('../providers/testing');
 const providerAdapters = require('../providers/adapters');
+const generationValidation = require('../generationValidation');
 const { executeQueryTable } = require('../core/queryService');
 const {
   executeListRuns,
@@ -855,6 +856,9 @@ const zeus = {
   // Provider-neutral Community contracts. Empty by default; registration is
   // explicit and restricted to trusted, already-imported in-process adapters.
   providers,
+  // Generation Validation Foundation (Iteration 29): offline candidate validation.
+  // Never mutates the analyzed source workspace. review-ready is not compile readiness.
+  generationValidation,
   components: new ComponentRegistry(),
   analyzeStages: analyzeStageRegistry,
 
@@ -928,6 +932,13 @@ module.exports = {
   providers,
   createProviderRegistry,
 
+  // Generation Validation Foundation (Community safety baseline)
+  generationValidation,
+
   zeus,
-  createZeus: () => ({ ...zeus, providers: createProviderNamespace() }),
+  createZeus: () => ({
+    ...zeus,
+    providers: createProviderNamespace(),
+    generationValidation,
+  }),
 };

--- a/src/core/contracts/contractIds.js
+++ b/src/core/contracts/contractIds.js
@@ -37,4 +37,7 @@ module.exports = Object.freeze({
   EGRESS_POLICY: 'zeus.egress-policy',
   PROVIDER_POLICY_DENIAL: 'zeus.provider-policy-denial',
   PROVIDER_CONFIG_PROVENANCE: 'zeus.provider-config-provenance',
+  GENERATION_CANDIDATE: 'zeus.generation-candidate',
+  GENERATION_VALIDATION_REPORT: 'zeus.generation-validation-report',
+  EXTERNAL_LINTER_ADAPTER: 'zeus.external-linter-adapter',
 });

--- a/src/core/contracts/index.js
+++ b/src/core/contracts/index.js
@@ -17,6 +17,7 @@ const { SchemaValidationError, normalizeValidationErrors } = require('./errors')
 const artifactReference = require('./artifactReference');
 const runManifest = require('./runManifest');
 const providerContracts = require('../../providers/contracts');
+const generationValidation = require('../../generationValidation');
 
 module.exports = {
   createSchemaRegistry,
@@ -25,4 +26,5 @@ module.exports = {
   artifactReference,
   runManifest,
   providerContracts,
+  generationValidation,
 };

--- a/src/core/contracts/schemas.js
+++ b/src/core/contracts/schemas.js
@@ -269,6 +269,7 @@ const safetyPolicySchema = value => {
 };
 
 const { PROVIDER_SCHEMAS } = require('../../providers/contracts');
+const { GENERATION_SCHEMAS } = require('../../generationValidation/contracts');
 
 const INITIAL_SCHEMAS = Object.freeze({
   [CONTRACT_IDS.EVIDENCE_MODEL]: { version: 1, schema: evidenceModelSchema },
@@ -279,6 +280,7 @@ const INITIAL_SCHEMAS = Object.freeze({
   [CONTRACT_IDS.INVESTIGATION_SESSION]: { version: 1, schema: investigationSessionSchema },
   [CONTRACT_IDS.SAFETY_POLICY]: { version: 1, schema: safetyPolicySchema },
   ...PROVIDER_SCHEMAS,
+  ...GENERATION_SCHEMAS,
 });
 
 module.exports = {

--- a/src/generationValidation/builtInValidators.js
+++ b/src/generationValidation/builtInValidators.js
@@ -1,0 +1,388 @@
+'use strict';
+
+const path = require('path');
+const {
+  DIAGNOSTIC_IDS,
+  SEVERITY,
+  ALLOWED_FILE_EXTENSIONS,
+  DEFAULT_LIMITS,
+  FILE_ACTIONS,
+} = require('./constants');
+const { validateWorkspacePath, caseFoldKey, normalizeRelativePath } = require('./pathSafety');
+const { CONTRACT_IDS, generationCandidateSchema } = require('./contracts');
+
+function byteLength(text) {
+  return Buffer.byteLength(String(text || ''), 'utf8');
+}
+
+function secretLike(text) {
+  const s = String(text || '');
+  return (
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(s) ||
+    /(?:password|secret|api[_-]?key|token)\s*[:=]\s*['"][^'"]{8,}/i.test(s)
+  );
+}
+
+function createBuiltInValidators(options = {}) {
+  const limits = { ...DEFAULT_LIMITS, ...(options.limits || {}) };
+  const allowedExtensions = options.allowedExtensions || ALLOWED_FILE_EXTENSIONS;
+
+  return [
+    {
+      id: 'schema',
+      version: 1,
+      order: 10,
+      title: 'Schema validator',
+      description: 'Validates generation-candidate/v1 structure',
+      validate(ctx) {
+        const errors = generationCandidateSchema(ctx.candidate);
+        if (!errors.length) return [];
+        return errors.map(err => ({
+          id: DIAGNOSTIC_IDS.SCHEMA_INVALID,
+          severity: SEVERITY.BLOCKING,
+          path: err.path || null,
+          message: err.message,
+        }));
+      },
+    },
+    {
+      id: 'contract-version',
+      version: 1,
+      order: 20,
+      title: 'Contract version validator',
+      description: 'Ensures supported generation-candidate contract version',
+      validate(ctx) {
+        const c = ctx.candidate || {};
+        if (Number(c.schemaVersion) !== 1) {
+          return [
+            {
+              id: DIAGNOSTIC_IDS.CONTRACT_VERSION_UNSUPPORTED,
+              severity: SEVERITY.BLOCKING,
+              path: '/schemaVersion',
+              message: `Unsupported generation-candidate version: ${c.schemaVersion}`,
+            },
+          ];
+        }
+        if (
+          c.contractId != null &&
+          c.contractId !== CONTRACT_IDS.GENERATION_CANDIDATE &&
+          c.contractId !== `${CONTRACT_IDS.GENERATION_CANDIDATE}@1`
+        ) {
+          return [
+            {
+              id: DIAGNOSTIC_IDS.CONTRACT_VERSION_UNSUPPORTED,
+              severity: SEVERITY.BLOCKING,
+              path: '/contractId',
+              message: 'Unsupported generation-candidate contract id',
+            },
+          ];
+        }
+        return [];
+      },
+    },
+    {
+      id: 'workspace-path',
+      version: 1,
+      order: 30,
+      title: 'Workspace path validator',
+      description: 'Rejects absolute, traversal, UNC, drive, and control-character paths',
+      validate(ctx) {
+        const out = [];
+        const files = Array.isArray(ctx.candidate && ctx.candidate.proposedFiles)
+          ? ctx.candidate.proposedFiles
+          : [];
+        for (const file of files) {
+          const result = validateWorkspacePath(file && file.path, {
+            workspaceRoot: ctx.workspaceRoot,
+            allowedRelativeRoots: ctx.allowedRelativeRoots,
+          });
+          if (!result.ok) {
+            const id =
+              result.code === 'outside-workspace'
+                ? DIAGNOSTIC_IDS.PATH_OUTSIDE_WORKSPACE
+                : result.code === 'outside-scope'
+                  ? DIAGNOSTIC_IDS.PATH_OUTSIDE_SCOPE
+                  : DIAGNOSTIC_IDS.PATH_UNSAFE;
+            out.push({
+              id,
+              severity: SEVERITY.BLOCKING,
+              path: file && file.path ? String(file.path) : null,
+              message: result.message,
+            });
+          }
+        }
+        return out;
+      },
+    },
+    {
+      id: 'file-type',
+      version: 1,
+      order: 40,
+      title: 'Allowed file type validator',
+      validate(ctx) {
+        const out = [];
+        const files = Array.isArray(ctx.candidate && ctx.candidate.proposedFiles)
+          ? ctx.candidate.proposedFiles
+          : [];
+        for (const file of files) {
+          const ext = path.posix.extname(normalizeRelativePath(file && file.path)).toLowerCase();
+          if (!allowedExtensions.includes(ext)) {
+            out.push({
+              id: DIAGNOSTIC_IDS.FILE_TYPE_DENIED,
+              severity: SEVERITY.BLOCKING,
+              path: file && file.path ? String(file.path) : null,
+              message: `File extension is not allowed: ${ext || '(none)'}`,
+            });
+          }
+        }
+        return out;
+      },
+    },
+    {
+      id: 'size-limits',
+      version: 1,
+      order: 50,
+      title: 'Content and file size limits',
+      validate(ctx) {
+        const out = [];
+        const files = Array.isArray(ctx.candidate && ctx.candidate.proposedFiles)
+          ? ctx.candidate.proposedFiles
+          : [];
+        if (files.length > limits.maxFiles) {
+          out.push({
+            id: DIAGNOSTIC_IDS.TOO_MANY_FILES,
+            severity: SEVERITY.BLOCKING,
+            path: '/proposedFiles',
+            message: `Too many proposed files (max ${limits.maxFiles})`,
+          });
+        }
+        let total = 0;
+        for (const file of files) {
+          const size = byteLength(file && file.content);
+          total += size;
+          if (size > limits.maxContentBytes) {
+            out.push({
+              id: DIAGNOSTIC_IDS.CONTENT_TOO_LARGE,
+              severity: SEVERITY.BLOCKING,
+              path: file && file.path ? String(file.path) : null,
+              message: `File content exceeds ${limits.maxContentBytes} bytes`,
+            });
+          }
+        }
+        if (total > limits.maxTotalContentBytes) {
+          out.push({
+            id: DIAGNOSTIC_IDS.TOTAL_CONTENT_TOO_LARGE,
+            severity: SEVERITY.BLOCKING,
+            path: '/proposedFiles',
+            message: `Total content exceeds ${limits.maxTotalContentBytes} bytes`,
+          });
+        }
+        return out;
+      },
+    },
+    {
+      id: 'duplicate-target',
+      version: 1,
+      order: 60,
+      title: 'Duplicate target validator',
+      validate(ctx) {
+        const out = [];
+        const files = Array.isArray(ctx.candidate && ctx.candidate.proposedFiles)
+          ? ctx.candidate.proposedFiles
+          : [];
+        const seen = new Map();
+        for (const file of files) {
+          const key = caseFoldKey(file && file.path);
+          if (!key) continue;
+          if (seen.has(key)) {
+            out.push({
+              id: DIAGNOSTIC_IDS.DUPLICATE_TARGET,
+              severity: SEVERITY.BLOCKING,
+              path: file.path,
+              message: `Duplicate target path (case-insensitive): ${file.path}`,
+            });
+          } else {
+            seen.set(key, file.path);
+          }
+        }
+        return out;
+      },
+    },
+    {
+      id: 'scope',
+      version: 1,
+      order: 70,
+      title: 'Declared scope validator',
+      validate(ctx) {
+        const out = [];
+        const declared = Array.isArray(ctx.declaredScopePaths)
+          ? ctx.declaredScopePaths.map(normalizeRelativePath)
+          : null;
+        if (!declared || declared.length === 0) return out;
+        const files = Array.isArray(ctx.candidate && ctx.candidate.proposedFiles)
+          ? ctx.candidate.proposedFiles
+          : [];
+        for (const file of files) {
+          const p = normalizeRelativePath(file && file.path);
+          const allowed = declared.some(root => p === root || p.startsWith(`${root}/`));
+          if (!allowed) {
+            out.push({
+              id: DIAGNOSTIC_IDS.SCOPE_EXPANSION,
+              severity: SEVERITY.BLOCKING,
+              path: p,
+              message: 'Proposed file expands beyond the declared validation scope',
+            });
+          }
+        }
+        // Undeclared expansion markers (e.g. free-text additionalFiles) are ignored as changes.
+        if (Array.isArray(ctx.candidate && ctx.candidate.additionalFiles)) {
+          out.push({
+            id: DIAGNOSTIC_IDS.UNDECLARED_FILE,
+            severity: SEVERITY.BLOCKING,
+            path: '/additionalFiles',
+            message: 'Undeclared additionalFiles are not accepted as proposed changes',
+          });
+        }
+        return out;
+      },
+    },
+    {
+      id: 'evidence-reference',
+      version: 1,
+      order: 80,
+      title: 'Evidence reference validator',
+      validate(ctx) {
+        const out = [];
+        const refs = Array.isArray(ctx.candidate && ctx.candidate.evidenceReferences)
+          ? ctx.candidate.evidenceReferences
+          : [];
+        const store =
+          ctx.evidenceStore && typeof ctx.evidenceStore === 'object' ? ctx.evidenceStore : {};
+        if (refs.length === 0) {
+          out.push({
+            id: DIAGNOSTIC_IDS.EVIDENCE_MISSING,
+            severity: SEVERITY.BLOCKING,
+            path: '/evidenceReferences',
+            message: 'At least one evidence reference is required',
+          });
+          return out;
+        }
+        for (const ref of refs) {
+          const id = ref && ref.id;
+          const entry = store[id];
+          if (!entry) {
+            out.push({
+              id: DIAGNOSTIC_IDS.EVIDENCE_UNKNOWN,
+              severity: SEVERITY.BLOCKING,
+              path: `/evidenceReferences/${id || ''}`,
+              message: `Unknown evidence reference: ${id || '(missing id)'}`,
+            });
+            continue;
+          }
+          if (ref.kind && entry.kind && String(ref.kind) !== String(entry.kind)) {
+            out.push({
+              id: DIAGNOSTIC_IDS.EVIDENCE_TYPE_MISMATCH,
+              severity: SEVERITY.BLOCKING,
+              path: `/evidenceReferences/${id}`,
+              message: `Evidence kind mismatch for ${id}`,
+            });
+          }
+        }
+        return out;
+      },
+    },
+    {
+      id: 'policy',
+      version: 1,
+      order: 90,
+      title: 'Safety and policy validator',
+      validate(ctx) {
+        const out = [];
+        if (ctx.policy && ctx.policy.deny === true) {
+          out.push({
+            id: DIAGNOSTIC_IDS.POLICY_DENIED,
+            severity: SEVERITY.BLOCKING,
+            path: null,
+            message: String(ctx.policy.reason || 'Candidate denied by local safety policy'),
+          });
+        }
+        const files = Array.isArray(ctx.candidate && ctx.candidate.proposedFiles)
+          ? ctx.candidate.proposedFiles
+          : [];
+        for (const file of files) {
+          if (secretLike(file && file.content)) {
+            out.push({
+              id: DIAGNOSTIC_IDS.SECRET_LIKE_CONTENT,
+              severity: SEVERITY.BLOCKING,
+              path: file && file.path ? String(file.path) : null,
+              message: 'Proposed content appears to contain secret-like material',
+            });
+          }
+          const action = file && file.action ? String(file.action) : 'modify';
+          if (!FILE_ACTIONS.includes(action)) {
+            out.push({
+              id: DIAGNOSTIC_IDS.POLICY_DENIED,
+              severity: SEVERITY.BLOCKING,
+              path: file && file.path ? String(file.path) : null,
+              message: `Unsupported file action: ${action}`,
+            });
+          }
+        }
+        return out;
+      },
+    },
+    {
+      id: 'static-parse',
+      version: 1,
+      order: 100,
+      title: 'Optional local static parse check',
+      description:
+        'Reuses existing source-type classification; does not invent a second RPG parser or claim compile readiness',
+      validate(ctx) {
+        const out = [];
+        let classifySourceFile;
+        let sourceTypeFamily;
+        try {
+          ({ classifySourceFile, sourceTypeFamily } = require('../source/sourceType'));
+        } catch {
+          return [
+            {
+              id: DIAGNOSTIC_IDS.STATIC_PARSE_UNSUPPORTED,
+              severity: SEVERITY.WARNING,
+              path: null,
+              message: 'Source type classifier unavailable; static parse skipped',
+            },
+          ];
+        }
+        const files = Array.isArray(ctx.candidate && ctx.candidate.proposedFiles)
+          ? ctx.candidate.proposedFiles
+          : [];
+        for (const file of files) {
+          if (!file || file.action === 'delete') continue;
+          const sourceType = classifySourceFile(file.path || '');
+          const family = sourceTypeFamily(sourceType);
+          if (!family || family === 'UNKNOWN') {
+            // Not every allowed extension is an RPG/CL/DDS source unit.
+            continue;
+          }
+          // Capability honesty: classification only — not semantic or compile validity.
+          if (['RPG', 'CL', 'DDS'].includes(family)) {
+            if (typeof file.content === 'string' && file.content.includes('\u0000')) {
+              out.push({
+                id: DIAGNOSTIC_IDS.STATIC_PARSE_FAILED,
+                severity: SEVERITY.BLOCKING,
+                path: file.path,
+                message: 'Source content contains NUL bytes and cannot be parsed safely',
+              });
+            }
+          }
+        }
+        return out;
+      },
+    },
+  ];
+}
+
+module.exports = {
+  createBuiltInValidators,
+};

--- a/src/generationValidation/constants.js
+++ b/src/generationValidation/constants.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Generation Validation Foundation (Iteration 29) — status and diagnostic vocabulary.
+ *
+ * Status meanings (Community safety baseline, not correctness/compile claims):
+ * - invalid: candidate fails schema/contract structure
+ * - denied: safety/policy rejects the candidate
+ * - validation-failed: one or more blocking validator diagnostics
+ * - unsupported: required local check cannot run for the declared artifact kind
+ * - internal-validator-failure: a validator threw or returned unusable output
+ * - review-ready: all required checks passed; still not compiled, approved, or deployable
+ */
+
+const STATUS = Object.freeze({
+  INVALID: 'invalid',
+  DENIED: 'denied',
+  VALIDATION_FAILED: 'validation-failed',
+  UNSUPPORTED: 'unsupported',
+  INTERNAL_VALIDATOR_FAILURE: 'internal-validator-failure',
+  REVIEW_READY: 'review-ready',
+});
+
+const SEVERITY = Object.freeze({
+  INFO: 'info',
+  WARNING: 'warning',
+  ERROR: 'error',
+  BLOCKING: 'blocking',
+});
+
+const FILE_ACTIONS = Object.freeze(['create', 'modify', 'delete', 'rename']);
+
+const ALLOWED_FILE_EXTENSIONS = Object.freeze([
+  '.rpgle',
+  '.sqlrpgle',
+  '.rpg',
+  '.clle',
+  '.clp',
+  '.pf',
+  '.lf',
+  '.dspf',
+  '.prtf',
+  '.sql',
+  '.bnd',
+  '.txt',
+  '.md',
+  '.json',
+]);
+
+const DEFAULT_LIMITS = Object.freeze({
+  maxFiles: 32,
+  maxContentBytes: 256 * 1024,
+  maxTotalContentBytes: 1024 * 1024,
+  maxTaskSummaryChars: 4000,
+  maxRationaleChars: 4000,
+});
+
+const DIAGNOSTIC_IDS = Object.freeze({
+  SCHEMA_INVALID: 'GENVAL.SCHEMA_INVALID',
+  CONTRACT_VERSION_UNSUPPORTED: 'GENVAL.CONTRACT_VERSION_UNSUPPORTED',
+  PATH_UNSAFE: 'GENVAL.PATH_UNSAFE',
+  PATH_OUTSIDE_WORKSPACE: 'GENVAL.PATH_OUTSIDE_WORKSPACE',
+  PATH_OUTSIDE_SCOPE: 'GENVAL.PATH_OUTSIDE_SCOPE',
+  FILE_TYPE_DENIED: 'GENVAL.FILE_TYPE_DENIED',
+  CONTENT_TOO_LARGE: 'GENVAL.CONTENT_TOO_LARGE',
+  TOTAL_CONTENT_TOO_LARGE: 'GENVAL.TOTAL_CONTENT_TOO_LARGE',
+  TOO_MANY_FILES: 'GENVAL.TOO_MANY_FILES',
+  DUPLICATE_TARGET: 'GENVAL.DUPLICATE_TARGET',
+  UNDECLARED_FILE: 'GENVAL.UNDECLARED_FILE',
+  EVIDENCE_MISSING: 'GENVAL.EVIDENCE_MISSING',
+  EVIDENCE_UNKNOWN: 'GENVAL.EVIDENCE_UNKNOWN',
+  EVIDENCE_TYPE_MISMATCH: 'GENVAL.EVIDENCE_TYPE_MISMATCH',
+  POLICY_DENIED: 'GENVAL.POLICY_DENIED',
+  SCOPE_EXPANSION: 'GENVAL.SCOPE_EXPANSION',
+  STATIC_PARSE_UNSUPPORTED: 'GENVAL.STATIC_PARSE_UNSUPPORTED',
+  STATIC_PARSE_FAILED: 'GENVAL.STATIC_PARSE_FAILED',
+  VALIDATOR_INTERNAL: 'GENVAL.VALIDATOR_INTERNAL',
+  VALIDATOR_MISSING: 'GENVAL.VALIDATOR_MISSING',
+  SECRET_LIKE_CONTENT: 'GENVAL.SECRET_LIKE_CONTENT',
+});
+
+module.exports = {
+  STATUS,
+  SEVERITY,
+  FILE_ACTIONS,
+  ALLOWED_FILE_EXTENSIONS,
+  DEFAULT_LIMITS,
+  DIAGNOSTIC_IDS,
+};

--- a/src/generationValidation/contracts.js
+++ b/src/generationValidation/contracts.js
@@ -1,0 +1,242 @@
+'use strict';
+
+const { FILE_ACTIONS, DEFAULT_LIMITS } = require('./constants');
+
+const CONTRACT_IDS = Object.freeze({
+  GENERATION_CANDIDATE: 'zeus.generation-candidate',
+  GENERATION_VALIDATION_REPORT: 'zeus.generation-validation-report',
+  EXTERNAL_LINTER_ADAPTER: 'zeus.external-linter-adapter',
+});
+
+function isPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function push(errors, path, message) {
+  errors.push({ path, message });
+}
+
+/**
+ * generation-candidate/v1
+ * Structured AI/local generation proposal. Advisory only — never evidence.
+ */
+function generationCandidateSchema(value) {
+  const errors = [];
+  if (!isPlainObject(value)) {
+    push(errors, '', 'expected an object');
+    return errors;
+  }
+  if (Number(value.schemaVersion) !== 1) {
+    push(errors, '/schemaVersion', 'expected 1');
+  }
+  if (value.kind != null && value.kind !== 'generation-candidate') {
+    push(errors, '/kind', 'kind must be "generation-candidate" when present');
+  }
+  if (typeof value.candidateId !== 'string' || !value.candidateId.trim()) {
+    push(errors, '/candidateId', 'candidateId is required');
+  }
+  if (typeof value.taskSummary !== 'string' || !value.taskSummary.trim()) {
+    push(errors, '/taskSummary', 'taskSummary is required');
+  } else if (value.taskSummary.length > DEFAULT_LIMITS.maxTaskSummaryChars) {
+    push(errors, '/taskSummary', 'taskSummary exceeds size limit');
+  }
+  if (!Array.isArray(value.evidenceReferences)) {
+    push(errors, '/evidenceReferences', 'evidenceReferences must be an array');
+  } else {
+    value.evidenceReferences.forEach((ref, i) => {
+      if (!isPlainObject(ref)) {
+        push(errors, `/evidenceReferences/${i}`, 'reference must be an object');
+        return;
+      }
+      if (typeof ref.id !== 'string' || !ref.id.trim()) {
+        push(errors, `/evidenceReferences/${i}/id`, 'id is required');
+      }
+      if (typeof ref.kind !== 'string' || !ref.kind.trim()) {
+        push(errors, `/evidenceReferences/${i}/kind`, 'kind is required');
+      }
+      if (ref.path != null && typeof ref.path !== 'string') {
+        push(errors, `/evidenceReferences/${i}/path`, 'path must be a string when present');
+      }
+    });
+  }
+  if (value.assumptions != null && !Array.isArray(value.assumptions)) {
+    push(errors, '/assumptions', 'assumptions must be an array when present');
+  }
+  if (value.uncertainties != null && !Array.isArray(value.uncertainties)) {
+    push(errors, '/uncertainties', 'uncertainties must be an array when present');
+  }
+  if (!Array.isArray(value.proposedFiles)) {
+    push(errors, '/proposedFiles', 'proposedFiles must be an array');
+  } else {
+    if (value.proposedFiles.length > DEFAULT_LIMITS.maxFiles) {
+      push(errors, '/proposedFiles', 'too many proposed files');
+    }
+    value.proposedFiles.forEach((file, i) => {
+      const base = `/proposedFiles/${i}`;
+      if (!isPlainObject(file)) {
+        push(errors, base, 'file entry must be an object');
+        return;
+      }
+      if (typeof file.path !== 'string' || !file.path.trim()) {
+        push(errors, `${base}/path`, 'path is required');
+      }
+      if (file.action != null && !FILE_ACTIONS.includes(String(file.action))) {
+        push(errors, `${base}/action`, `action must be one of ${FILE_ACTIONS.join(', ')}`);
+      }
+      if (file.language != null && typeof file.language !== 'string') {
+        push(errors, `${base}/language`, 'language must be a string when present');
+      }
+      if (file.content != null && typeof file.content !== 'string') {
+        push(errors, `${base}/content`, 'content must be a string when present');
+      }
+      if (file.action !== 'delete' && (file.content == null || typeof file.content !== 'string')) {
+        push(errors, `${base}/content`, 'content is required unless action is delete');
+      }
+      if (file.rationale != null && typeof file.rationale !== 'string') {
+        push(errors, `${base}/rationale`, 'rationale must be a string when present');
+      }
+      if (
+        typeof file.rationale === 'string' &&
+        file.rationale.length > DEFAULT_LIMITS.maxRationaleChars
+      ) {
+        push(errors, `${base}/rationale`, 'rationale exceeds size limit');
+      }
+    });
+  }
+  if (value.validationPlan != null && !isPlainObject(value.validationPlan)) {
+    push(errors, '/validationPlan', 'validationPlan must be an object when present');
+  }
+  if (value.providerIdentity != null) {
+    if (!isPlainObject(value.providerIdentity)) {
+      push(errors, '/providerIdentity', 'providerIdentity must be an object when present');
+    } else {
+      if (
+        value.providerIdentity.providerId != null &&
+        typeof value.providerIdentity.providerId !== 'string'
+      ) {
+        push(errors, '/providerIdentity/providerId', 'must be a string');
+      }
+      if (
+        value.providerIdentity.model != null &&
+        typeof value.providerIdentity.model !== 'string'
+      ) {
+        push(errors, '/providerIdentity/model', 'must be a string');
+      }
+    }
+  }
+  if (value.correlationId != null && typeof value.correlationId !== 'string') {
+    push(errors, '/correlationId', 'correlationId must be a string when present');
+  }
+  // Chain-of-thought must not be required or stored as a first-class field.
+  if (value.chainOfThought != null || value.hiddenReasoning != null) {
+    push(errors, '', 'hidden reasoning / chain-of-thought fields are not allowed');
+  }
+  return errors;
+}
+
+/**
+ * generation-validation-report/v1
+ */
+function generationValidationReportSchema(value) {
+  const errors = [];
+  if (!isPlainObject(value)) {
+    push(errors, '', 'expected an object');
+    return errors;
+  }
+  if (Number(value.schemaVersion) !== 1) {
+    push(errors, '/schemaVersion', 'expected 1');
+  }
+  if (value.kind != null && value.kind !== 'generation-validation-report') {
+    push(errors, '/kind', 'kind must be "generation-validation-report" when present');
+  }
+  if (typeof value.candidateId !== 'string' || !value.candidateId.trim()) {
+    push(errors, '/candidateId', 'candidateId is required');
+  }
+  if (typeof value.status !== 'string' || !value.status.trim()) {
+    push(errors, '/status', 'status is required');
+  }
+  if (typeof value.reviewReady !== 'boolean') {
+    push(errors, '/reviewReady', 'reviewReady boolean is required');
+  }
+  if (!Array.isArray(value.diagnostics)) {
+    push(errors, '/diagnostics', 'diagnostics must be an array');
+  } else {
+    value.diagnostics.forEach((d, i) => {
+      const base = `/diagnostics/${i}`;
+      if (!isPlainObject(d)) {
+        push(errors, base, 'diagnostic must be an object');
+        return;
+      }
+      if (typeof d.id !== 'string' || !d.id.trim()) {
+        push(errors, `${base}/id`, 'id is required');
+      }
+      if (typeof d.severity !== 'string' || !d.severity.trim()) {
+        push(errors, `${base}/severity`, 'severity is required');
+      }
+      if (typeof d.message !== 'string') {
+        push(errors, `${base}/message`, 'message is required');
+      }
+      if (typeof d.validatorId !== 'string' || !d.validatorId.trim()) {
+        push(errors, `${base}/validatorId`, 'validatorId is required');
+      }
+    });
+  }
+  if (value.summary != null && typeof value.summary !== 'string') {
+    push(errors, '/summary', 'summary must be a string when present');
+  }
+  if (value.policy != null && !isPlainObject(value.policy)) {
+    push(errors, '/policy', 'policy must be an object when present');
+  }
+  return errors;
+}
+
+/**
+ * Neutral optional external linter adapter descriptor (no network default).
+ */
+function externalLinterAdapterSchema(value) {
+  const errors = [];
+  if (!isPlainObject(value)) {
+    push(errors, '', 'expected an object');
+    return errors;
+  }
+  if (Number(value.schemaVersion) !== 1) {
+    push(errors, '/schemaVersion', 'expected 1');
+  }
+  if (typeof value.id !== 'string' || !value.id.trim()) {
+    push(errors, '/id', 'id is required');
+  }
+  if (value.requiresNetwork === true) {
+    push(
+      errors,
+      '/requiresNetwork',
+      'network-dependent linters are not allowed in Community default'
+    );
+  }
+  if (value.requiresCompiler === true) {
+    push(errors, '/requiresCompiler', 'compiler-backed linters are out of Community scope');
+  }
+  return errors;
+}
+
+const GENERATION_SCHEMAS = Object.freeze({
+  [CONTRACT_IDS.GENERATION_CANDIDATE]: {
+    version: 1,
+    schema: generationCandidateSchema,
+  },
+  [CONTRACT_IDS.GENERATION_VALIDATION_REPORT]: {
+    version: 1,
+    schema: generationValidationReportSchema,
+  },
+  [CONTRACT_IDS.EXTERNAL_LINTER_ADAPTER]: {
+    version: 1,
+    schema: externalLinterAdapterSchema,
+  },
+});
+
+module.exports = {
+  CONTRACT_IDS,
+  GENERATION_SCHEMAS,
+  generationCandidateSchema,
+  generationValidationReportSchema,
+  externalLinterAdapterSchema,
+};

--- a/src/generationValidation/extractDeclaredFiles.js
+++ b/src/generationValidation/extractDeclaredFiles.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { normalizeRelativePath } = require('./pathSafety');
+const { FILE_ACTIONS } = require('./constants');
+
+/**
+ * Deterministically extract only explicitly declared proposedFiles.
+ * Markdown fences, free-text paths, and undeclared side channels are ignored.
+ */
+function extractDeclaredFiles(candidate) {
+  const files = Array.isArray(candidate && candidate.proposedFiles) ? candidate.proposedFiles : [];
+  const extracted = [];
+  for (const file of files) {
+    if (!file || typeof file !== 'object') continue;
+    const path = normalizeRelativePath(file.path);
+    if (!path) continue;
+    const action = FILE_ACTIONS.includes(String(file.action || 'modify'))
+      ? String(file.action || 'modify')
+      : 'modify';
+    extracted.push({
+      path,
+      action,
+      language: file.language == null ? null : String(file.language),
+      content: action === 'delete' ? null : file.content == null ? null : String(file.content),
+      rationale: file.rationale == null ? null : String(file.rationale),
+    });
+  }
+  extracted.sort((a, b) => a.path.localeCompare(b.path) || a.action.localeCompare(b.action));
+  return extracted;
+}
+
+module.exports = {
+  extractDeclaredFiles,
+};

--- a/src/generationValidation/index.js
+++ b/src/generationValidation/index.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const constants = require('./constants');
+const contracts = require('./contracts');
+const { createValidatorRegistry } = require('./validatorRegistry');
+const { createBuiltInValidators } = require('./builtInValidators');
+const { extractDeclaredFiles } = require('./extractDeclaredFiles');
+const { validateWorkspacePath, normalizeRelativePath } = require('./pathSafety');
+const {
+  validateGenerationCandidate,
+  createDefaultValidatorRegistry,
+  createDefaultSchemaRegistry,
+} = require('./validateCandidate');
+const {
+  buildReviewDiff,
+  buildValidationReport,
+  writeReviewArtifacts,
+} = require('./reviewArtifacts');
+
+module.exports = {
+  ...constants,
+  CONTRACT_IDS: contracts.CONTRACT_IDS,
+  GENERATION_SCHEMAS: contracts.GENERATION_SCHEMAS,
+  generationCandidateSchema: contracts.generationCandidateSchema,
+  generationValidationReportSchema: contracts.generationValidationReportSchema,
+  externalLinterAdapterSchema: contracts.externalLinterAdapterSchema,
+  createValidatorRegistry,
+  createBuiltInValidators,
+  extractDeclaredFiles,
+  validateWorkspacePath,
+  normalizeRelativePath,
+  validateGenerationCandidate,
+  createDefaultValidatorRegistry,
+  createDefaultSchemaRegistry,
+  buildReviewDiff,
+  buildValidationReport,
+  writeReviewArtifacts,
+};

--- a/src/generationValidation/pathSafety.js
+++ b/src/generationValidation/pathSafety.js
@@ -1,0 +1,180 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const WINDOWS_RESERVED = new Set([
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  'COM1',
+  'COM2',
+  'COM3',
+  'COM4',
+  'COM5',
+  'COM6',
+  'COM7',
+  'COM8',
+  'COM9',
+  'LPT1',
+  'LPT2',
+  'LPT3',
+  'LPT4',
+  'LPT5',
+  'LPT6',
+  'LPT7',
+  'LPT8',
+  'LPT9',
+]);
+
+/**
+ * Normalize a candidate relative path for comparison (posix separators, no leading ./).
+ */
+function normalizeRelativePath(input) {
+  return String(input || '')
+    .replace(/\\/g, '/')
+    .replace(/^\.\/+/, '')
+    .replace(/\/+/g, '/');
+}
+
+function hasControlOrNul(value) {
+  return /[\u0000-\u001f\u007f]/.test(String(value || ''));
+}
+
+function isUncPath(value) {
+  return /^[\\/]{2}/.test(String(value || ''));
+}
+
+function isWindowsDrivePath(value) {
+  return /^[A-Za-z]:[\\/]/.test(String(value || ''));
+}
+
+function hasWindowsReservedName(relativePosix) {
+  const parts = relativePosix.split('/').filter(Boolean);
+  return parts.some(part => {
+    const base = part.split('.')[0].toUpperCase();
+    return WINDOWS_RESERVED.has(base);
+  });
+}
+
+/**
+ * Validate that a declared target path is workspace-relative and inside allowed roots.
+ * Uses path.resolve + relative containment — never prefix-only matching.
+ *
+ * @returns {{ ok: true, relativePath: string, absolutePath: string } | { ok: false, code: string, message: string }}
+ */
+function validateWorkspacePath(rawPath, options = {}) {
+  const { workspaceRoot, allowedRelativeRoots = ['.'], allowAbsolute = false } = options;
+
+  if (rawPath == null || typeof rawPath !== 'string' || !rawPath.trim()) {
+    return { ok: false, code: 'empty', message: 'path is required' };
+  }
+  if (hasControlOrNul(rawPath)) {
+    return { ok: false, code: 'control', message: 'path contains control characters or NUL' };
+  }
+  if (isUncPath(rawPath)) {
+    return { ok: false, code: 'unc', message: 'UNC paths are not allowed' };
+  }
+  if (isWindowsDrivePath(rawPath)) {
+    return { ok: false, code: 'drive', message: 'Windows drive-absolute paths are not allowed' };
+  }
+  if (rawPath.startsWith('/') || rawPath.startsWith('\\')) {
+    if (!allowAbsolute) {
+      return { ok: false, code: 'absolute', message: 'absolute paths are not allowed' };
+    }
+  }
+
+  const posix = normalizeRelativePath(rawPath);
+  if (!posix || posix === '.' || posix === '..') {
+    return { ok: false, code: 'empty', message: 'path is empty after normalization' };
+  }
+  if (posix.split('/').includes('..')) {
+    return { ok: false, code: 'traversal', message: 'parent traversal is not allowed' };
+  }
+  if (hasWindowsReservedName(posix)) {
+    return { ok: false, code: 'reserved', message: 'Windows reserved device name is not allowed' };
+  }
+
+  if (!workspaceRoot || typeof workspaceRoot !== 'string') {
+    // Structural path rules only (no filesystem bind).
+    return { ok: true, relativePath: posix, absolutePath: null };
+  }
+
+  let realRoot;
+  try {
+    realRoot = fs.realpathSync.native
+      ? fs.realpathSync.native(path.resolve(workspaceRoot))
+      : fs.realpathSync(path.resolve(workspaceRoot));
+  } catch {
+    realRoot = path.resolve(workspaceRoot);
+  }
+
+  const candidateAbs = path.resolve(realRoot, ...posix.split('/'));
+  const relativeToRoot = path.relative(realRoot, candidateAbs);
+  if (
+    relativeToRoot.startsWith('..') ||
+    path.isAbsolute(relativeToRoot) ||
+    relativeToRoot.includes(`..${path.sep}`) ||
+    relativeToRoot === '..'
+  ) {
+    return {
+      ok: false,
+      code: 'outside-workspace',
+      message: 'resolved path escapes the authorized workspace root',
+    };
+  }
+
+  // Symlink escape: if the path exists, re-resolve and re-check containment.
+  try {
+    if (fs.existsSync(candidateAbs)) {
+      const realCandidate = fs.realpathSync.native
+        ? fs.realpathSync.native(candidateAbs)
+        : fs.realpathSync(candidateAbs);
+      const rel2 = path.relative(realRoot, realCandidate);
+      if (rel2.startsWith('..') || path.isAbsolute(rel2)) {
+        return {
+          ok: false,
+          code: 'symlink-escape',
+          message: 'resolved path escapes workspace via symlink',
+        };
+      }
+    }
+  } catch {
+    // Non-existent targets are fine for proposed creates; ignore resolve errors.
+  }
+
+  const allowed = (Array.isArray(allowedRelativeRoots) ? allowedRelativeRoots : ['.'])
+    .map(normalizeRelativePath)
+    .filter(Boolean);
+  const inScope = allowed.some(root => {
+    if (root === '.' || root === '') return true;
+    return posix === root || posix.startsWith(`${root}/`);
+  });
+  if (!inScope) {
+    return {
+      ok: false,
+      code: 'outside-scope',
+      message: 'path is outside the authorized relative scope roots',
+    };
+  }
+
+  return {
+    ok: true,
+    relativePath: posix,
+    absolutePath: candidateAbs,
+  };
+}
+
+function caseFoldKey(relativePosix) {
+  return normalizeRelativePath(relativePosix).toLowerCase();
+}
+
+module.exports = {
+  normalizeRelativePath,
+  validateWorkspacePath,
+  caseFoldKey,
+  hasControlOrNul,
+  isUncPath,
+  isWindowsDrivePath,
+};

--- a/src/generationValidation/reviewArtifacts.js
+++ b/src/generationValidation/reviewArtifacts.js
@@ -1,0 +1,184 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { CONTRACT_IDS } = require('./contracts');
+const { STATUS } = require('./constants');
+const { validateWorkspacePath } = require('./pathSafety');
+
+function sha256Text(text) {
+  return crypto
+    .createHash('sha256')
+    .update(String(text || ''), 'utf8')
+    .digest('hex');
+}
+
+function buildReviewDiff(extractedFiles) {
+  const files = (extractedFiles || []).map(file => ({
+    path: file.path,
+    action: file.action,
+    contentSha256: file.content == null ? null : sha256Text(file.content),
+    byteLength: file.content == null ? 0 : Buffer.byteLength(file.content, 'utf8'),
+  }));
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return {
+    schemaVersion: 1,
+    kind: 'generation-review-diff',
+    files,
+  };
+}
+
+function buildValidationReport({
+  candidate,
+  status,
+  diagnostics,
+  extractedFiles,
+  evidenceChecked,
+  policy,
+}) {
+  const reviewReady = status === STATUS.REVIEW_READY;
+  const blockingCount = diagnostics.filter(
+    d => d.severity === 'blocking' || d.severity === 'error'
+  ).length;
+  const summary = [
+    `status=${status}`,
+    `reviewReady=${reviewReady}`,
+    `diagnostics=${diagnostics.length}`,
+    `blockingOrError=${blockingCount}`,
+    `files=${extractedFiles.length}`,
+  ].join('; ');
+
+  const report = {
+    schemaVersion: 1,
+    kind: 'generation-validation-report',
+    contractId: CONTRACT_IDS.GENERATION_VALIDATION_REPORT,
+    contractVersion: 1,
+    candidateId: candidate && candidate.candidateId ? String(candidate.candidateId) : '',
+    correlationId: candidate && candidate.correlationId ? String(candidate.correlationId) : null,
+    status,
+    reviewReady,
+    diagnostics: diagnostics.map(d => ({
+      id: d.id,
+      severity: d.severity,
+      validatorId: d.validatorId,
+      validatorVersion: d.validatorVersion,
+      path: d.path,
+      message: redactMessage(d.message),
+    })),
+    evidenceChecked: Array.isArray(evidenceChecked) ? evidenceChecked : [],
+    assumptions: Array.isArray(candidate && candidate.assumptions)
+      ? [...candidate.assumptions].map(String)
+      : [],
+    uncertainties: Array.isArray(candidate && candidate.uncertainties)
+      ? [...candidate.uncertainties].map(String)
+      : [],
+    policy: policy
+      ? {
+          denied: policy.deny === true,
+          reason: policy.deny === true ? redactMessage(policy.reason || 'denied') : null,
+        }
+      : { denied: false, reason: null },
+    providerIdentity:
+      candidate && candidate.providerIdentity
+        ? {
+            providerId: candidate.providerIdentity.providerId || null,
+            model: candidate.providerIdentity.model || null,
+            advisoryOnly: true,
+            sourceOfTruth: false,
+          }
+        : null,
+    summary,
+    notes: [
+      'review-ready means structural/policy validation passed only.',
+      'It does not mean compiled, functionally correct, IBM i tested, approved, or deployable.',
+      'Provider/model identity is provenance only and is never treated as evidence.',
+    ],
+  };
+
+  // Drop nulls for cleaner deterministic JSON
+  if (report.correlationId == null) delete report.correlationId;
+  if (report.providerIdentity == null) delete report.providerIdentity;
+  return report;
+}
+
+function redactMessage(message) {
+  return String(message || '')
+    .replace(/[A-Za-z]:\\[^\s]+/g, '<redacted-path>')
+    .replace(/\/(?:Users|home)\/[^\s]+/g, '<redacted-path>')
+    .replace(/(password|secret|token|api[_-]?key)\s*[:=]\s*\S+/gi, '$1=<redacted>');
+}
+
+/**
+ * Optionally persist review artifacts under an explicit review root.
+ * Never writes into the analyzed source workspace.
+ */
+function writeReviewArtifacts({
+  reviewArtifactRoot,
+  sourceWorkspaceRoot,
+  report,
+  reviewDiff,
+  candidateId,
+}) {
+  if (!reviewArtifactRoot) {
+    return { written: false, files: [] };
+  }
+  const absReview = path.resolve(reviewArtifactRoot);
+  if (sourceWorkspaceRoot) {
+    const absSource = path.resolve(sourceWorkspaceRoot);
+    const rel = path.relative(absSource, absReview);
+    // Review root must not equal source workspace and must not be inside it.
+    if (rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel))) {
+      throw new Error('reviewArtifactRoot must not be inside the source workspace');
+    }
+  }
+
+  const pathCheck = validateWorkspacePath(`${candidateId || 'candidate'}/validation-report.json`, {
+    workspaceRoot: absReview,
+    allowedRelativeRoots: ['.'],
+  });
+  if (!pathCheck.ok) {
+    throw new Error(`unsafe review artifact path: ${pathCheck.message}`);
+  }
+
+  const dir = path.join(absReview, String(candidateId || 'candidate'));
+  fs.mkdirSync(dir, { recursive: true });
+  const reportPath = path.join(dir, 'validation-report.json');
+  const diffPath = path.join(dir, 'review-diff.json');
+  const reportJson = `${JSON.stringify(report, null, 2)}\n`;
+  const diffJson = `${JSON.stringify(reviewDiff, null, 2)}\n`;
+  fs.writeFileSync(reportPath, reportJson, 'utf8');
+  fs.writeFileSync(diffPath, diffJson, 'utf8');
+  const manifest = {
+    schemaVersion: 1,
+    kind: 'generation-validation-manifest',
+    candidateId: candidateId || null,
+    artifacts: [
+      {
+        path: path.posix.join(String(candidateId || 'candidate'), 'validation-report.json'),
+        sha256: sha256Text(reportJson),
+        sizeBytes: Buffer.byteLength(reportJson, 'utf8'),
+      },
+      {
+        path: path.posix.join(String(candidateId || 'candidate'), 'review-diff.json'),
+        sha256: sha256Text(diffJson),
+        sizeBytes: Buffer.byteLength(diffJson, 'utf8'),
+      },
+    ],
+  };
+  const manifestPath = path.join(dir, 'manifest.json');
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  return {
+    written: true,
+    files: [reportPath, diffPath, manifestPath],
+    manifest,
+  };
+}
+
+module.exports = {
+  buildReviewDiff,
+  buildValidationReport,
+  writeReviewArtifacts,
+  sha256Text,
+  redactMessage,
+};

--- a/src/generationValidation/validateCandidate.js
+++ b/src/generationValidation/validateCandidate.js
@@ -1,0 +1,188 @@
+'use strict';
+
+const { createSchemaRegistry } = require('../core/contracts/schemaRegistry');
+const { CONTRACT_IDS: CORE_CONTRACT_IDS, INITIAL_SCHEMAS } = require('../core/contracts/schemas');
+const { CONTRACT_IDS, GENERATION_SCHEMAS } = require('./contracts');
+const { STATUS, SEVERITY } = require('./constants');
+const { createValidatorRegistry } = require('./validatorRegistry');
+const { createBuiltInValidators } = require('./builtInValidators');
+const { extractDeclaredFiles } = require('./extractDeclaredFiles');
+const {
+  buildReviewDiff,
+  buildValidationReport,
+  writeReviewArtifacts,
+} = require('./reviewArtifacts');
+
+function createDefaultSchemaRegistry() {
+  const registry = createSchemaRegistry({ allowRegistrationAfterUse: true });
+  for (const [id, def] of Object.entries(INITIAL_SCHEMAS)) {
+    registry.register({ id, version: def.version, schema: def.schema });
+  }
+  for (const [id, def] of Object.entries(GENERATION_SCHEMAS)) {
+    try {
+      registry.register({ id, version: def.version, schema: def.schema });
+    } catch {
+      // already registered via INITIAL_SCHEMAS
+    }
+  }
+  return registry;
+}
+
+function createDefaultValidatorRegistry(options = {}) {
+  const registry = createValidatorRegistry({
+    requiredIds: [
+      'schema',
+      'contract-version',
+      'workspace-path',
+      'file-type',
+      'size-limits',
+      'duplicate-target',
+      'scope',
+      'evidence-reference',
+      'policy',
+    ],
+  });
+  for (const validator of createBuiltInValidators(options)) {
+    registry.register(validator);
+  }
+  return registry;
+}
+
+function deriveStatus(diagnostics) {
+  const list = Array.isArray(diagnostics) ? diagnostics : [];
+  const has = idPrefix => list.some(d => String(d.id).startsWith(idPrefix) || d.id === idPrefix);
+  if (list.some(d => d.id === 'GENVAL.VALIDATOR_INTERNAL')) {
+    return STATUS.INTERNAL_VALIDATOR_FAILURE;
+  }
+  if (list.some(d => d.id === 'GENVAL.POLICY_DENIED' || d.id === 'GENVAL.SECRET_LIKE_CONTENT')) {
+    return STATUS.DENIED;
+  }
+  if (
+    list.some(
+      d => d.id === 'GENVAL.SCHEMA_INVALID' || d.id === 'GENVAL.CONTRACT_VERSION_UNSUPPORTED'
+    )
+  ) {
+    return STATUS.INVALID;
+  }
+  if (
+    list.some(d => d.id === 'GENVAL.STATIC_PARSE_UNSUPPORTED' && d.severity === SEVERITY.BLOCKING)
+  ) {
+    return STATUS.UNSUPPORTED;
+  }
+  if (
+    list.some(
+      d =>
+        d.severity === SEVERITY.BLOCKING ||
+        d.severity === SEVERITY.ERROR ||
+        d.id === 'GENVAL.VALIDATOR_MISSING'
+    )
+  ) {
+    return STATUS.VALIDATION_FAILED;
+  }
+  void has;
+  return STATUS.REVIEW_READY;
+}
+
+/**
+ * Validate a generation candidate offline.
+ * Never mutates the source workspace.
+ */
+async function validateGenerationCandidate(candidate, options = {}) {
+  const schemaRegistry = options.schemaRegistry || createDefaultSchemaRegistry();
+  const validatorRegistry =
+    options.validatorRegistry || createDefaultValidatorRegistry(options.validatorOptions || {});
+
+  // Early schema probe for structured invalid without running everything? Still run all required validators.
+  const context = {
+    candidate,
+    workspaceRoot: options.workspaceRoot || null,
+    allowedRelativeRoots: options.allowedRelativeRoots || ['.'],
+    declaredScopePaths: options.declaredScopePaths || null,
+    evidenceStore: options.evidenceStore || {},
+    policy: options.policy || null,
+    schemaRegistry,
+  };
+
+  const { diagnostics } = await validatorRegistry.runAll(context);
+  const status = deriveStatus(diagnostics);
+  const extractedFiles = extractDeclaredFiles(candidate);
+  const evidenceChecked = Array.isArray(candidate && candidate.evidenceReferences)
+    ? candidate.evidenceReferences.map(ref => ({
+        id: ref.id,
+        kind: ref.kind,
+        known: Boolean(options.evidenceStore && options.evidenceStore[ref.id]),
+      }))
+    : [];
+
+  const report = buildValidationReport({
+    candidate,
+    status,
+    diagnostics,
+    extractedFiles,
+    evidenceChecked,
+    policy: options.policy,
+  });
+
+  // Cross-check report against its own schema when registry is available.
+  const reportValidation = schemaRegistry.validate(
+    CONTRACT_IDS.GENERATION_VALIDATION_REPORT,
+    1,
+    report
+  );
+  if (!reportValidation.ok) {
+    report.status = STATUS.INTERNAL_VALIDATOR_FAILURE;
+    report.reviewReady = false;
+    report.diagnostics = [
+      ...report.diagnostics,
+      {
+        id: 'GENVAL.VALIDATOR_INTERNAL',
+        severity: SEVERITY.BLOCKING,
+        validatorId: 'report-schema',
+        validatorVersion: 1,
+        path: null,
+        message: 'Validation report failed its own schema contract',
+      },
+    ];
+    report.summary = `status=${report.status}; reviewReady=false; report-schema-invalid`;
+  }
+
+  const reviewDiff = buildReviewDiff(extractedFiles);
+  let written = { written: false, files: [] };
+  if (options.reviewArtifactRoot) {
+    written = writeReviewArtifacts({
+      reviewArtifactRoot: options.reviewArtifactRoot,
+      sourceWorkspaceRoot: options.workspaceRoot || null,
+      report,
+      reviewDiff,
+      candidateId: candidate && candidate.candidateId,
+    });
+  }
+
+  return {
+    status: report.status,
+    reviewReady: report.reviewReady === true && report.status === STATUS.REVIEW_READY,
+    report,
+    reviewDiff,
+    extractedFiles,
+    artifacts: written,
+    // Explicit non-claims for consumers and docs parity.
+    claims: Object.freeze({
+      structurallyValidated: report.reviewReady === true,
+      compiled: false,
+      functionallyCorrect: false,
+      ibmITested: false,
+      approved: false,
+      deployable: false,
+      sourceWorkspaceMutated: false,
+    }),
+  };
+}
+
+module.exports = {
+  validateGenerationCandidate,
+  createDefaultValidatorRegistry,
+  createDefaultSchemaRegistry,
+  deriveStatus,
+  // re-export for tests
+  CORE_CONTRACT_IDS,
+};

--- a/src/generationValidation/validatorRegistry.js
+++ b/src/generationValidation/validatorRegistry.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const { SEVERITY, DIAGNOSTIC_IDS } = require('./constants');
+
+/**
+ * Dedicated Generation Validator Registry.
+ * Separate from Capability Registry and Provider Registry.
+ * Deterministic order by explicit `order` then id.
+ */
+function createValidatorRegistry(options = {}) {
+  const byId = new Map();
+  let sealed = false;
+  const requiredIds = Array.isArray(options.requiredIds) ? [...options.requiredIds] : [];
+
+  function register(descriptor) {
+    if (sealed) {
+      throw new Error('validator registry is sealed; registration after seal is not allowed');
+    }
+    if (!descriptor || typeof descriptor !== 'object') {
+      throw new Error('validator descriptor must be an object');
+    }
+    const id = String(descriptor.id || '').trim();
+    if (!id) throw new Error('validator id is required');
+    if (byId.has(id)) throw new Error(`duplicate validator id: ${id}`);
+    const version = Number(descriptor.version);
+    if (!Number.isInteger(version) || version < 1) {
+      throw new Error('validator version must be a positive integer');
+    }
+    if (typeof descriptor.validate !== 'function') {
+      throw new Error(`validator ${id} must provide validate(context)`);
+    }
+    const order = Number.isFinite(Number(descriptor.order)) ? Number(descriptor.order) : 100;
+    byId.set(id, {
+      id,
+      version,
+      title: descriptor.title ? String(descriptor.title) : id,
+      description: descriptor.description ? String(descriptor.description) : '',
+      order,
+      blocking: descriptor.blocking !== false,
+      validate: descriptor.validate,
+    });
+  }
+
+  function list() {
+    return [...byId.values()]
+      .map(v => ({
+        id: v.id,
+        version: v.version,
+        title: v.title,
+        description: v.description,
+        order: v.order,
+        blocking: v.blocking,
+      }))
+      .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id));
+  }
+
+  function seal() {
+    sealed = true;
+  }
+
+  function isSealed() {
+    return sealed;
+  }
+
+  /**
+   * Run validators in deterministic order with isolation.
+   * A thrown validator becomes an internal-validator-failure diagnostic and does not
+   * skip remaining required validators.
+   */
+  async function runAll(context) {
+    const missingRequired = requiredIds.filter(id => !byId.has(id));
+    const diagnostics = [];
+    for (const id of missingRequired) {
+      diagnostics.push({
+        id: DIAGNOSTIC_IDS.VALIDATOR_MISSING,
+        severity: SEVERITY.BLOCKING,
+        validatorId: 'registry',
+        validatorVersion: 1,
+        path: null,
+        message: `Required validator is not registered: ${id}`,
+      });
+    }
+
+    const ordered = [...byId.values()].sort(
+      (a, b) => a.order - b.order || a.id.localeCompare(b.id)
+    );
+    for (const validator of ordered) {
+      try {
+        const result = await validator.validate(context);
+        const items = Array.isArray(result)
+          ? result
+          : result && Array.isArray(result.diagnostics)
+            ? result.diagnostics
+            : [];
+        for (const item of items) {
+          if (!item || typeof item !== 'object') continue;
+          diagnostics.push({
+            id: String(item.id || DIAGNOSTIC_IDS.VALIDATOR_INTERNAL),
+            severity: String(item.severity || SEVERITY.ERROR),
+            validatorId: validator.id,
+            validatorVersion: validator.version,
+            path: item.path == null ? null : String(item.path),
+            message: String(item.message || 'validator reported an issue'),
+          });
+        }
+      } catch (error) {
+        diagnostics.push({
+          id: DIAGNOSTIC_IDS.VALIDATOR_INTERNAL,
+          severity: SEVERITY.BLOCKING,
+          validatorId: validator.id,
+          validatorVersion: validator.version,
+          path: null,
+          message: 'Validator failed internally; raw exception details are redacted.',
+        });
+        // Keep iterating — remaining required checks still run.
+        void error;
+      }
+    }
+
+    diagnostics.sort((a, b) => {
+      const bySev = severityRank(a.severity) - severityRank(b.severity);
+      if (bySev !== 0) return bySev;
+      const byIdCmp = a.id.localeCompare(b.id);
+      if (byIdCmp !== 0) return byIdCmp;
+      return String(a.path || '').localeCompare(String(b.path || ''));
+    });
+
+    return { diagnostics };
+  }
+
+  return {
+    register,
+    list,
+    seal,
+    isSealed,
+    runAll,
+    has: id => byId.has(id),
+  };
+}
+
+function severityRank(severity) {
+  switch (String(severity)) {
+    case SEVERITY.BLOCKING:
+      return 0;
+    case SEVERITY.ERROR:
+      return 1;
+    case SEVERITY.WARNING:
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+module.exports = {
+  createValidatorRegistry,
+};

--- a/tests/generation-validation.test.js
+++ b/tests/generation-validation.test.js
@@ -1,0 +1,321 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  validateGenerationCandidate,
+  createDefaultValidatorRegistry,
+  createValidatorRegistry,
+  extractDeclaredFiles,
+  validateWorkspacePath,
+  CONTRACT_IDS,
+  STATUS,
+  DIAGNOSTIC_IDS,
+  generationCandidateSchema,
+  generationValidationReportSchema,
+} = require('../src/generationValidation');
+const { CONTRACT_IDS: CORE_IDS, INITIAL_SCHEMAS } = require('../src/core/contracts/schemas');
+const contracts = require('../src/core/contracts');
+const { createZeus } = require('../src/api/zeusApi');
+
+function minimalCandidate(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'generation-candidate',
+    contractId: CONTRACT_IDS.GENERATION_CANDIDATE,
+    candidateId: 'cand-1',
+    taskSummary: 'Adjust field handling in ORDERPGM',
+    evidenceReferences: [{ id: 'ev-canonical', kind: 'artifact', path: 'canonical-analysis.json' }],
+    assumptions: ['Source encoding is UTF-8'],
+    uncertainties: ['Business rule completeness unknown'],
+    proposedFiles: [
+      {
+        path: 'QRPGLESRC/ORDERPGM.rpgle',
+        action: 'modify',
+        language: 'rpgle',
+        content: '**free\ndcl-s x int(10);\n',
+        rationale: 'Declare working variable',
+      },
+    ],
+    validationPlan: { requiredValidators: ['schema', 'workspace-path'] },
+    providerIdentity: { providerId: 'mock-local', model: 'mock-1' },
+    correlationId: 'corr-1',
+    ...overrides,
+  };
+}
+
+function evidenceStore() {
+  return {
+    'ev-canonical': { kind: 'artifact', path: 'canonical-analysis.json' },
+  };
+}
+
+test('contracts are registered in INITIAL_SCHEMAS', () => {
+  assert.ok(INITIAL_SCHEMAS[CONTRACT_IDS.GENERATION_CANDIDATE]);
+  assert.ok(INITIAL_SCHEMAS[CONTRACT_IDS.GENERATION_VALIDATION_REPORT]);
+  assert.ok(INITIAL_SCHEMAS[CONTRACT_IDS.EXTERNAL_LINTER_ADAPTER]);
+  assert.equal(CORE_IDS.GENERATION_CANDIDATE, 'zeus.generation-candidate');
+});
+
+test('schema accepts minimal valid candidate and rejects bad version', () => {
+  assert.equal(generationCandidateSchema(minimalCandidate()).length, 0);
+  const bad = generationCandidateSchema(minimalCandidate({ schemaVersion: 99 }));
+  assert.ok(bad.some(e => e.path === '/schemaVersion'));
+});
+
+test('schema rejects chain-of-thought fields', () => {
+  const errors = generationCandidateSchema(minimalCandidate({ chainOfThought: 'secret thoughts' }));
+  assert.ok(errors.length > 0);
+});
+
+test('extractDeclaredFiles ignores undeclared side channels', () => {
+  const candidate = minimalCandidate({
+    additionalFiles: [{ path: 'evil.rpgle', content: 'x' }],
+    freeText: '```rpgle\n// not declared\n```',
+  });
+  const extracted = extractDeclaredFiles(candidate);
+  assert.equal(extracted.length, 1);
+  assert.equal(extracted[0].path, 'QRPGLESRC/ORDERPGM.rpgle');
+});
+
+test('path safety rejects traversal, absolute, drive, unc, and control chars', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-genval-ws-'));
+  try {
+    assert.equal(validateWorkspacePath('../escape.rpgle', { workspaceRoot: root }).ok, false);
+    assert.equal(validateWorkspacePath('/etc/passwd', { workspaceRoot: root }).ok, false);
+    assert.equal(validateWorkspacePath('C:\\Windows\\a.rpgle', { workspaceRoot: root }).ok, false);
+    assert.equal(
+      validateWorkspacePath('\\\\server\\share\\a.rpgle', { workspaceRoot: root }).ok,
+      false
+    );
+    assert.equal(validateWorkspacePath('a\u0000b.rpgle', { workspaceRoot: root }).ok, false);
+    assert.equal(
+      validateWorkspacePath('QRPGLESRC/ORDERPGM.rpgle', { workspaceRoot: root }).ok,
+      true
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('valid candidate with evidence becomes review-ready without mutating workspace', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-genval-src-'));
+  const marker = path.join(root, 'untouched.txt');
+  fs.writeFileSync(marker, 'keep\n', 'utf8');
+  const before = fs.readFileSync(marker, 'utf8');
+  try {
+    const result = await validateGenerationCandidate(minimalCandidate(), {
+      workspaceRoot: root,
+      evidenceStore: evidenceStore(),
+    });
+    assert.equal(result.status, STATUS.REVIEW_READY);
+    assert.equal(result.reviewReady, true);
+    assert.equal(result.claims.compiled, false);
+    assert.equal(result.claims.sourceWorkspaceMutated, false);
+    assert.equal(fs.readFileSync(marker, 'utf8'), before);
+    assert.equal(generationValidationReportSchema(result.report).length, 0);
+    assert.equal(result.report.providerIdentity.advisoryOnly, true);
+    assert.equal(result.report.providerIdentity.sourceOfTruth, false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('missing evidence is not review-ready', async () => {
+  const result = await validateGenerationCandidate(minimalCandidate(), {
+    evidenceStore: {},
+  });
+  assert.notEqual(result.status, STATUS.REVIEW_READY);
+  assert.equal(result.reviewReady, false);
+  assert.ok(result.report.diagnostics.some(d => d.id === DIAGNOSTIC_IDS.EVIDENCE_UNKNOWN));
+});
+
+test('policy denial cannot become review-ready', async () => {
+  const result = await validateGenerationCandidate(minimalCandidate(), {
+    evidenceStore: evidenceStore(),
+    policy: { deny: true, reason: 'org policy blocks generation review' },
+  });
+  assert.equal(result.status, STATUS.DENIED);
+  assert.equal(result.reviewReady, false);
+  assert.ok(result.report.diagnostics.some(d => d.id === DIAGNOSTIC_IDS.POLICY_DENIED));
+});
+
+test('traversal path fails closed', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-genval-trav-'));
+  try {
+    const result = await validateGenerationCandidate(
+      minimalCandidate({
+        proposedFiles: [
+          {
+            path: '../outside.rpgle',
+            action: 'create',
+            content: 'x\n',
+          },
+        ],
+      }),
+      { workspaceRoot: root, evidenceStore: evidenceStore() }
+    );
+    assert.equal(result.reviewReady, false);
+    assert.ok(result.report.diagnostics.some(d => d.id === DIAGNOSTIC_IDS.PATH_UNSAFE));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('duplicate targets and disallowed types fail', async () => {
+  const result = await validateGenerationCandidate(
+    minimalCandidate({
+      proposedFiles: [
+        { path: 'QRPGLESRC/A.rpgle', action: 'modify', content: 'a\n' },
+        { path: 'qrpglesrc/a.rpgle', action: 'modify', content: 'b\n' },
+        { path: 'bin/tool.exe', action: 'create', content: 'MZ' },
+      ],
+    }),
+    { evidenceStore: evidenceStore() }
+  );
+  assert.equal(result.reviewReady, false);
+  assert.ok(result.report.diagnostics.some(d => d.id === DIAGNOSTIC_IDS.DUPLICATE_TARGET));
+  assert.ok(result.report.diagnostics.some(d => d.id === DIAGNOSTIC_IDS.FILE_TYPE_DENIED));
+});
+
+test('scope expansion fails closed', async () => {
+  const result = await validateGenerationCandidate(minimalCandidate(), {
+    evidenceStore: evidenceStore(),
+    declaredScopePaths: ['QCLLESRC'],
+  });
+  assert.equal(result.reviewReady, false);
+  assert.ok(result.report.diagnostics.some(d => d.id === DIAGNOSTIC_IDS.SCOPE_EXPANSION));
+});
+
+test('secret-like content is denied', async () => {
+  const result = await validateGenerationCandidate(
+    minimalCandidate({
+      proposedFiles: [
+        {
+          path: 'QRPGLESRC/X.rpgle',
+          action: 'modify',
+          content: "password = 'super-secret-value-123'\n",
+        },
+      ],
+    }),
+    { evidenceStore: evidenceStore() }
+  );
+  assert.equal(result.status, STATUS.DENIED);
+  assert.equal(result.reviewReady, false);
+});
+
+test('validator registry isolates failures and keeps required order', async () => {
+  const registry = createValidatorRegistry({ requiredIds: ['a', 'b'] });
+  const seen = [];
+  registry.register({
+    id: 'a',
+    version: 1,
+    order: 1,
+    validate() {
+      seen.push('a');
+      throw new Error('boom with secret=abc');
+    },
+  });
+  registry.register({
+    id: 'b',
+    version: 1,
+    order: 2,
+    validate() {
+      seen.push('b');
+      return [{ id: 'GENVAL.TEST', severity: 'warning', message: 'ok' }];
+    },
+  });
+  const { diagnostics } = await registry.runAll({});
+  assert.deepEqual(seen, ['a', 'b']);
+  assert.ok(diagnostics.some(d => d.id === DIAGNOSTIC_IDS.VALIDATOR_INTERNAL));
+  assert.ok(!JSON.stringify(diagnostics).includes('secret=abc'));
+  assert.ok(diagnostics.some(d => d.validatorId === 'b'));
+});
+
+test('duplicate validator registration fails', () => {
+  const registry = createDefaultValidatorRegistry();
+  assert.throws(() => {
+    registry.register({ id: 'schema', version: 1, validate: () => [] });
+  }, /duplicate validator id/);
+});
+
+test('review artifacts write only outside source workspace', async () => {
+  const source = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-genval-source-'));
+  const review = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-genval-review-'));
+  try {
+    const result = await validateGenerationCandidate(minimalCandidate(), {
+      workspaceRoot: source,
+      reviewArtifactRoot: review,
+      evidenceStore: evidenceStore(),
+    });
+    assert.equal(result.reviewReady, true);
+    assert.equal(result.artifacts.written, true);
+    assert.ok(fs.existsSync(path.join(review, 'cand-1', 'validation-report.json')));
+    assert.ok(fs.existsSync(path.join(review, 'cand-1', 'review-diff.json')));
+    assert.ok(fs.existsSync(path.join(review, 'cand-1', 'manifest.json')));
+    // source remains empty of generated patches
+    assert.deepEqual(fs.readdirSync(source), []);
+  } finally {
+    fs.rmSync(source, { recursive: true, force: true });
+    fs.rmSync(review, { recursive: true, force: true });
+  }
+});
+
+test('writing review artifacts into source workspace is rejected', async () => {
+  const source = fs.mkdtempSync(path.join(os.tmpdir(), 'zeus-genval-badreview-'));
+  try {
+    await assert.rejects(
+      () =>
+        validateGenerationCandidate(minimalCandidate(), {
+          workspaceRoot: source,
+          reviewArtifactRoot: source,
+          evidenceStore: evidenceStore(),
+        }),
+      /must not be inside the source workspace/
+    );
+  } finally {
+    fs.rmSync(source, { recursive: true, force: true });
+  }
+});
+
+test('reports are deterministic across repeated runs', async () => {
+  const options = { evidenceStore: evidenceStore() };
+  const a = await validateGenerationCandidate(minimalCandidate(), options);
+  const b = await validateGenerationCandidate(minimalCandidate(), options);
+  assert.equal(JSON.stringify(a.report), JSON.stringify(b.report));
+  assert.equal(JSON.stringify(a.reviewDiff), JSON.stringify(b.reviewDiff));
+});
+
+test('public API exposes generationValidation namespace', async () => {
+  const zeus = createZeus();
+  assert.equal(typeof zeus.generationValidation.validateGenerationCandidate, 'function');
+  const result = await zeus.generationValidation.validateGenerationCandidate(minimalCandidate(), {
+    evidenceStore: evidenceStore(),
+  });
+  assert.equal(result.reviewReady, true);
+  assert.ok(contracts.generationValidation);
+});
+
+test('unsupported contract version is invalid', async () => {
+  const result = await validateGenerationCandidate(minimalCandidate({ schemaVersion: 2 }), {
+    evidenceStore: evidenceStore(),
+  });
+  assert.equal(result.status, STATUS.INVALID);
+  assert.equal(result.reviewReady, false);
+});
+
+test('content size limit fails closed', async () => {
+  const big = 'x'.repeat(300 * 1024);
+  const result = await validateGenerationCandidate(
+    minimalCandidate({
+      proposedFiles: [{ path: 'QRPGLESRC/BIG.rpgle', action: 'modify', content: big }],
+    }),
+    { evidenceStore: evidenceStore() }
+  );
+  assert.equal(result.reviewReady, false);
+  assert.ok(result.report.diagnostics.some(d => d.id === DIAGNOSTIC_IDS.CONTENT_TOO_LARGE));
+});


### PR DESCRIPTION
## Summary

Adds the Community **Generation Validation Foundation** (Iteration 29): offline, fail-closed validation of structured generation candidates as review artifacts.

### Contracts
- `zeus.generation-candidate@1`
- `zeus.generation-validation-report@1`
- `zeus.external-linter-adapter@1` (descriptor only; no network/compiler default)

### Behavior
- Dedicated validator registry (separate from capability/provider registries)
- Built-ins: schema, contract version, workspace path, file type, size limits, duplicate targets, declared scope, evidence references, policy, light static source-type check
- Deterministic extraction of **only** declared `proposedFiles`
- Review report + review diff; optional write under explicit `reviewArtifactRoot` **outside** the source workspace
- `review-ready` is structural/policy only — never compiled/functionally correct/IBM i tested/approved/deployable
- No source workspace mutation, no repair loop, no commercial packs, no CLI/MCP expansion required

### API
- Programmatic: `zeus.generationValidation.validateGenerationCandidate(...)`
- Documented in ADR-008

### Validation
- Focused suite 20/20 (x3)
- format, lint, typecheck, discovery (131), quality, benchmark, package smoke, docs, demo safety, public claims, portability, audit, pack dry-run
- Full suite local: only known Windows symlink EPERM environmental failure remains (GitHub Windows CI is authoritative)

## Non-goals kept out
Repair controller, auto workspace writes, compiler/IBM i calls, commercial Generation Assurance, entitlement, Iteration 30.