### PR TITLE
feat(core): add external module compatibility contracts

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -40,6 +40,9 @@ All subsequent implementation and agent guidance must be consistent with these d
   private-by-default transport policy, redaction, and evidence-separation rules in ADR-007.
 - Structured generation candidates must follow the offline validation, path/scope safety,
   evidence-reference, and non-mutation rules in ADR-008. `review-ready` is never compile readiness.
+- External modules must use the trusted in-process registrar and module descriptor contracts
+  (ADR-006 executable subset; see `docs/modules/authoring-external-module-registration.md`).
+  The core never enforces commercial licenses.
 
 ## Regenerating Supporting Artifacts
 

--- a/docs/modules/authoring-external-module-registration.md
+++ b/docs/modules/authoring-external-module-registration.md
@@ -1,0 +1,101 @@
+---
+Title: External Module Registration
+Description: How trusted in-process modules register against Zeus Community Core without core license enforcement.
+Last Updated: 2026-07-19
+---
+
+# External Module Registration (Community Core)
+
+This guide describes the **public neutral module boundary** introduced in Iteration 30.
+It implements the executable subset of [ADR-006](../architecture/adr-006-commercial-extension-architecture.md).
+
+## Core principles
+
+- Zeus Community Core remains fully useful **without** any external module.
+- Registration is **explicit and trusted**: the host imports an installed package and calls
+  `registerModule({ descriptor, register })`.
+- The core **never** scans directories, environment paths, or marketplaces, and never
+  dynamically loads untrusted module names.
+- `edition` and `entitlement.mode` are **display/classification metadata only**. The core does
+  **not** parse license keys, validate signatures, or unlock paid features.
+- Entitlement enforcement belongs in the external module (for commercial packages).
+- Module code runs with the same process rights as the host. Loading arbitrary third-party code
+  is **not** a security sandbox.
+
+## Descriptor v1
+
+Required shape (normalized):
+
+```json
+{
+  "descriptorVersion": "zeus.module-descriptor/v1",
+  "id": "vendor.module-name",
+  "version": "1.0.0",
+  "edition": "community",
+  "compatibility": { "moduleApi": ">=1.0.0 <2.0.0" },
+  "capabilities": [{ "id": "vendor.capability", "version": 1 }],
+  "safety": { "level": "S1", "sideEffects": ["local-read"] },
+  "runtime": { "requiredFeatures": ["local-filesystem"] },
+  "entitlement": { "mode": "none" },
+  "docs": { "title": "Example", "reference": "docs/modules/example.md" }
+}
+```
+
+- `edition`: `community` | `professional` | `enterprise` (classification only).
+- `entitlement.mode`: `none` | `module-managed` (no license material).
+- Runtime features must come from the public allowlist (`local-filesystem`, `local-process`,
+  `node-crypto`, `offline-only`).
+
+## Registration API
+
+```js
+const { createZeus } = require('zeus-rpg-promptkit/api');
+const zeus = createZeus();
+
+const result = await zeus.modules.registerModule({
+  descriptor: {/* ... */},
+  register({ capabilityRegistry, module, coreModuleApiVersion }) {
+    capabilityRegistry.register({
+      id: 'vendor.capability',
+      version: 1,
+      title: 'Example',
+      safety: { level: 'S1', sideEffects: ['local-read'], requiresExplicitApproval: false },
+      availability: { api: true },
+      execute: async () => ({ ok: true }),
+    });
+  },
+  status: {
+    availability: 'available',
+    reasonCode: 'AVAILABLE',
+  },
+});
+```
+
+Registration is **atomic**: on failure, the module is not listed and capabilities are not
+committed. The core continues to serve Community analysis and existing user artifacts.
+
+## Availability reason codes
+
+Public status uses fixed redacted codes such as `AVAILABLE`, `NOT_INSTALLED`,
+`INCOMPATIBLE_CORE`, `DESCRIPTOR_INVALID`, `REGISTRATION_FAILED`, `RUNTIME_UNAVAILABLE`,
+`POLICY_DENIED`, `ENTITLEMENT_REQUIRED`, `ENTITLEMENT_EXPIRED`, `ENTITLEMENT_INVALID`.
+
+Entitlement-related codes may be **reported by modules** for UI honesty. The core does not
+evaluate licenses to produce them.
+
+## Contract Test Kit
+
+```js
+const { runModuleContractTests } = require('zeus-rpg-promptkit/module-contract-test');
+await runModuleContractTests();
+```
+
+The kit contains no commercial implementation and no signing keys.
+
+## Failure isolation
+
+If a module is missing, incompatible, or fails registration:
+
+- Community commands, evidence, and artifacts remain available;
+- only the module's capabilities are absent;
+- diagnostics are redacted (no secrets, license keys, customer IDs, or local paths).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./cli/zeus.js",
     "./api": "./src/api/zeusApi.js",
+    "./module-contract-test": "./src/modules/contractTestKit.js",
     "./package.json": "./package.json"
   },
   "bin": {

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -22,6 +22,8 @@ const providerRedaction = require('../providers/redaction');
 const providerTesting = require('../providers/testing');
 const providerAdapters = require('../providers/adapters');
 const generationValidation = require('../generationValidation');
+const modulesApi = require('../modules');
+const { createAtomicModuleRegistrar } = require('../modules/moduleRegistrar');
 const { executeQueryTable } = require('../core/queryService');
 const {
   executeListRuns,
@@ -859,6 +861,12 @@ const zeus = {
   // Generation Validation Foundation (Iteration 29): offline candidate validation.
   // Never mutates the analyzed source workspace. review-ready is not compile readiness.
   generationValidation,
+  // External module contracts (Iteration 30): trusted in-process registration only.
+  // Core does not parse licenses or enforce commercial entitlement.
+  modules: createAtomicModuleRegistrar({
+    capabilityRegistry,
+  }),
+  moduleContracts: modulesApi,
   components: new ComponentRegistry(),
   analyzeStages: analyzeStageRegistry,
 
@@ -935,10 +943,22 @@ module.exports = {
   // Generation Validation Foundation (Community safety baseline)
   generationValidation,
 
+  // Module descriptor / registrar contracts (Community; no license enforcement)
+  modules: zeus.modules,
+  moduleContracts: modulesApi,
+  createAtomicModuleRegistrar,
+
   zeus,
-  createZeus: () => ({
-    ...zeus,
-    providers: createProviderNamespace(),
-    generationValidation,
-  }),
+  createZeus: () => {
+    const { createCapabilityRegistry: createCaps } = require('../core/capabilityRegistry');
+    const caps = createCaps();
+    return {
+      ...zeus,
+      providers: createProviderNamespace(),
+      generationValidation,
+      capabilities: caps,
+      modules: createAtomicModuleRegistrar({ capabilityRegistry: caps }),
+      moduleContracts: modulesApi,
+    };
+  },
 };

--- a/src/core/contracts/contractIds.js
+++ b/src/core/contracts/contractIds.js
@@ -40,4 +40,6 @@ module.exports = Object.freeze({
   GENERATION_CANDIDATE: 'zeus.generation-candidate',
   GENERATION_VALIDATION_REPORT: 'zeus.generation-validation-report',
   EXTERNAL_LINTER_ADAPTER: 'zeus.external-linter-adapter',
+  MODULE_DESCRIPTOR: 'zeus.module-descriptor',
+  MODULE_STATUS: 'zeus.module-status',
 });

--- a/src/core/contracts/schemas.js
+++ b/src/core/contracts/schemas.js
@@ -270,6 +270,31 @@ const safetyPolicySchema = value => {
 
 const { PROVIDER_SCHEMAS } = require('../../providers/contracts');
 const { GENERATION_SCHEMAS } = require('../../generationValidation/contracts');
+const { moduleDescriptorSchema } = require('../../modules/descriptor');
+
+function moduleStatusSchema(value) {
+  const errors = basicHeaderValidator(1)(value);
+  if (!value || typeof value !== 'object') return errors;
+  if (value.kind != null && value.kind !== 'module-status') {
+    errors.push({ path: '/kind', message: 'kind must be "module-status" when present' });
+  }
+  if (typeof value.lifecycle !== 'string' || !value.lifecycle) {
+    errors.push({ path: '/lifecycle', message: 'lifecycle is required' });
+  }
+  if (typeof value.availability !== 'string' || !value.availability) {
+    errors.push({ path: '/availability', message: 'availability is required' });
+  }
+  if (typeof value.reasonCode !== 'string' || !value.reasonCode) {
+    errors.push({ path: '/reasonCode', message: 'reasonCode is required' });
+  }
+  if (value.coreEnforcesEntitlement !== false && value.coreEnforcesEntitlement != null) {
+    errors.push({
+      path: '/coreEnforcesEntitlement',
+      message: 'coreEnforcesEntitlement must be false when present',
+    });
+  }
+  return errors;
+}
 
 const INITIAL_SCHEMAS = Object.freeze({
   [CONTRACT_IDS.EVIDENCE_MODEL]: { version: 1, schema: evidenceModelSchema },
@@ -281,6 +306,8 @@ const INITIAL_SCHEMAS = Object.freeze({
   [CONTRACT_IDS.SAFETY_POLICY]: { version: 1, schema: safetyPolicySchema },
   ...PROVIDER_SCHEMAS,
   ...GENERATION_SCHEMAS,
+  [CONTRACT_IDS.MODULE_DESCRIPTOR]: { version: 1, schema: moduleDescriptorSchema },
+  [CONTRACT_IDS.MODULE_STATUS]: { version: 1, schema: moduleStatusSchema },
 });
 
 module.exports = {

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const DESCRIPTOR_VERSION = 'zeus.module-descriptor/v1';
+const MODULE_API_VERSION = '1.0.0';
+const MODULE_STATUS_KIND = 'module-status';
+
+const EDITIONS = Object.freeze(['community', 'professional', 'enterprise']);
+const ENTITLEMENT_MODES = Object.freeze(['none', 'module-managed']);
+
+const AVAILABILITY = Object.freeze({
+  AVAILABLE: 'available',
+  DEGRADED: 'degraded',
+  UNAVAILABLE: 'unavailable',
+});
+
+/**
+ * Fixed redacted public reason codes (ADR-006 + Iteration 30).
+ * Core never invents entitlement outcomes; it may only surface codes supplied
+ * by an external trusted module or produced by core compatibility checks.
+ */
+const REASON_CODES = Object.freeze({
+  AVAILABLE: 'AVAILABLE',
+  NOT_INSTALLED: 'NOT_INSTALLED',
+  INCOMPATIBLE_CORE: 'INCOMPATIBLE_CORE',
+  DESCRIPTOR_INVALID: 'DESCRIPTOR_INVALID',
+  REGISTRATION_FAILED: 'REGISTRATION_FAILED',
+  RUNTIME_UNAVAILABLE: 'RUNTIME_UNAVAILABLE',
+  POLICY_DENIED: 'POLICY_DENIED',
+  ENTITLEMENT_REQUIRED: 'ENTITLEMENT_REQUIRED',
+  ENTITLEMENT_EXPIRED: 'ENTITLEMENT_EXPIRED',
+  ENTITLEMENT_INVALID: 'ENTITLEMENT_INVALID',
+  // ADR-006 aliases kept for documentation parity
+  MODULE_API_INCOMPATIBLE: 'MODULE_API_INCOMPATIBLE',
+  DUPLICATE_MODULE_ID: 'DUPLICATE_MODULE_ID',
+  CAPABILITY_CONFLICT: 'CAPABILITY_CONFLICT',
+  RUNTIME_FEATURE_MISSING: 'RUNTIME_FEATURE_MISSING',
+  ENTITLEMENT_UNAVAILABLE: 'ENTITLEMENT_UNAVAILABLE',
+  MODULE_POLICY_DENIED: 'MODULE_POLICY_DENIED',
+  MODULE_INITIALIZATION_FAILED: 'MODULE_INITIALIZATION_FAILED',
+  MODULE_DISABLED: 'MODULE_DISABLED',
+  MODULE_UNAVAILABLE: 'MODULE_UNAVAILABLE',
+});
+
+const LIFECYCLE = Object.freeze({
+  DECLARED: 'declared',
+  VALIDATING: 'validating',
+  REGISTERED: 'registered',
+  REJECTED: 'rejected',
+});
+
+const RUNTIME_FEATURE_ALLOWLIST = Object.freeze([
+  'local-filesystem',
+  'local-process',
+  'node-crypto',
+  'offline-only',
+]);
+
+const SAFETY_LEVELS = Object.freeze(['S0', 'S1', 'S2', 'S3', 'S4']);
+
+module.exports = {
+  DESCRIPTOR_VERSION,
+  MODULE_API_VERSION,
+  MODULE_STATUS_KIND,
+  EDITIONS,
+  ENTITLEMENT_MODES,
+  AVAILABILITY,
+  REASON_CODES,
+  LIFECYCLE,
+  RUNTIME_FEATURE_ALLOWLIST,
+  SAFETY_LEVELS,
+};

--- a/src/modules/contractTestKit.js
+++ b/src/modules/contractTestKit.js
@@ -1,0 +1,199 @@
+'use strict';
+
+/**
+ * Public Module Contract Test Kit (Iteration 30).
+ * External module authors can require('zeus-rpg-promptkit/module-contract-test').
+ * No commercial entitlement implementation is included.
+ */
+
+const assert = require('node:assert/strict');
+const {
+  DESCRIPTOR_VERSION,
+  MODULE_API_VERSION,
+  REASON_CODES,
+  AVAILABILITY,
+} = require('./constants');
+const { normalizeModuleDescriptor } = require('./descriptor');
+const { createAtomicModuleRegistrar } = require('./moduleRegistrar');
+const { createCapabilityRegistry } = require('../core/capabilityRegistry');
+const { satisfies } = require('./semverRange');
+
+function buildValidDescriptor(overrides = {}) {
+  return {
+    descriptorVersion: DESCRIPTOR_VERSION,
+    id: 'example.community-module',
+    version: '1.0.0',
+    edition: 'community',
+    compatibility: { moduleApi: '>=1.0.0 <2.0.0' },
+    capabilities: [{ id: 'example.inspect', version: 1 }],
+    safety: { level: 'S1', sideEffects: ['local-read'] },
+    runtime: { requiredFeatures: ['local-filesystem'] },
+    entitlement: { mode: 'none' },
+    docs: { title: 'Example community module', reference: 'docs/modules/example.md' },
+    ...overrides,
+  };
+}
+
+function createMockRegister(capabilityId = 'example.inspect') {
+  return ({ capabilityRegistry }) => {
+    capabilityRegistry.register({
+      id: capabilityId,
+      version: 1,
+      title: 'Example inspect',
+      description: 'Harmless mock capability for contract tests',
+      category: 'module',
+      safety: { level: 'S1', sideEffects: ['local-read'], requiresExplicitApproval: false },
+      availability: { api: true, cli: false, mcp: false, viewer: false, vscode: false },
+      execute: async () => ({ ok: true, advisory: true }),
+    });
+  };
+}
+
+/**
+ * Run the standard contract assertions against the current core.
+ * Throws AssertionError on failure (usable from node:test or mocha).
+ */
+async function runModuleContractTests(options = {}) {
+  const results = [];
+  function check(name, fn) {
+    try {
+      const out = fn();
+      if (out && typeof out.then === 'function') {
+        return out
+          .then(() => results.push({ name, ok: true }))
+          .catch(err => {
+            results.push({ name, ok: false, error: String(err && err.message) });
+            throw err;
+          });
+      }
+      results.push({ name, ok: true });
+    } catch (err) {
+      results.push({ name, ok: false, error: String(err && err.message) });
+      throw err;
+    }
+  }
+
+  await check('valid minimal descriptor normalizes', () => {
+    const res = normalizeModuleDescriptor(buildValidDescriptor());
+    assert.equal(res.ok, true);
+    assert.equal(res.descriptor.descriptorVersion, DESCRIPTOR_VERSION);
+  });
+
+  await check('invalid descriptor is rejected', () => {
+    const res = normalizeModuleDescriptor(buildValidDescriptor({ id: '' }));
+    assert.equal(res.ok, false);
+  });
+
+  await check('core module API satisfies default range', () => {
+    assert.equal(satisfies(MODULE_API_VERSION, '>=1.0.0 <2.0.0'), true);
+  });
+
+  await check('valid module registers atomically', async () => {
+    const registrar = createAtomicModuleRegistrar({
+      capabilityRegistry: createCapabilityRegistry(),
+    });
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor(),
+      register: createMockRegister(),
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.status.reasonCode, REASON_CODES.AVAILABLE);
+    assert.equal(result.status.coreEnforcesEntitlement, false);
+    assert.ok(registrar.capabilityRegistry.get('example.inspect'));
+  });
+
+  await check('duplicate module id is rejected', async () => {
+    const registrar = createAtomicModuleRegistrar({
+      capabilityRegistry: createCapabilityRegistry(),
+    });
+    const input = {
+      descriptor: buildValidDescriptor(),
+      register: createMockRegister(),
+    };
+    assert.equal((await registrar.registerModule(input)).ok, true);
+    const second = await registrar.registerModule(input);
+    assert.equal(second.ok, false);
+    assert.equal(second.status.reasonCode, REASON_CODES.DUPLICATE_MODULE_ID);
+  });
+
+  await check('incompatible core range fails closed', async () => {
+    const registrar = createAtomicModuleRegistrar();
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor({
+        compatibility: { moduleApi: '>=9.0.0 <10.0.0' },
+      }),
+      register: createMockRegister(),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status.reasonCode, REASON_CODES.INCOMPATIBLE_CORE);
+  });
+
+  await check('dynamic path registration is denied', async () => {
+    const registrar = createAtomicModuleRegistrar();
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor(),
+      register: createMockRegister(),
+      path: 'C:\\untrusted\\module.js',
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status.reasonCode, REASON_CODES.POLICY_DENIED);
+  });
+
+  await check('handler failure does not leave module registered', async () => {
+    const caps = createCapabilityRegistry();
+    const registrar = createAtomicModuleRegistrar({ capabilityRegistry: caps });
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor(),
+      register: () => {
+        throw new Error('init boom secret=abc');
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(registrar.listModules().length, 0);
+    assert.equal(caps.list().length, 0);
+    assert.ok(!JSON.stringify(result.status).includes('secret=abc'));
+  });
+
+  await check('not installed status is available', () => {
+    const registrar = createAtomicModuleRegistrar();
+    const status = registrar.notInstalledStatus();
+    assert.equal(status.reasonCode, REASON_CODES.NOT_INSTALLED);
+    assert.equal(status.availability, AVAILABILITY.UNAVAILABLE);
+  });
+
+  await check('module-reported entitlement code is display-only', async () => {
+    const registrar = createAtomicModuleRegistrar();
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor({
+        edition: 'professional',
+        entitlement: { mode: 'module-managed' },
+      }),
+      register: createMockRegister(),
+      status: {
+        availability: 'unavailable',
+        reasonCode: REASON_CODES.ENTITLEMENT_REQUIRED,
+        message: 'Commercial entitlement required',
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.status.reasonCode, REASON_CODES.ENTITLEMENT_REQUIRED);
+    assert.equal(result.status.coreEnforcesEntitlement, false);
+  });
+
+  if (options.returnResults) return results;
+  return { ok: true, coreModuleApiVersion: MODULE_API_VERSION, results };
+}
+
+module.exports = {
+  DESCRIPTOR_VERSION,
+  MODULE_API_VERSION,
+  REASON_CODES,
+  AVAILABILITY,
+  buildValidDescriptor,
+  createMockRegister,
+  normalizeModuleDescriptor,
+  createAtomicModuleRegistrar,
+  createCapabilityRegistry,
+  runModuleContractTests,
+  satisfies,
+};

--- a/src/modules/descriptor.js
+++ b/src/modules/descriptor.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const {
+  DESCRIPTOR_VERSION,
+  EDITIONS,
+  ENTITLEMENT_MODES,
+  RUNTIME_FEATURE_ALLOWLIST,
+  SAFETY_LEVELS,
+} = require('./constants');
+const { parseVersion } = require('./semverRange');
+
+function isPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function redactSecrets(text) {
+  return String(text || '')
+    .replace(/[A-Za-z]:\\[^\s]+/g, '<redacted-path>')
+    .replace(/\/(?:Users|home)\/[^\s]+/g, '<redacted-path>')
+    .replace(/(password|secret|token|api[_-]?key|license)\s*[:=]\s*\S+/gi, '$1=<redacted>');
+}
+
+/**
+ * Validate and normalize a module descriptor v1.
+ * Returns { ok:true, descriptor } or { ok:false, errors:[{path,message}] }.
+ * Core never enforces commercial licenses from edition/entitlement.mode.
+ */
+function normalizeModuleDescriptor(raw) {
+  const errors = [];
+  if (!isPlainObject(raw)) {
+    return { ok: false, errors: [{ path: '', message: 'descriptor must be an object' }] };
+  }
+
+  // Forbidden material in public descriptors
+  for (const key of ['privateKey', 'signingKey', 'licenseKey', 'customerId', 'secret']) {
+    if (raw[key] != null) {
+      errors.push({ path: `/${key}`, message: 'secrets and license material are not allowed' });
+    }
+  }
+
+  if (raw.descriptorVersion !== DESCRIPTOR_VERSION) {
+    errors.push({
+      path: '/descriptorVersion',
+      message: `expected ${DESCRIPTOR_VERSION}`,
+    });
+  }
+
+  const id = typeof raw.id === 'string' ? raw.id.trim() : '';
+  if (!id || !/^[a-z][a-z0-9.-]*\.[a-z0-9.-]+$/i.test(id)) {
+    errors.push({
+      path: '/id',
+      message: 'id must be a stable non-empty namespaced module id (e.g. vendor.module)',
+    });
+  }
+  if (id.includes('..') || id.includes('/') || id.includes('\\')) {
+    errors.push({ path: '/id', message: 'id must not encode paths' });
+  }
+
+  const version = typeof raw.version === 'string' ? raw.version.trim() : '';
+  if (!parseVersion(version)) {
+    errors.push({ path: '/version', message: 'version must be a semver string' });
+  }
+
+  const edition = typeof raw.edition === 'string' ? raw.edition.trim().toLowerCase() : '';
+  if (!EDITIONS.includes(edition)) {
+    errors.push({
+      path: '/edition',
+      message: `edition must be one of ${EDITIONS.join(', ')} (display classification only)`,
+    });
+  }
+
+  if (!isPlainObject(raw.compatibility) || typeof raw.compatibility.moduleApi !== 'string') {
+    errors.push({
+      path: '/compatibility/moduleApi',
+      message: 'compatibility.moduleApi range is required',
+    });
+  }
+
+  if (!Array.isArray(raw.capabilities) || raw.capabilities.length === 0) {
+    errors.push({ path: '/capabilities', message: 'capabilities must be a non-empty array' });
+  } else {
+    raw.capabilities.forEach((cap, i) => {
+      if (!isPlainObject(cap)) {
+        errors.push({ path: `/capabilities/${i}`, message: 'capability must be an object' });
+        return;
+      }
+      if (typeof cap.id !== 'string' || !cap.id.trim()) {
+        errors.push({ path: `/capabilities/${i}/id`, message: 'capability id is required' });
+      }
+      if (!Number.isInteger(Number(cap.version)) || Number(cap.version) < 1) {
+        errors.push({
+          path: `/capabilities/${i}/version`,
+          message: 'capability version must be a positive integer',
+        });
+      }
+    });
+  }
+
+  if (!isPlainObject(raw.safety)) {
+    errors.push({ path: '/safety', message: 'safety metadata is required' });
+  } else {
+    if (!SAFETY_LEVELS.includes(String(raw.safety.level || ''))) {
+      errors.push({ path: '/safety/level', message: 'safety.level must be S0-S4' });
+    }
+    if (!Array.isArray(raw.safety.sideEffects) || raw.safety.sideEffects.length === 0) {
+      errors.push({
+        path: '/safety/sideEffects',
+        message: 'safety.sideEffects must be a non-empty array',
+      });
+    }
+  }
+
+  if (!isPlainObject(raw.runtime) || !Array.isArray(raw.runtime.requiredFeatures)) {
+    errors.push({
+      path: '/runtime/requiredFeatures',
+      message: 'runtime.requiredFeatures array is required (may be empty)',
+    });
+  } else {
+    raw.runtime.requiredFeatures.forEach((feat, i) => {
+      if (typeof feat !== 'string' || !RUNTIME_FEATURE_ALLOWLIST.includes(feat)) {
+        errors.push({
+          path: `/runtime/requiredFeatures/${i}`,
+          message: `feature must be one of: ${RUNTIME_FEATURE_ALLOWLIST.join(', ')}`,
+        });
+      }
+    });
+  }
+
+  let entitlementMode = 'none';
+  if (raw.entitlement != null) {
+    if (!isPlainObject(raw.entitlement)) {
+      errors.push({ path: '/entitlement', message: 'entitlement must be an object when present' });
+    } else {
+      entitlementMode = typeof raw.entitlement.mode === 'string' ? raw.entitlement.mode.trim() : '';
+      if (!ENTITLEMENT_MODES.includes(entitlementMode)) {
+        errors.push({
+          path: '/entitlement/mode',
+          message: 'entitlement.mode must be none or module-managed (display only in core)',
+        });
+      }
+      if (raw.entitlement.key != null || raw.entitlement.signature != null) {
+        errors.push({
+          path: '/entitlement',
+          message: 'license material must not appear in descriptors',
+        });
+      }
+    }
+  }
+
+  if (raw.docs != null && !isPlainObject(raw.docs)) {
+    errors.push({ path: '/docs', message: 'docs must be an object when present' });
+  }
+
+  if (errors.length) return { ok: false, errors };
+
+  const capabilities = raw.capabilities
+    .map(cap => ({ id: String(cap.id).trim(), version: Number(cap.version) }))
+    .sort((a, b) => a.id.localeCompare(b.id) || a.version - b.version);
+
+  // Duplicate capability ids in one module
+  const seen = new Set();
+  for (const cap of capabilities) {
+    if (seen.has(cap.id)) {
+      return {
+        ok: false,
+        errors: [{ path: '/capabilities', message: `duplicate capability id: ${cap.id}` }],
+      };
+    }
+    seen.add(cap.id);
+  }
+
+  const descriptor = {
+    descriptorVersion: DESCRIPTOR_VERSION,
+    id,
+    version,
+    edition,
+    compatibility: {
+      moduleApi: String(raw.compatibility.moduleApi).trim(),
+    },
+    capabilities,
+    safety: {
+      level: String(raw.safety.level),
+      sideEffects: [...raw.safety.sideEffects].map(String).sort(),
+    },
+    runtime: {
+      requiredFeatures: [...raw.runtime.requiredFeatures].map(String).sort(),
+    },
+    entitlement: {
+      mode: entitlementMode,
+    },
+    docs: {
+      title:
+        raw.docs && typeof raw.docs.title === 'string' && raw.docs.title.trim()
+          ? redactSecrets(raw.docs.title.trim())
+          : id,
+      reference:
+        raw.docs && typeof raw.docs.reference === 'string' ? String(raw.docs.reference) : null,
+    },
+  };
+  if (!descriptor.docs.reference) delete descriptor.docs.reference;
+
+  return { ok: true, descriptor };
+}
+
+function moduleDescriptorSchema(value) {
+  const result = normalizeModuleDescriptor(value);
+  if (result.ok) return [];
+  return result.errors;
+}
+
+module.exports = {
+  normalizeModuleDescriptor,
+  moduleDescriptorSchema,
+  redactSecrets,
+};

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const constants = require('./constants');
+const {
+  normalizeModuleDescriptor,
+  moduleDescriptorSchema,
+  redactSecrets,
+} = require('./descriptor');
+const {
+  createModuleRegistrar,
+  createAtomicModuleRegistrar,
+  fixedStatus,
+} = require('./moduleRegistrar');
+const { satisfies, parseVersion } = require('./semverRange');
+const contractTestKit = require('./contractTestKit');
+
+module.exports = {
+  ...constants,
+  normalizeModuleDescriptor,
+  moduleDescriptorSchema,
+  redactSecrets,
+  createModuleRegistrar,
+  createAtomicModuleRegistrar,
+  fixedStatus,
+  satisfies,
+  parseVersion,
+  contractTestKit,
+};

--- a/src/modules/moduleRegistrar.js
+++ b/src/modules/moduleRegistrar.js
@@ -1,0 +1,482 @@
+'use strict';
+
+const {
+  MODULE_API_VERSION,
+  AVAILABILITY,
+  REASON_CODES,
+  LIFECYCLE,
+  RUNTIME_FEATURE_ALLOWLIST,
+  MODULE_STATUS_KIND,
+} = require('./constants');
+const { normalizeModuleDescriptor, redactSecrets } = require('./descriptor');
+const { satisfies } = require('./semverRange');
+const { createCapabilityRegistry } = require('../core/capabilityRegistry');
+// normalizeModuleDescriptor used by atomic pre-checks
+
+function fixedStatus({
+  moduleId = null,
+  lifecycle,
+  availability,
+  reasonCode,
+  message = null,
+  edition = null,
+  entitlementMode = null,
+}) {
+  const status = {
+    schemaVersion: 1,
+    kind: MODULE_STATUS_KIND,
+    moduleId,
+    lifecycle,
+    availability,
+    reasonCode,
+    message: message ? redactSecrets(message) : null,
+    edition,
+    entitlementMode,
+    // Core does not enforce licenses; these fields are display/status only.
+    coreEnforcesEntitlement: false,
+  };
+  if (!status.message) delete status.message;
+  if (!status.edition) delete status.edition;
+  if (!status.entitlementMode) delete status.entitlementMode;
+  return Object.freeze(status);
+}
+
+/**
+ * Trusted in-process module registrar.
+ * Host must already import the module package; this API never scans paths or
+ * dynamically requires untrusted names.
+ */
+function createModuleRegistrar(options = {}) {
+  const coreModuleApiVersion = String(options.coreModuleApiVersion || MODULE_API_VERSION);
+  const hostFeatures = new Set(
+    Array.isArray(options.hostFeatures) && options.hostFeatures.length
+      ? options.hostFeatures
+      : RUNTIME_FEATURE_ALLOWLIST
+  );
+  const capabilityRegistry = options.capabilityRegistry || createCapabilityRegistry();
+  if (
+    options.capabilityRegistry &&
+    typeof capabilityRegistry.isSealed === 'function' &&
+    capabilityRegistry.isSealed()
+  ) {
+    throw new Error('capability registry is sealed; cannot create module registrar against it');
+  }
+
+  const modules = new Map(); // id -> { descriptor, status }
+  let sealed = false;
+
+  function listModules() {
+    return [...modules.values()]
+      .map(entry => ({
+        descriptor: entry.descriptor,
+        status: entry.status,
+      }))
+      .sort((a, b) => a.descriptor.id.localeCompare(b.descriptor.id));
+  }
+
+  function getModule(id) {
+    return modules.get(id) || null;
+  }
+
+  function getModuleStatus(id) {
+    const entry = modules.get(id);
+    return entry ? entry.status : null;
+  }
+
+  function notInstalledStatus() {
+    return fixedStatus({
+      lifecycle: LIFECYCLE.DECLARED,
+      availability: AVAILABILITY.UNAVAILABLE,
+      reasonCode: REASON_CODES.NOT_INSTALLED,
+      message: 'No external module is registered for this identifier.',
+    });
+  }
+
+  /**
+   * Explicit trusted registration.
+   * @param {{ descriptor: object, register: function({capabilityRegistry, module}): void|Promise }} input
+   */
+  async function registerModule(input) {
+    if (sealed) {
+      return {
+        ok: false,
+        status: fixedStatus({
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode: REASON_CODES.REGISTRATION_FAILED,
+          message: 'Module registrar is sealed.',
+        }),
+      };
+    }
+
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+      return {
+        ok: false,
+        status: fixedStatus({
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode: REASON_CODES.DESCRIPTOR_INVALID,
+          message: 'registerModule requires { descriptor, register }.',
+        }),
+      };
+    }
+
+    // Reject dynamic path loading hints
+    for (const banned of ['path', 'modulePath', 'requirePath', 'packagePath', 'file']) {
+      if (input[banned] != null) {
+        return {
+          ok: false,
+          status: fixedStatus({
+            lifecycle: LIFECYCLE.REJECTED,
+            availability: AVAILABILITY.UNAVAILABLE,
+            reasonCode: REASON_CODES.POLICY_DENIED,
+            message: 'Untrusted dynamic module paths are not accepted.',
+          }),
+        };
+      }
+    }
+
+    if (typeof input.register !== 'function') {
+      return {
+        ok: false,
+        status: fixedStatus({
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode: REASON_CODES.DESCRIPTOR_INVALID,
+          message: 'register callback is required.',
+        }),
+      };
+    }
+
+    const normalized = normalizeModuleDescriptor(input.descriptor);
+    if (!normalized.ok) {
+      return {
+        ok: false,
+        status: fixedStatus({
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode: REASON_CODES.DESCRIPTOR_INVALID,
+          message: normalized.errors.map(e => e.message).join('; '),
+        }),
+        errors: normalized.errors,
+      };
+    }
+
+    const descriptor = normalized.descriptor;
+    if (modules.has(descriptor.id)) {
+      return {
+        ok: false,
+        status: fixedStatus({
+          moduleId: descriptor.id,
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode: REASON_CODES.DUPLICATE_MODULE_ID,
+          message: `Duplicate module id: ${descriptor.id}`,
+          edition: descriptor.edition,
+          entitlementMode: descriptor.entitlement.mode,
+        }),
+      };
+    }
+
+    if (!satisfies(coreModuleApiVersion, descriptor.compatibility.moduleApi)) {
+      return {
+        ok: false,
+        status: fixedStatus({
+          moduleId: descriptor.id,
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode: REASON_CODES.INCOMPATIBLE_CORE,
+          message: `Module API ${coreModuleApiVersion} does not satisfy ${descriptor.compatibility.moduleApi}`,
+          edition: descriptor.edition,
+          entitlementMode: descriptor.entitlement.mode,
+        }),
+      };
+    }
+
+    for (const feature of descriptor.runtime.requiredFeatures) {
+      if (!hostFeatures.has(feature)) {
+        return {
+          ok: false,
+          status: fixedStatus({
+            moduleId: descriptor.id,
+            lifecycle: LIFECYCLE.REJECTED,
+            availability: AVAILABILITY.UNAVAILABLE,
+            reasonCode: REASON_CODES.RUNTIME_UNAVAILABLE,
+            message: `Required runtime feature unavailable: ${feature}`,
+            edition: descriptor.edition,
+            entitlementMode: descriptor.entitlement.mode,
+          }),
+        };
+      }
+    }
+
+    // Stage capability registrations; rollback on failure for atomicity.
+    const stagedIds = [];
+    const stagingRegistry = {
+      register(raw) {
+        const before = new Set(capabilityRegistry.list().map(c => c.id));
+        const registered = capabilityRegistry.register(raw);
+        const after = capabilityRegistry.list().map(c => c.id);
+        for (const id of after) {
+          if (!before.has(id)) stagedIds.push(id);
+        }
+        // Enforce module capability list membership
+        const declared = new Set(descriptor.capabilities.map(c => c.id));
+        if (!declared.has(registered.id)) {
+          throw Object.assign(new Error(`Capability ${registered.id} is not declared by module`), {
+            code: 'CAPABILITY_NOT_DECLARED',
+          });
+        }
+        // Capability safety must not be weaker than module safety
+        const moduleRank = SAFETY_RANK[descriptor.safety.level];
+        const capRank = SAFETY_RANK[registered.safety.level];
+        if (capRank < moduleRank) {
+          throw Object.assign(
+            new Error('Capability safety level cannot be weaker than module safety'),
+            { code: 'SAFETY_WEAKER' }
+          );
+        }
+        return registered;
+      },
+      list: (...args) => capabilityRegistry.list(...args),
+      get: (...args) => capabilityRegistry.get(...args),
+      resolve: (...args) => capabilityRegistry.resolve(...args),
+    };
+
+    try {
+      await input.register({
+        capabilityRegistry: stagingRegistry,
+        module: { descriptor },
+        coreModuleApiVersion,
+      });
+
+      // Ensure every declared capability was contributed
+      for (const cap of descriptor.capabilities) {
+        if (!capabilityRegistry.get(cap.id)) {
+          throw Object.assign(new Error(`Declared capability not registered: ${cap.id}`), {
+            code: 'CAPABILITY_MISSING',
+          });
+        }
+      }
+
+      // Optional module-reported availability (display only; core does not compute entitlement)
+      let reasonCode = REASON_CODES.AVAILABLE;
+      let availability = AVAILABILITY.AVAILABLE;
+      let message = null;
+      if (input.status && typeof input.status === 'object') {
+        if (typeof input.status.reasonCode === 'string' && input.status.reasonCode.trim()) {
+          reasonCode = String(input.status.reasonCode).trim();
+        }
+        if (typeof input.status.availability === 'string') {
+          const a = input.status.availability.toLowerCase();
+          if (Object.values(AVAILABILITY).includes(a)) availability = a;
+        }
+        if (input.status.message) message = redactSecrets(input.status.message);
+        // Reject secret-like status payloads
+        const statusJson = JSON.stringify(input.status);
+        if (
+          /license\s*key|licenseKey|private\s*key|privateKey|-----BEGIN|api[_-]?key/i.test(
+            statusJson
+          )
+        ) {
+          throw Object.assign(new Error('Module status contains secret-like material'), {
+            code: 'STATUS_SECRET',
+          });
+        }
+      }
+
+      const status = fixedStatus({
+        moduleId: descriptor.id,
+        lifecycle: LIFECYCLE.REGISTERED,
+        availability,
+        reasonCode,
+        message,
+        edition: descriptor.edition,
+        entitlementMode: descriptor.entitlement.mode,
+      });
+
+      modules.set(descriptor.id, { descriptor: Object.freeze(descriptor), status });
+      return { ok: true, descriptor, status };
+    } catch (error) {
+      // Atomic rollback of staged capabilities
+      if (typeof capabilityRegistry.unregister === 'function') {
+        for (const id of stagedIds) {
+          try {
+            capabilityRegistry.unregister(id);
+          } catch {
+            /* ignore */
+          }
+        }
+      } else {
+        // Capability registry has no unregister — document partial risk.
+        // For atomicity without unregister, we rethrow as registration failure and
+        // rely on staging into a temporary registry when provided by host.
+        // If the shared registry was mutated, surface CAPABILITY_CONFLICT semantics.
+      }
+
+      const code = error && error.code;
+      let reasonCode = REASON_CODES.REGISTRATION_FAILED;
+      if (code === 'DUPLICATE' || /duplicate capability/i.test(String(error && error.message))) {
+        reasonCode = REASON_CODES.CAPABILITY_CONFLICT;
+      }
+      if (code === 'STATUS_SECRET') reasonCode = REASON_CODES.POLICY_DENIED;
+
+      return {
+        ok: false,
+        status: fixedStatus({
+          moduleId: descriptor.id,
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode,
+          message: 'Module registration failed; core remains operational.',
+          edition: descriptor.edition,
+          entitlementMode: descriptor.entitlement.mode,
+        }),
+      };
+    }
+  }
+
+  function seal() {
+    sealed = true;
+  }
+
+  return {
+    registerModule,
+    listModules,
+    getModule,
+    getModuleStatus,
+    notInstalledStatus,
+    seal,
+    isSealed: () => sealed,
+    coreModuleApiVersion,
+    capabilityRegistry,
+  };
+}
+
+const SAFETY_RANK = Object.freeze({ S0: 0, S1: 1, S2: 2, S3: 3, S4: 4 });
+
+/**
+ * Registrar that stages capabilities in an isolated registry first, then copies
+ * into the host registry only after full success — true atomic commit.
+ */
+function createAtomicModuleRegistrar(options = {}) {
+  const hostCapabilityRegistry = options.capabilityRegistry || createCapabilityRegistry();
+  const coreModuleApiVersion = String(options.coreModuleApiVersion || MODULE_API_VERSION);
+  const hostFeatures = options.hostFeatures;
+  const modules = new Map();
+  let sealed = false;
+
+  async function registerModule(input) {
+    if (sealed) {
+      return {
+        ok: false,
+        status: fixedStatus({
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode: REASON_CODES.REGISTRATION_FAILED,
+          message: 'Module registrar is sealed.',
+        }),
+      };
+    }
+
+    // Pre-check module id against committed modules (before ephemeral registration).
+    const pre = normalizeModuleDescriptor(input && input.descriptor);
+    if (pre.ok && modules.has(pre.descriptor.id)) {
+      return {
+        ok: false,
+        status: fixedStatus({
+          moduleId: pre.descriptor.id,
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode: REASON_CODES.DUPLICATE_MODULE_ID,
+          message: `Duplicate module id: ${pre.descriptor.id}`,
+          edition: pre.descriptor.edition,
+          entitlementMode: pre.descriptor.entitlement.mode,
+        }),
+      };
+    }
+
+    // Use ephemeral registrar for validation + callback
+    const ephemeralCaps = createCapabilityRegistry();
+    const ephemeral = createModuleRegistrar({
+      capabilityRegistry: ephemeralCaps,
+      coreModuleApiVersion,
+      hostFeatures,
+    });
+    const result = await ephemeral.registerModule(input);
+    if (!result.ok) return result;
+
+    // Commit capabilities into host registry atomically; rollback on conflict
+    const committed = [];
+    try {
+      for (const capId of result.descriptor.capabilities.map(c => c.id)) {
+        const staged = ephemeralCaps.get(capId);
+        if (!staged) throw new Error(`missing staged capability ${capId}`);
+        // Re-register full descriptor with execute handler
+        hostCapabilityRegistry.register({
+          id: staged.id,
+          version: staged.version,
+          title: staged.title,
+          description: staged.description,
+          category: staged.category,
+          safety: staged.safety,
+          aliases: staged.aliases,
+          inputContract: staged.inputContract,
+          outputContract: staged.outputContract,
+          availability: staged.availability,
+          docs: staged.docs,
+          execute: staged.execute,
+        });
+        committed.push(staged.id);
+      }
+      modules.set(result.descriptor.id, {
+        descriptor: result.descriptor,
+        status: result.status,
+      });
+      return result;
+    } catch (error) {
+      void error;
+      return {
+        ok: false,
+        status: fixedStatus({
+          moduleId: result.descriptor.id,
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode: REASON_CODES.CAPABILITY_CONFLICT,
+          message: 'Capability commit failed; no partial module registration retained.',
+          edition: result.descriptor.edition,
+          entitlementMode: result.descriptor.entitlement.mode,
+        }),
+      };
+    }
+  }
+
+  return {
+    registerModule,
+    listModules: () =>
+      [...modules.values()]
+        .map(e => ({ descriptor: e.descriptor, status: e.status }))
+        .sort((a, b) => a.descriptor.id.localeCompare(b.descriptor.id)),
+    getModule: id => modules.get(id) || null,
+    getModuleStatus: id => (modules.get(id) ? modules.get(id).status : null),
+    notInstalledStatus: () =>
+      fixedStatus({
+        lifecycle: LIFECYCLE.DECLARED,
+        availability: AVAILABILITY.UNAVAILABLE,
+        reasonCode: REASON_CODES.NOT_INSTALLED,
+        message: 'No external module is registered for this identifier.',
+      }),
+    seal: () => {
+      sealed = true;
+    },
+    isSealed: () => sealed,
+    coreModuleApiVersion,
+    capabilityRegistry: hostCapabilityRegistry,
+  };
+}
+
+module.exports = {
+  createModuleRegistrar,
+  createAtomicModuleRegistrar,
+  fixedStatus,
+};

--- a/src/modules/semverRange.js
+++ b/src/modules/semverRange.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * Minimal semver utilities for moduleApi ranges used by module descriptors.
+ * Supports forms: "1.0.0", ">=1.0.0 <2.0.0", "^1.2.3", "~1.2.3".
+ * Fail closed on unparseable input.
+ */
+
+function parseVersion(raw) {
+  const m = String(raw || '')
+    .trim()
+    .match(/^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/);
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+  };
+}
+
+function cmp(a, b) {
+  if (a.major !== b.major) return a.major < b.major ? -1 : 1;
+  if (a.minor !== b.minor) return a.minor < b.minor ? -1 : 1;
+  if (a.patch !== b.patch) return a.patch < b.patch ? -1 : 1;
+  return 0;
+}
+
+function satisfiesComparator(version, op, bound) {
+  const c = cmp(version, bound);
+  switch (op) {
+    case '>=':
+      return c >= 0;
+    case '>':
+      return c > 0;
+    case '<=':
+      return c <= 0;
+    case '<':
+      return c < 0;
+    case '=':
+    case '==':
+      return c === 0;
+    default:
+      return false;
+  }
+}
+
+function expandCaret(v) {
+  if (v.major > 0) return { low: v, high: { major: v.major + 1, minor: 0, patch: 0 } };
+  if (v.minor > 0) return { low: v, high: { major: 0, minor: v.minor + 1, patch: 0 } };
+  return { low: v, high: { major: 0, minor: 0, patch: v.patch + 1 } };
+}
+
+function expandTilde(v) {
+  return { low: v, high: { major: v.major, minor: v.minor + 1, patch: 0 } };
+}
+
+/**
+ * @param {string} versionStr
+ * @param {string} rangeStr
+ */
+function satisfies(versionStr, rangeStr) {
+  const version = parseVersion(versionStr);
+  const range = String(rangeStr || '').trim();
+  if (!version || !range) return false;
+
+  if (/^\d+\.\d+\.\d+/.test(range) && !/[\s^~<>]/.test(range)) {
+    const exact = parseVersion(range);
+    return exact ? cmp(version, exact) === 0 : false;
+  }
+
+  if (range.startsWith('^')) {
+    const base = parseVersion(range.slice(1));
+    if (!base) return false;
+    const { low, high } = expandCaret(base);
+    return cmp(version, low) >= 0 && cmp(version, high) < 0;
+  }
+  if (range.startsWith('~')) {
+    const base = parseVersion(range.slice(1));
+    if (!base) return false;
+    const { low, high } = expandTilde(base);
+    return cmp(version, low) >= 0 && cmp(version, high) < 0;
+  }
+
+  const tokens = range.split(/\s+/).filter(Boolean);
+  for (const token of tokens) {
+    const m = token.match(/^(>=|>|<=|<|=|==)?\s*(\d+\.\d+\.\d+(?:[-+].*)?)$/);
+    if (!m) return false;
+    const op = m[1] || '=';
+    const bound = parseVersion(m[2]);
+    if (!bound || !satisfiesComparator(version, op, bound)) return false;
+  }
+  return true;
+}
+
+module.exports = {
+  parseVersion,
+  satisfies,
+};

--- a/tests/module-sdk.test.js
+++ b/tests/module-sdk.test.js
@@ -1,0 +1,218 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+
+const {
+  normalizeModuleDescriptor,
+  createAtomicModuleRegistrar,
+  REASON_CODES,
+  DESCRIPTOR_VERSION,
+  MODULE_API_VERSION,
+} = require('../src/modules');
+const {
+  buildValidDescriptor,
+  createMockRegister,
+  runModuleContractTests,
+} = require('../src/modules/contractTestKit');
+const { createCapabilityRegistry } = require('../src/core/capabilityRegistry');
+const { CONTRACT_IDS, INITIAL_SCHEMAS } = require('../src/core/contracts/schemas');
+const { createZeus } = require('../src/api/zeusApi');
+
+test('module descriptor contract is registered', () => {
+  assert.ok(INITIAL_SCHEMAS[CONTRACT_IDS.MODULE_DESCRIPTOR]);
+  assert.ok(INITIAL_SCHEMAS[CONTRACT_IDS.MODULE_STATUS]);
+  assert.equal(DESCRIPTOR_VERSION, 'zeus.module-descriptor/v1');
+  assert.equal(MODULE_API_VERSION, '1.0.0');
+});
+
+test('valid descriptor normalizes deterministically', () => {
+  const a = normalizeModuleDescriptor(buildValidDescriptor());
+  const b = normalizeModuleDescriptor(buildValidDescriptor());
+  assert.equal(a.ok, true);
+  assert.deepEqual(a.descriptor, b.descriptor);
+  assert.equal(a.descriptor.edition, 'community');
+  assert.equal(a.descriptor.entitlement.mode, 'none');
+});
+
+test('rejects missing safety, bad id, and license material', () => {
+  assert.equal(normalizeModuleDescriptor(buildValidDescriptor({ safety: null })).ok, false);
+  assert.equal(normalizeModuleDescriptor(buildValidDescriptor({ id: 'nopath' })).ok, false);
+  assert.equal(normalizeModuleDescriptor(buildValidDescriptor({ licenseKey: 'ABC' })).ok, false);
+  assert.equal(
+    normalizeModuleDescriptor(
+      buildValidDescriptor({ entitlement: { mode: 'module-managed', key: 'x' } })
+    ).ok,
+    false
+  );
+});
+
+test('registers module and capability; core does not enforce entitlement', async () => {
+  const registrar = createAtomicModuleRegistrar({
+    capabilityRegistry: createCapabilityRegistry(),
+  });
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: createMockRegister(),
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.status.reasonCode, REASON_CODES.AVAILABLE);
+  assert.equal(result.status.coreEnforcesEntitlement, false);
+  assert.ok(registrar.capabilityRegistry.get('example.inspect'));
+});
+
+test('duplicate module id fails closed', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const input = { descriptor: buildValidDescriptor(), register: createMockRegister() };
+  assert.equal((await registrar.registerModule(input)).ok, true);
+  const second = await registrar.registerModule(input);
+  assert.equal(second.ok, false);
+  assert.equal(second.status.reasonCode, REASON_CODES.DUPLICATE_MODULE_ID);
+});
+
+test('incompatible moduleApi fails closed', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor({ compatibility: { moduleApi: '>=99.0.0' } }),
+    register: createMockRegister(),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.INCOMPATIBLE_CORE);
+});
+
+test('missing runtime feature fails closed', async () => {
+  const registrar = createAtomicModuleRegistrar({ hostFeatures: ['node-crypto'] });
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor({
+      runtime: { requiredFeatures: ['local-filesystem'] },
+    }),
+    register: createMockRegister(),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.RUNTIME_UNAVAILABLE);
+});
+
+test('handler failure does not partially register module', async () => {
+  const caps = createCapabilityRegistry();
+  const registrar = createAtomicModuleRegistrar({ capabilityRegistry: caps });
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: ({ capabilityRegistry }) => {
+      capabilityRegistry.register({
+        id: 'example.inspect',
+        version: 1,
+        title: 'x',
+        safety: { level: 'S1', sideEffects: ['local-read'], requiresExplicitApproval: false },
+        execute: async () => ({}),
+      });
+      throw new Error('later failure token=supersecret');
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(registrar.listModules().length, 0);
+  // ephemeral staging means host caps stay empty
+  assert.equal(caps.list().filter(c => c.id === 'example.inspect').length, 0);
+  assert.ok(!JSON.stringify(result).includes('supersecret'));
+});
+
+test('capability conflict on commit is isolated', async () => {
+  const caps = createCapabilityRegistry();
+  caps.register({
+    id: 'example.inspect',
+    version: 1,
+    title: 'existing',
+    safety: { level: 'S1', sideEffects: ['local-read'], requiresExplicitApproval: false },
+    execute: async () => ({}),
+  });
+  const registrar = createAtomicModuleRegistrar({ capabilityRegistry: caps });
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: createMockRegister(),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.CAPABILITY_CONFLICT);
+  assert.equal(registrar.listModules().length, 0);
+});
+
+test('untrusted path field is denied', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: createMockRegister(),
+    modulePath: '/tmp/evil.js',
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.POLICY_DENIED);
+});
+
+test('module-reported entitlement status is display-only', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor({
+      edition: 'professional',
+      entitlement: { mode: 'module-managed' },
+    }),
+    register: createMockRegister(),
+    status: {
+      availability: 'unavailable',
+      reasonCode: REASON_CODES.ENTITLEMENT_EXPIRED,
+      message: 'Entitlement expired',
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.status.reasonCode, REASON_CODES.ENTITLEMENT_EXPIRED);
+  assert.equal(result.status.coreEnforcesEntitlement, false);
+});
+
+test('createZeus exposes modules registrar without commercial deps', async () => {
+  const zeus = createZeus();
+  assert.equal(typeof zeus.modules.registerModule, 'function');
+  assert.equal(zeus.moduleContracts.MODULE_API_VERSION, MODULE_API_VERSION);
+  const result = await zeus.modules.registerModule({
+    descriptor: buildValidDescriptor({ id: 'demo.module' }),
+    register: createMockRegister(),
+  });
+  assert.equal(result.ok, true);
+  // Community core still has analyzers/providers/generationValidation
+  assert.ok(zeus.generationValidation);
+  assert.ok(zeus.providers);
+});
+
+test('contract test kit passes against core', async () => {
+  const summary = await runModuleContractTests({ returnResults: false });
+  assert.equal(summary.ok, true);
+});
+
+test('package export path module-contract-test is present', () => {
+  const pkg = require('../package.json');
+  assert.equal(pkg.exports['./module-contract-test'], './src/modules/contractTestKit.js');
+  assert.ok(fs.existsSync(path.join(__dirname, '../src/modules/contractTestKit.js')));
+});
+
+test('community artifacts remain readable without modules', () => {
+  const zeus = createZeus();
+  assert.equal(zeus.modules.listModules().length, 0);
+  assert.equal(zeus.modules.notInstalledStatus().reasonCode, REASON_CODES.NOT_INSTALLED);
+  // Existing public surface still available
+  assert.equal(typeof zeus.analyze, 'function');
+  assert.equal(typeof zeus.contracts.createSchemaRegistry, 'function');
+});
+
+test('status rejects secret-like module status payloads', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: createMockRegister(),
+    status: {
+      availability: 'available',
+      reasonCode: 'AVAILABLE',
+      licenseKey: 'should-not-appear',
+    },
+  });
+  // licenseKey on status object is extra; we stringify check for secret patterns
+  // Our check looks for license key patterns in JSON
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.POLICY_DENIED);
+});


### PR DESCRIPTION
## Summary

Iteration 30 Phase A — public neutral module contracts for Zeus Community Core.

- module descriptor v1 + module status contracts in the schema registry
- trusted in-process atomic registrar (no path scanning / dynamic untrusted load)
- redacted availability/reason codes (display only; core does not enforce licenses)
- public export `zeus-rpg-promptkit/module-contract-test`
- authoring guide under `docs/modules/`
- isolated capability commit with fail-closed duplicate/incompatible handling

## Non-goals (kept out of public core)

- license parsing, signatures, private keys
- entitlement enforcement / edition unlock
- Generation Assurance, Repair, commercial capabilities
- telemetrics, remote activation

## Validation

Local gates green except known Windows symlink EPERM environmental test. Package smoke and full quality suite green.