### PR TITLE
Iteration 30: repair module SDK registration baseline

### DIFF
--- a/docs/architecture/adr-006-commercial-extension-architecture.md
+++ b/docs/architecture/adr-006-commercial-extension-architecture.md
@@ -1,12 +1,12 @@
 ---
 Title: ADR-006 Commercial Extension Architecture
 Description: Open-core ownership, versioned module descriptors, explicit registration, compatibility, availability, and artifact portability boundaries.
-Last Updated: 2026-07-16
+Last Updated: 2026-07-19
 ---
 
 # ADR-006: Commercial Extension Architecture
 
-**Status:** Accepted specification; executable module registrar and commercial modules are future work
+**Status:** Accepted; public executable module contracts and atomic registrar implemented
 
 ## Context
 
@@ -20,9 +20,11 @@ Those are trusted embedding mechanisms, not a package loader, sandbox, compatibi
 transaction, marketplace, or entitlement boundary. JavaScript executes as soon as an imported
 package is evaluated, before any Zeus registration validation can protect the host.
 
-This ADR specifies the boundary that a future narrow module registrar and SDK must implement. It
-does not claim that such a registrar, commercial package, or entitlement system is currently
-shipped.
+This decision originated in Iteration 26 as a documentation-only specification. Iteration 30
+subsequently delivered the public descriptor/status contracts, explicit trusted registrar and
+external contract test kit. This update records that delivered state without changing the
+historical ownership decision. Commercial behavior and entitlement enforcement remain outside the
+public core.
 
 ## Decision
 
@@ -99,9 +101,11 @@ The required fields and rules are:
 - `docs`: non-secret title and stable reference metadata.
 
 Missing or unknown required classification, compatibility, safety, side-effect, or runtime policy
-is rejection. Unknown additive fields are tolerated within v1 and retained only where a future
-normalizer explicitly permits them. Persisted descriptors have deterministic field order and
-values and contain no registration timestamps or raw runtime errors.
+is rejection. Capability IDs and versions must exactly match the descriptor. Capability side
+effects must use the public provider-neutral vocabulary and be a subset of the module's aggregate
+declaration. Unknown additive fields are tolerated within v1 and retained only where a normalizer
+explicitly permits them. Persisted descriptors have deterministic field order and values and
+contain no registration timestamps or raw runtime errors.
 
 Mutable health is not part of the immutable descriptor. A normalized runtime record may pair the
 descriptor with:
@@ -114,8 +118,10 @@ descriptor with:
 }
 ```
 
-`availability` is `available`, `degraded`, or `unavailable`. Public status exposes only one fixed,
-redacted reason code:
+`availability` is `available`, `degraded`, or `unavailable`. Public status exposes only a value
+from the closed `REASON_CODES` vocabulary. Unknown module-supplied values fail registration and
+are reduced to the neutral `MODULE_UNAVAILABLE` code without echoing the supplied value. The
+vocabulary includes:
 
 - `DESCRIPTOR_INVALID`
 - `MODULE_API_INCOMPATIBLE`
@@ -128,6 +134,11 @@ redacted reason code:
 - `MODULE_DISABLED`
 - `MODULE_UNAVAILABLE` for any unclassified failure
 
+Modules may report only availability outcomes: `AVAILABLE`, runtime or policy unavailability,
+entitlement outcomes, `MODULE_DISABLED`, or `MODULE_UNAVAILABLE`. Registration provenance stays
+with core: modules cannot report descriptor/API failures, duplicate IDs, capability conflicts,
+initialization failures, or `NOT_INSTALLED` as their own registered status.
+
 Raw exceptions, secrets, license material, customer or organization IDs, local paths, and private
 endpoints never enter descriptors or public module-status diagnostics. Secrets are never
 transmissible. Source, usage, and customer identifiers do not leave the trust zone or get sent for
@@ -135,10 +146,10 @@ entitlement or availability validation.
 
 ### Explicit registration and trust boundary
 
-The future host composition root explicitly imports an installed, operator-trusted package and
+The host composition root explicitly imports an installed, operator-trusted package and
 passes its descriptor and registration callback to a narrow public registrar. The conceptual API
-is `registerModule({ descriptor, register })`; this is a specification name, not a current package
-export.
+is the implemented `registerModule({ descriptor, register })` surface exposed through
+`createZeus().modules`.
 
 The core never scans directories, package manifests, environment-provided paths, or marketplaces,
 and never dynamically `require`s, imports, or evaluates an untrusted name. Explicit import does not
@@ -147,7 +158,7 @@ sandbox a package: the operator and package manager remain responsible for trust
 ```mermaid
 flowchart LR
     H[Trusted host composition root] -->|explicit import| P[Installed module package]
-    H -->|descriptor + callback| R[Future narrow module registrar]
+    H -->|descriptor + callback| R[Public narrow module registrar]
     R -->|validate and stage atomically| C[Core Capability Registry]
     C --> A[Thin CLI / API / MCP projections]
 
@@ -165,11 +176,13 @@ flowchart LR
     P -.->|unavailable: only its capabilities disabled| C
 ```
 
-Before invoking contributed behavior, the registrar must validate descriptor completeness,
-descriptor major, module API compatibility, runtime feature names, module ID uniqueness,
-capability ID and alias ownership, and safety classification. All registrations from one module
-are staged and committed atomically. Any conflict or incompatibility rejects the entire module
-without partially mutating the Capability Registry.
+Before invoking contributed behavior, the registrar validates descriptor completeness, descriptor
+major, module API compatibility, runtime feature names, module ID uniqueness, exact capability ID
+and version, alias ownership, safety classification and side-effect coverage. All registrations
+from one module are staged in an isolated registry. The Capability Registry validates the complete
+ID/alias batch against snapshot maps and publishes it synchronously only after full validation.
+Any conflict or incompatibility rejects the entire module without partially mutating the host
+registry, module list or module status.
 
 Module contributions use only the canonical Capability Registry. CLI and MCP remain projections
 of registered capability metadata and do not gain module-specific or product-specific branches.
@@ -219,8 +232,9 @@ persisted format.
 - Community remains a complete, useful baseline and the extension contract is Apache-2.0.
 - External packages can contribute capability metadata without changes to CLI or MCP adapters.
 - Paid behavior and entitlement enforcement remain separable from core orchestration.
-- Future registrar work must add executable validation, atomic staging, deterministic status, and
-  contract tests; the existing broad `registerPlugin` hook does not satisfy this specification.
+- The public registrar now supplies executable validation, transactional batch registration,
+  deterministic closed status and an external contract test kit; the existing broad
+  `registerPlugin` hook still does not satisfy this specification.
 - Module failure is isolated, while malformed or incompatible registration fails closed.
 
 ## Alternatives considered
@@ -241,9 +255,15 @@ persisted format.
 - **Put entitlement checks in core or lock user artifacts.** Rejected because a paid capability
   failure must not disable core or deny users their data.
 
-## Follow-up boundary
+## Implemented and remaining boundary
 
-This iteration introduces documentation only. A later iteration may add the executable descriptor,
-registrar, and SDK after architecture and commercial re-review. That work must test descriptor
-completeness, atomic duplicate rejection, incompatibility before callback execution, deterministic
-listing, fixed redaction, and core startup with zero or unavailable modules.
+Implemented in the public core: descriptor and status contracts, explicit trusted registration,
+module-API/runtime compatibility checks, exact capability matching, closed reason codes,
+transactional multi-capability registration, failure isolation, deterministic listing and the
+external contract test kit.
+
+Not implemented in the public core: package discovery, arbitrary dynamic loading, sandboxing, hot
+reload/unload, marketplace behavior, entitlement validation, license parsing, paid capabilities,
+online activation, telemetry or artifact locking. A trusted imported package still runs with the
+host process's full rights before and during registration; the registrar is a contract boundary,
+not a security sandbox.

--- a/docs/modules/authoring-external-module-registration.md
+++ b/docs/modules/authoring-external-module-registration.md
@@ -21,6 +21,10 @@ It implements the executable subset of [ADR-006](../architecture/adr-006-commerc
 - Entitlement enforcement belongs in the external module (for commercial packages).
 - Module code runs with the same process rights as the host. Loading arbitrary third-party code
   is **not** a security sandbox.
+- Every registered capability ID and version must exactly match one descriptor declaration. Extra,
+  missing or version-mismatched capabilities reject the whole module.
+- Capability safety may be stricter, never weaker, than module safety. Capability side effects
+  must use the public vocabulary and be fully covered by the module aggregate declaration.
 
 ## Descriptor v1
 
@@ -45,6 +49,9 @@ Required shape (normalized):
 - `entitlement.mode`: `none` | `module-managed` (no license material).
 - Runtime features must come from the public allowlist (`local-filesystem`, `local-process`,
   `node-crypto`, `offline-only`).
+- Capability side effects must come from exported `CAPABILITY_SIDE_EFFECTS`: `local-read`,
+  `local-artifact-write`, `local-config-write`, `local-secret-write`, `local-listener`,
+  `local-process-stdio`, `remote-read`, `remote-write`, or `operator-gated`.
 
 ## Registration API
 
@@ -71,8 +78,10 @@ const result = await zeus.modules.registerModule({
 });
 ```
 
-Registration is **atomic**: on failure, the module is not listed and capabilities are not
-committed. The core continues to serve Community analysis and existing user artifacts.
+Registration is **atomic**: the callback first writes only to an isolated staging registry. The
+host validates the complete capability ID/alias batch and publishes it in one transaction. A
+conflict at any capability leaves host IDs, aliases, module list and module status unchanged. The
+core continues to serve Community analysis and existing user artifacts.
 
 ## Availability reason codes
 
@@ -80,8 +89,11 @@ Public status uses fixed redacted codes such as `AVAILABLE`, `NOT_INSTALLED`,
 `INCOMPATIBLE_CORE`, `DESCRIPTOR_INVALID`, `REGISTRATION_FAILED`, `RUNTIME_UNAVAILABLE`,
 `POLICY_DENIED`, `ENTITLEMENT_REQUIRED`, `ENTITLEMENT_EXPIRED`, `ENTITLEMENT_INVALID`.
 
-Entitlement-related codes may be **reported by modules** for UI honesty. The core does not
-evaluate licenses to produce them.
+Entitlement-, policy-, runtime-, and module-availability codes may be **reported by modules** for
+UI honesty. The core does not evaluate licenses to produce them. Core-owned registration outcomes
+such as `NOT_INSTALLED`, descriptor/API failures, duplicate IDs, capability conflicts, and
+initialization failures cannot be supplied by a module. Unknown, core-owned, or secret-bearing
+strings fail closed to `MODULE_UNAVAILABLE` and are never echoed.
 
 ## Contract Test Kit
 
@@ -91,6 +103,9 @@ await runModuleContractTests();
 ```
 
 The kit contains no commercial implementation and no signing keys.
+
+It exercises the executable public guarantees, including late multi-capability conflicts, closed
+reason codes, exact capability versions and side-effect coverage.
 
 ## Failure isolation
 

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -17,6 +17,7 @@ module.exports = {
       'tests/tool-catalog-generator.test.js',
       'tests/provider-contracts.test.js',
       'tests/provider-local-adapters.test.js',
+      'tests/module-sdk.test.js',
       'tests/workflow-presets.test.js',
     ],
     smoke: [
@@ -28,7 +29,11 @@ module.exports = {
     corpus: ['tests/scanner-corpus.test.js'],
     benchmark: ['tests/analyze-benchmark.test.js'],
     quality: ['tests/golden-quality.test.js'],
-    unit: ['tests/test-inventory.test.js', 'tests/typecheck-scope.test.js'],
+    unit: [
+      'tests/capability-registry.test.js',
+      'tests/test-inventory.test.js',
+      'tests/typecheck-scope.test.js',
+    ],
   },
   exclusions: [],
 };

--- a/src/core/capabilityRegistry.js
+++ b/src/core/capabilityRegistry.js
@@ -28,6 +28,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
 const { createSchemaRegistry } = require('./contracts');
+const { CAPABILITY_SIDE_EFFECTS } = require('./safetyMetadata');
+const CAPABILITY_SIDE_EFFECT_SET = new Set(CAPABILITY_SIDE_EFFECTS);
 
 function validateSafety(safety) {
   if (!safety || typeof safety !== 'object') {
@@ -40,9 +42,15 @@ function validateSafety(safety) {
   if (!Array.isArray(safety.sideEffects)) {
     throw new Error('safety.sideEffects must be an array');
   }
+  const sideEffects = [...new Set(safety.sideEffects.map(value => String(value).trim()))];
+  for (const sideEffect of sideEffects) {
+    if (!CAPABILITY_SIDE_EFFECT_SET.has(sideEffect)) {
+      throw new Error(`unknown capability side effect: ${sideEffect || '<empty>'}`);
+    }
+  }
   return {
     level,
-    sideEffects: [...safety.sideEffects],
+    sideEffects: sideEffects.sort(),
     requiresExplicitApproval: !!safety.requiresExplicitApproval,
   };
 }
@@ -105,33 +113,52 @@ function normalizeDescriptor(raw) {
 }
 
 function createCapabilityRegistry() {
-  const byId = new Map();
-  const aliasToId = new Map();
+  let byId = new Map();
+  let aliasToId = new Map();
   let sealed = false;
 
-  function register(rawDescriptor) {
+  function registerBatch(rawDescriptors) {
     if (sealed) {
       throw new Error('capability registry is sealed; registration after seal is not allowed');
     }
-    const desc = normalizeDescriptor(rawDescriptor);
-
-    if (byId.has(desc.id)) {
-      throw new Error(`duplicate capability id: ${desc.id}`);
+    if (!Array.isArray(rawDescriptors) || rawDescriptors.length === 0) {
+      throw new Error('capability registration batch must be a non-empty array');
     }
 
-    for (const alias of desc.aliases) {
-      if (aliasToId.has(alias)) {
-        throw new Error(`duplicate alias "${alias}" (already maps to ${aliasToId.get(alias)})`);
+    const normalized = rawDescriptors.map(normalizeDescriptor);
+    const nextById = new Map(byId);
+    const nextAliasToId = new Map(aliasToId);
+
+    for (const desc of normalized) {
+      if (nextById.has(desc.id)) {
+        throw new Error(`duplicate capability id: ${desc.id}`);
+      }
+      if (nextAliasToId.has(desc.id)) {
+        throw new Error(
+          `capability id "${desc.id}" conflicts with existing id or alias for ${nextAliasToId.get(desc.id)}`
+        );
+      }
+      nextById.set(desc.id, desc);
+      nextAliasToId.set(desc.id, desc.id);
+
+      for (const alias of desc.aliases) {
+        if (nextAliasToId.has(alias)) {
+          throw new Error(
+            `duplicate alias "${alias}" (already maps to ${nextAliasToId.get(alias)})`
+          );
+        }
+        nextAliasToId.set(alias, desc.id);
       }
     }
 
-    byId.set(desc.id, desc);
-    aliasToId.set(desc.id, desc.id);
-    for (const alias of desc.aliases) {
-      aliasToId.set(alias, desc.id);
-    }
+    // One synchronous reference swap publishes the fully validated batch.
+    byId = nextById;
+    aliasToId = nextAliasToId;
+    return normalized;
+  }
 
-    return desc;
+  function register(rawDescriptor) {
+    return registerBatch([rawDescriptor])[0];
   }
 
   function get(idOrAlias) {
@@ -219,6 +246,7 @@ function createCapabilityRegistry() {
 
   return {
     register,
+    registerBatch,
     get,
     list,
     resolve,
@@ -268,6 +296,7 @@ const TINY_VERSION_CAPABILITY = {
 };
 
 module.exports = {
+  CAPABILITY_SIDE_EFFECTS,
   createCapabilityRegistry,
   TINY_VERSION_CAPABILITY,
 };

--- a/src/core/contracts/schemas.js
+++ b/src/core/contracts/schemas.js
@@ -271,6 +271,7 @@ const safetyPolicySchema = value => {
 const { PROVIDER_SCHEMAS } = require('../../providers/contracts');
 const { GENERATION_SCHEMAS } = require('../../generationValidation/contracts');
 const { moduleDescriptorSchema } = require('../../modules/descriptor');
+const { REASON_CODES, LIFECYCLE, AVAILABILITY } = require('../../modules/constants');
 
 function moduleStatusSchema(value) {
   const errors = basicHeaderValidator(1)(value);
@@ -278,14 +279,17 @@ function moduleStatusSchema(value) {
   if (value.kind != null && value.kind !== 'module-status') {
     errors.push({ path: '/kind', message: 'kind must be "module-status" when present' });
   }
-  if (typeof value.lifecycle !== 'string' || !value.lifecycle) {
-    errors.push({ path: '/lifecycle', message: 'lifecycle is required' });
+  if (!Object.values(LIFECYCLE).includes(value.lifecycle)) {
+    errors.push({ path: '/lifecycle', message: 'lifecycle must be a defined module lifecycle' });
   }
-  if (typeof value.availability !== 'string' || !value.availability) {
-    errors.push({ path: '/availability', message: 'availability is required' });
+  if (!Object.values(AVAILABILITY).includes(value.availability)) {
+    errors.push({ path: '/availability', message: 'availability must be a defined module state' });
   }
-  if (typeof value.reasonCode !== 'string' || !value.reasonCode) {
-    errors.push({ path: '/reasonCode', message: 'reasonCode is required' });
+  if (!Object.values(REASON_CODES).includes(value.reasonCode)) {
+    errors.push({
+      path: '/reasonCode',
+      message: 'reasonCode must be a defined public reason code',
+    });
   }
   if (value.coreEnforcesEntitlement !== false && value.coreEnforcesEntitlement != null) {
     errors.push({

--- a/src/core/safetyMetadata.js
+++ b/src/core/safetyMetadata.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** Provider-neutral side effects understood by the public Capability Registry. */
+const CAPABILITY_SIDE_EFFECTS = Object.freeze([
+  'local-artifact-write',
+  'local-config-write',
+  'local-listener',
+  'local-process-stdio',
+  'local-read',
+  'local-secret-write',
+  'operator-gated',
+  'remote-read',
+  'remote-write',
+]);
+
+module.exports = { CAPABILITY_SIDE_EFFECTS };

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { CAPABILITY_SIDE_EFFECTS } = require('../core/safetyMetadata');
+
 const DESCRIPTOR_VERSION = 'zeus.module-descriptor/v1';
 const MODULE_API_VERSION = '1.0.0';
 const MODULE_STATUS_KIND = 'module-status';
@@ -68,4 +70,5 @@ module.exports = {
   LIFECYCLE,
   RUNTIME_FEATURE_ALLOWLIST,
   SAFETY_LEVELS,
+  CAPABILITY_SIDE_EFFECTS,
 };

--- a/src/modules/contractTestKit.js
+++ b/src/modules/contractTestKit.js
@@ -12,6 +12,7 @@ const {
   MODULE_API_VERSION,
   REASON_CODES,
   AVAILABILITY,
+  CAPABILITY_SIDE_EFFECTS,
 } = require('./constants');
 const { normalizeModuleDescriptor } = require('./descriptor');
 const { createAtomicModuleRegistrar } = require('./moduleRegistrar');
@@ -102,6 +103,32 @@ async function runModuleContractTests(options = {}) {
     assert.ok(registrar.capabilityRegistry.get('example.inspect'));
   });
 
+  await check('late capability conflict leaves no partial host registration', async () => {
+    const caps = createCapabilityRegistry();
+    const baseCapability = {
+      version: 1,
+      safety: { level: 'S1', sideEffects: ['local-read'], requiresExplicitApproval: false },
+      execute: async () => ({}),
+    };
+    caps.register({ ...baseCapability, id: 'example.second' });
+    const registrar = createAtomicModuleRegistrar({ capabilityRegistry: caps });
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor({
+        capabilities: [
+          { id: 'example.first', version: 1 },
+          { id: 'example.second', version: 1 },
+        ],
+      }),
+      register({ capabilityRegistry }) {
+        capabilityRegistry.register({ ...baseCapability, id: 'example.first' });
+        capabilityRegistry.register({ ...baseCapability, id: 'example.second' });
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(caps.get('example.first'), null);
+    assert.equal(registrar.listModules().length, 0);
+  });
+
   await check('duplicate module id is rejected', async () => {
     const registrar = createAtomicModuleRegistrar({
       capabilityRegistry: createCapabilityRegistry(),
@@ -180,6 +207,52 @@ async function runModuleContractTests(options = {}) {
     assert.equal(result.status.coreEnforcesEntitlement, false);
   });
 
+  await check('unknown module reason code fails closed', async () => {
+    const registrar = createAtomicModuleRegistrar();
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor(),
+      register: createMockRegister(),
+      status: { availability: 'available', reasonCode: 'VENDOR_INTERNAL_DETAIL' },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status.reasonCode, REASON_CODES.MODULE_UNAVAILABLE);
+    assert.equal(registrar.capabilityRegistry.get('example.inspect'), null);
+  });
+
+  await check('capability version must match descriptor version', async () => {
+    const registrar = createAtomicModuleRegistrar();
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor(),
+      register({ capabilityRegistry }) {
+        capabilityRegistry.register({
+          id: 'example.inspect',
+          version: 2,
+          safety: { level: 'S1', sideEffects: ['local-read'] },
+          execute: async () => ({}),
+        });
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(registrar.capabilityRegistry.get('example.inspect'), null);
+  });
+
+  await check('capability side effects must be covered by module declaration', async () => {
+    const registrar = createAtomicModuleRegistrar();
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor(),
+      register({ capabilityRegistry }) {
+        capabilityRegistry.register({
+          id: 'example.inspect',
+          version: 1,
+          safety: { level: 'S1', sideEffects: ['remote-write'] },
+          execute: async () => ({}),
+        });
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(registrar.capabilityRegistry.get('example.inspect'), null);
+  });
+
   if (options.returnResults) return results;
   return { ok: true, coreModuleApiVersion: MODULE_API_VERSION, results };
 }
@@ -189,6 +262,7 @@ module.exports = {
   MODULE_API_VERSION,
   REASON_CODES,
   AVAILABILITY,
+  CAPABILITY_SIDE_EFFECTS,
   buildValidDescriptor,
   createMockRegister,
   normalizeModuleDescriptor,

--- a/src/modules/descriptor.js
+++ b/src/modules/descriptor.js
@@ -8,6 +8,8 @@ const {
   SAFETY_LEVELS,
 } = require('./constants');
 const { parseVersion } = require('./semverRange');
+const { CAPABILITY_SIDE_EFFECTS } = require('../core/safetyMetadata');
+const CAPABILITY_SIDE_EFFECT_SET = new Set(CAPABILITY_SIDE_EFFECTS);
 
 function isPlainObject(value) {
   return value != null && typeof value === 'object' && !Array.isArray(value);
@@ -107,6 +109,23 @@ function normalizeModuleDescriptor(raw) {
         path: '/safety/sideEffects',
         message: 'safety.sideEffects must be a non-empty array',
       });
+    } else {
+      const seenSideEffects = new Set();
+      raw.safety.sideEffects.forEach((sideEffect, i) => {
+        const normalized = typeof sideEffect === 'string' ? sideEffect.trim() : '';
+        if (!CAPABILITY_SIDE_EFFECT_SET.has(normalized)) {
+          errors.push({
+            path: `/safety/sideEffects/${i}`,
+            message: `side effect must be one of: ${CAPABILITY_SIDE_EFFECTS.join(', ')}`,
+          });
+        } else if (seenSideEffects.has(normalized)) {
+          errors.push({
+            path: `/safety/sideEffects/${i}`,
+            message: `duplicate side effect: ${normalized}`,
+          });
+        }
+        seenSideEffects.add(normalized);
+      });
     }
   }
 
@@ -180,7 +199,7 @@ function normalizeModuleDescriptor(raw) {
     capabilities,
     safety: {
       level: String(raw.safety.level),
-      sideEffects: [...raw.safety.sideEffects].map(String).sort(),
+      sideEffects: [...raw.safety.sideEffects].map(value => String(value).trim()).sort(),
     },
     runtime: {
       requiredFeatures: [...raw.runtime.requiredFeatures].map(String).sort(),

--- a/src/modules/moduleRegistrar.js
+++ b/src/modules/moduleRegistrar.js
@@ -13,6 +13,24 @@ const { satisfies } = require('./semverRange');
 const { createCapabilityRegistry } = require('../core/capabilityRegistry');
 // normalizeModuleDescriptor used by atomic pre-checks
 
+const REASON_CODE_SET = new Set(Object.values(REASON_CODES));
+const MODULE_REPORTED_REASON_CODE_SET = new Set([
+  REASON_CODES.AVAILABLE,
+  REASON_CODES.RUNTIME_UNAVAILABLE,
+  REASON_CODES.POLICY_DENIED,
+  REASON_CODES.ENTITLEMENT_REQUIRED,
+  REASON_CODES.ENTITLEMENT_EXPIRED,
+  REASON_CODES.ENTITLEMENT_INVALID,
+  REASON_CODES.ENTITLEMENT_UNAVAILABLE,
+  REASON_CODES.MODULE_POLICY_DENIED,
+  REASON_CODES.MODULE_DISABLED,
+  REASON_CODES.MODULE_UNAVAILABLE,
+]);
+
+function normalizeReasonCode(reasonCode) {
+  return REASON_CODE_SET.has(reasonCode) ? reasonCode : REASON_CODES.MODULE_UNAVAILABLE;
+}
+
 function fixedStatus({
   moduleId = null,
   lifecycle,
@@ -28,7 +46,7 @@ function fixedStatus({
     moduleId,
     lifecycle,
     availability,
-    reasonCode,
+    reasonCode: normalizeReasonCode(reasonCode),
     message: message ? redactSecrets(message) : null,
     edition,
     entitlementMode,
@@ -46,7 +64,7 @@ function fixedStatus({
  * Host must already import the module package; this API never scans paths or
  * dynamically requires untrusted names.
  */
-function createModuleRegistrar(options = {}) {
+function createStagingModuleRegistrar(options = {}) {
   const coreModuleApiVersion = String(options.coreModuleApiVersion || MODULE_API_VERSION);
   const hostFeatures = new Set(
     Array.isArray(options.hostFeatures) && options.hostFeatures.length
@@ -163,6 +181,10 @@ function createModuleRegistrar(options = {}) {
     }
 
     const descriptor = normalized.descriptor;
+    const declaredCapabilities = new Map(
+      descriptor.capabilities.map(capability => [capability.id, capability])
+    );
+    const declaredSideEffects = new Set(descriptor.safety.sideEffects);
     if (modules.has(descriptor.id)) {
       return {
         ok: false,
@@ -221,11 +243,19 @@ function createModuleRegistrar(options = {}) {
           if (!before.has(id)) stagedIds.push(id);
         }
         // Enforce module capability list membership
-        const declared = new Set(descriptor.capabilities.map(c => c.id));
-        if (!declared.has(registered.id)) {
+        const declared = declaredCapabilities.get(registered.id);
+        if (!declared) {
           throw Object.assign(new Error(`Capability ${registered.id} is not declared by module`), {
             code: 'CAPABILITY_NOT_DECLARED',
           });
+        }
+        if (registered.version !== declared.version) {
+          throw Object.assign(
+            new Error(
+              `Capability ${registered.id} version ${registered.version} does not match declared version ${declared.version}`
+            ),
+            { code: 'CAPABILITY_VERSION_MISMATCH' }
+          );
         }
         // Capability safety must not be weaker than module safety
         const moduleRank = SAFETY_RANK[descriptor.safety.level];
@@ -235,6 +265,14 @@ function createModuleRegistrar(options = {}) {
             new Error('Capability safety level cannot be weaker than module safety'),
             { code: 'SAFETY_WEAKER' }
           );
+        }
+        for (const sideEffect of registered.safety.sideEffects) {
+          if (!declaredSideEffects.has(sideEffect)) {
+            throw Object.assign(
+              new Error(`Capability side effect is not declared by module: ${sideEffect}`),
+              { code: 'SIDE_EFFECT_NOT_DECLARED' }
+            );
+          }
         }
         return registered;
       },
@@ -251,8 +289,14 @@ function createModuleRegistrar(options = {}) {
       });
 
       // Ensure every declared capability was contributed
+      if (stagedIds.length !== descriptor.capabilities.length) {
+        throw Object.assign(new Error('Registered capability set does not match descriptor'), {
+          code: 'CAPABILITY_SET_MISMATCH',
+        });
+      }
+      const registeredIds = new Set(stagedIds);
       for (const cap of descriptor.capabilities) {
-        if (!capabilityRegistry.get(cap.id)) {
+        if (!registeredIds.has(cap.id)) {
           throw Object.assign(new Error(`Declared capability not registered: ${cap.id}`), {
             code: 'CAPABILITY_MISSING',
           });
@@ -265,13 +309,30 @@ function createModuleRegistrar(options = {}) {
       let message = null;
       if (input.status && typeof input.status === 'object') {
         if (typeof input.status.reasonCode === 'string' && input.status.reasonCode.trim()) {
-          reasonCode = String(input.status.reasonCode).trim();
+          const suppliedReasonCode = String(input.status.reasonCode).trim();
+          if (!MODULE_REPORTED_REASON_CODE_SET.has(suppliedReasonCode)) {
+            throw Object.assign(new Error('Module status reason code is not permitted'), {
+              code: 'STATUS_REASON_INVALID',
+            });
+          }
+          reasonCode = suppliedReasonCode;
         }
         if (typeof input.status.availability === 'string') {
           const a = input.status.availability.toLowerCase();
-          if (Object.values(AVAILABILITY).includes(a)) availability = a;
+          if (!Object.values(AVAILABILITY).includes(a)) {
+            throw Object.assign(new Error('Module status availability is not recognized'), {
+              code: 'STATUS_AVAILABILITY_INVALID',
+            });
+          }
+          availability = a;
         }
-        if (input.status.message) message = redactSecrets(input.status.message);
+        if ((reasonCode === REASON_CODES.AVAILABLE) !== (availability === AVAILABILITY.AVAILABLE)) {
+          throw Object.assign(new Error('Module status availability and reason code conflict'), {
+            code: 'STATUS_INCOHERENT',
+          });
+        }
+        // Public status is code-driven. Do not copy module-supplied free-form diagnostics.
+        if (input.status.message) message = 'Module reported status.';
         // Reject secret-like status payloads
         const statusJson = JSON.stringify(input.status);
         if (
@@ -320,6 +381,10 @@ function createModuleRegistrar(options = {}) {
         reasonCode = REASON_CODES.CAPABILITY_CONFLICT;
       }
       if (code === 'STATUS_SECRET') reasonCode = REASON_CODES.POLICY_DENIED;
+      if (code === 'STATUS_REASON_INVALID') reasonCode = REASON_CODES.MODULE_UNAVAILABLE;
+      if (code === 'STATUS_AVAILABILITY_INVALID' || code === 'STATUS_INCOHERENT') {
+        reasonCode = REASON_CODES.MODULE_UNAVAILABLE;
+      }
 
       return {
         ok: false,
@@ -361,10 +426,23 @@ const SAFETY_RANK = Object.freeze({ S0: 0, S1: 1, S2: 2, S3: 3, S4: 4 });
  */
 function createAtomicModuleRegistrar(options = {}) {
   const hostCapabilityRegistry = options.capabilityRegistry || createCapabilityRegistry();
+  if (typeof hostCapabilityRegistry.registerBatch !== 'function') {
+    throw new Error('atomic module registration requires a capability registry with registerBatch');
+  }
+  if (typeof hostCapabilityRegistry.isSealed === 'function' && hostCapabilityRegistry.isSealed()) {
+    throw new Error('capability registry is sealed; cannot create module registrar against it');
+  }
   const coreModuleApiVersion = String(options.coreModuleApiVersion || MODULE_API_VERSION);
   const hostFeatures = options.hostFeatures;
   const modules = new Map();
+  const pendingModules = new Set();
   let sealed = false;
+
+  function hostRegistryIsSealed() {
+    return (
+      typeof hostCapabilityRegistry.isSealed === 'function' && hostCapabilityRegistry.isSealed()
+    );
+  }
 
   async function registerModule(input) {
     if (sealed) {
@@ -378,10 +456,21 @@ function createAtomicModuleRegistrar(options = {}) {
         }),
       };
     }
+    if (hostRegistryIsSealed()) {
+      return {
+        ok: false,
+        status: fixedStatus({
+          lifecycle: LIFECYCLE.REJECTED,
+          availability: AVAILABILITY.UNAVAILABLE,
+          reasonCode: REASON_CODES.REGISTRATION_FAILED,
+          message: 'Capability registry is sealed.',
+        }),
+      };
+    }
 
     // Pre-check module id against committed modules (before ephemeral registration).
     const pre = normalizeModuleDescriptor(input && input.descriptor);
-    if (pre.ok && modules.has(pre.descriptor.id)) {
+    if (pre.ok && (modules.has(pre.descriptor.id) || pendingModules.has(pre.descriptor.id))) {
       return {
         ok: false,
         status: fixedStatus({
@@ -395,59 +484,65 @@ function createAtomicModuleRegistrar(options = {}) {
         }),
       };
     }
-
-    // Use ephemeral registrar for validation + callback
-    const ephemeralCaps = createCapabilityRegistry();
-    const ephemeral = createModuleRegistrar({
-      capabilityRegistry: ephemeralCaps,
-      coreModuleApiVersion,
-      hostFeatures,
-    });
-    const result = await ephemeral.registerModule(input);
-    if (!result.ok) return result;
-
-    // Commit capabilities into host registry atomically; rollback on conflict
-    const committed = [];
+    if (pre.ok) pendingModules.add(pre.descriptor.id);
     try {
-      for (const capId of result.descriptor.capabilities.map(c => c.id)) {
-        const staged = ephemeralCaps.get(capId);
-        if (!staged) throw new Error(`missing staged capability ${capId}`);
-        // Re-register full descriptor with execute handler
-        hostCapabilityRegistry.register({
-          id: staged.id,
-          version: staged.version,
-          title: staged.title,
-          description: staged.description,
-          category: staged.category,
-          safety: staged.safety,
-          aliases: staged.aliases,
-          inputContract: staged.inputContract,
-          outputContract: staged.outputContract,
-          availability: staged.availability,
-          docs: staged.docs,
-          execute: staged.execute,
-        });
-        committed.push(staged.id);
-      }
-      modules.set(result.descriptor.id, {
-        descriptor: result.descriptor,
-        status: result.status,
+      // Use an internal isolated registrar for validation + callback.
+      const ephemeralCaps = createCapabilityRegistry();
+      const ephemeral = createStagingModuleRegistrar({
+        capabilityRegistry: ephemeralCaps,
+        coreModuleApiVersion,
+        hostFeatures,
       });
-      return result;
-    } catch (error) {
-      void error;
-      return {
-        ok: false,
-        status: fixedStatus({
-          moduleId: result.descriptor.id,
-          lifecycle: LIFECYCLE.REJECTED,
-          availability: AVAILABILITY.UNAVAILABLE,
-          reasonCode: REASON_CODES.CAPABILITY_CONFLICT,
-          message: 'Capability commit failed; no partial module registration retained.',
-          edition: result.descriptor.edition,
-          entitlementMode: result.descriptor.entitlement.mode,
-        }),
-      };
+      const result = await ephemeral.registerModule(input);
+      if (!result.ok) return result;
+
+      // Commit the fully validated capability set through one host-registry transaction.
+      try {
+        const batch = result.descriptor.capabilities.map(({ id: capId }) => {
+          const staged = ephemeralCaps.get(capId);
+          if (!staged) throw new Error(`missing staged capability ${capId}`);
+          return {
+            id: staged.id,
+            version: staged.version,
+            title: staged.title,
+            description: staged.description,
+            category: staged.category,
+            safety: staged.safety,
+            aliases: staged.aliases,
+            inputContract: staged.inputContract,
+            outputContract: staged.outputContract,
+            availability: staged.availability,
+            docs: staged.docs,
+            execute: staged.execute,
+          };
+        });
+        hostCapabilityRegistry.registerBatch(batch);
+        modules.set(result.descriptor.id, {
+          descriptor: result.descriptor,
+          status: result.status,
+        });
+        return result;
+      } catch (error) {
+        const registrySealed = /registry is sealed/i.test(String(error && error.message));
+        return {
+          ok: false,
+          status: fixedStatus({
+            moduleId: result.descriptor.id,
+            lifecycle: LIFECYCLE.REJECTED,
+            availability: AVAILABILITY.UNAVAILABLE,
+            reasonCode: registrySealed
+              ? REASON_CODES.REGISTRATION_FAILED
+              : REASON_CODES.CAPABILITY_CONFLICT,
+            message: registrySealed
+              ? 'Capability registry was sealed before commit.'
+              : 'Capability commit failed; no partial module registration retained.',
+            edition: result.descriptor.edition,
+            entitlementMode: result.descriptor.entitlement.mode,
+          }),
+        };
+      }
+    } finally {
+      if (pre.ok) pendingModules.delete(pre.descriptor.id);
     }
   }
 
@@ -473,6 +568,11 @@ function createAtomicModuleRegistrar(options = {}) {
     coreModuleApiVersion,
     capabilityRegistry: hostCapabilityRegistry,
   };
+}
+
+/** Compatibility alias: the public registrar now always uses atomic staging and batch commit. */
+function createModuleRegistrar(options = {}) {
+  return createAtomicModuleRegistrar(options);
 }
 
 module.exports = {

--- a/tests/capability-registry.test.js
+++ b/tests/capability-registry.test.js
@@ -33,6 +33,51 @@ test('capability registry rejects duplicate alias', () => {
   }, /duplicate alias/);
 });
 
+test('capability registry publishes a batch only after every id and alias validates', () => {
+  const reg = createCapabilityRegistry();
+  reg.register(TINY_VERSION_CAPABILITY);
+  const before = reg.list().map(capability => capability.id);
+  assert.throws(
+    () =>
+      reg.registerBatch([
+        { ...TINY_VERSION_CAPABILITY, id: 'test.first', aliases: ['first'] },
+        { ...TINY_VERSION_CAPABILITY, id: 'test.second', aliases: ['version'] },
+      ]),
+    /duplicate alias/
+  );
+  assert.deepEqual(
+    reg.list().map(capability => capability.id),
+    before
+  );
+  assert.equal(reg.get('test.first'), null);
+  assert.equal(reg.get('first'), null);
+});
+
+test('capability id cannot overwrite an existing alias', () => {
+  const reg = createCapabilityRegistry();
+  reg.register(TINY_VERSION_CAPABILITY);
+  assert.throws(
+    () => reg.register({ ...TINY_VERSION_CAPABILITY, id: 'version', aliases: [] }),
+    /conflicts with existing id or alias/
+  );
+  assert.equal(reg.get('version').id, 'system.version');
+});
+
+test('capability registry rejects unknown side effects', () => {
+  const reg = createCapabilityRegistry();
+  assert.throws(
+    () =>
+      reg.register({
+        ...TINY_VERSION_CAPABILITY,
+        id: 'test.unknown-side-effect',
+        aliases: [],
+        safety: { level: 'S1', sideEffects: ['unknown-effect'] },
+      }),
+    /unknown capability side effect/
+  );
+  assert.equal(reg.get('test.unknown-side-effect'), null);
+});
+
 test('capability registry execute returns structured result', async () => {
   const reg = createCapabilityRegistry();
   reg.register(TINY_VERSION_CAPABILITY);
@@ -110,4 +155,5 @@ test('capability registry can be sealed', () => {
   const reg = createCapabilityRegistry();
   reg.seal();
   assert.throws(() => reg.register(TINY_VERSION_CAPABILITY), /sealed/);
+  assert.throws(() => reg.registerBatch([TINY_VERSION_CAPABILITY]), /sealed/);
 });

--- a/tests/module-sdk.test.js
+++ b/tests/module-sdk.test.js
@@ -7,10 +7,13 @@ const fs = require('fs');
 
 const {
   normalizeModuleDescriptor,
+  createModuleRegistrar,
   createAtomicModuleRegistrar,
   REASON_CODES,
+  LIFECYCLE,
   DESCRIPTOR_VERSION,
   MODULE_API_VERSION,
+  CAPABILITY_SIDE_EFFECTS,
 } = require('../src/modules');
 const {
   buildValidDescriptor,
@@ -21,11 +24,55 @@ const { createCapabilityRegistry } = require('../src/core/capabilityRegistry');
 const { CONTRACT_IDS, INITIAL_SCHEMAS } = require('../src/core/contracts/schemas');
 const { createZeus } = require('../src/api/zeusApi');
 
+function capability({
+  id,
+  version = 1,
+  aliases = [],
+  level = 'S1',
+  sideEffects = ['local-read'],
+} = {}) {
+  return {
+    id,
+    version,
+    aliases,
+    title: id,
+    safety: { level, sideEffects, requiresExplicitApproval: false },
+    execute: async () => ({}),
+  };
+}
+
+function registerCapabilities(...capabilities) {
+  return ({ capabilityRegistry }) => {
+    for (const descriptor of capabilities) capabilityRegistry.register(descriptor);
+  };
+}
+
+function buildMultiCapabilityDescriptor(overrides = {}) {
+  return buildValidDescriptor({
+    capabilities: [
+      { id: 'example.first', version: 1 },
+      { id: 'example.second', version: 1 },
+    ],
+    ...overrides,
+  });
+}
+
 test('module descriptor contract is registered', () => {
   assert.ok(INITIAL_SCHEMAS[CONTRACT_IDS.MODULE_DESCRIPTOR]);
   assert.ok(INITIAL_SCHEMAS[CONTRACT_IDS.MODULE_STATUS]);
   assert.equal(DESCRIPTOR_VERSION, 'zeus.module-descriptor/v1');
   assert.equal(MODULE_API_VERSION, '1.0.0');
+  assert.ok(CAPABILITY_SIDE_EFFECTS.includes('local-read'));
+  assert.ok(CAPABILITY_SIDE_EFFECTS.includes('remote-write'));
+});
+
+test('module status schema accepts only closed lifecycle, availability, and reason codes', () => {
+  const statusSchema = INITIAL_SCHEMAS[CONTRACT_IDS.MODULE_STATUS].schema;
+  const validStatus = createAtomicModuleRegistrar().notInstalledStatus();
+  assert.deepEqual(statusSchema(validStatus), []);
+  assert.ok(statusSchema({ ...validStatus, reasonCode: 'VENDOR_DETAIL' }).length > 0);
+  assert.ok(statusSchema({ ...validStatus, availability: 'maybe' }).length > 0);
+  assert.ok(statusSchema({ ...validStatus, lifecycle: 'half-registered' }).length > 0);
 });
 
 test('valid descriptor normalizes deterministically', () => {
@@ -61,6 +108,120 @@ test('registers module and capability; core does not enforce entitlement', async
   assert.equal(result.status.reasonCode, REASON_CODES.AVAILABLE);
   assert.equal(result.status.coreEnforcesEntitlement, false);
   assert.ok(registrar.capabilityRegistry.get('example.inspect'));
+});
+
+test('registers multiple declared capabilities in one atomic batch', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildMultiCapabilityDescriptor(),
+    register: registerCapabilities(
+      capability({ id: 'example.first' }),
+      capability({ id: 'example.second' })
+    ),
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(
+    registrar.capabilityRegistry.list().map(entry => entry.id),
+    ['example.first', 'example.second']
+  );
+  assert.equal(registrar.listModules().length, 1);
+});
+
+test('id conflict on capability 2 leaves host and module state unchanged', async () => {
+  const caps = createCapabilityRegistry();
+  caps.register(capability({ id: 'example.second' }));
+  const before = caps.list().map(entry => ({ id: entry.id, aliases: entry.aliases }));
+  const registrar = createAtomicModuleRegistrar({ capabilityRegistry: caps });
+  const result = await registrar.registerModule({
+    descriptor: buildMultiCapabilityDescriptor(),
+    register: registerCapabilities(
+      capability({ id: 'example.first' }),
+      capability({ id: 'example.second' })
+    ),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.CAPABILITY_CONFLICT);
+  assert.deepEqual(
+    caps.list().map(entry => ({ id: entry.id, aliases: entry.aliases })),
+    before
+  );
+  assert.equal(caps.get('example.first'), null);
+  assert.equal(registrar.listModules().length, 0);
+});
+
+test('alias conflict on capability 2 leaves host and module state unchanged', async () => {
+  const caps = createCapabilityRegistry();
+  caps.register(capability({ id: 'host.existing', aliases: ['taken-alias'] }));
+  const before = caps.list().map(entry => ({ id: entry.id, aliases: entry.aliases }));
+  const registrar = createAtomicModuleRegistrar({ capabilityRegistry: caps });
+  const result = await registrar.registerModule({
+    descriptor: buildMultiCapabilityDescriptor(),
+    register: registerCapabilities(
+      capability({ id: 'example.first', aliases: ['first-alias'] }),
+      capability({ id: 'example.second', aliases: ['taken-alias'] })
+    ),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.CAPABILITY_CONFLICT);
+  assert.deepEqual(
+    caps.list().map(entry => ({ id: entry.id, aliases: entry.aliases })),
+    before
+  );
+  assert.equal(caps.get('example.first'), null);
+  assert.equal(caps.get('first-alias'), null);
+  assert.equal(registrar.listModules().length, 0);
+});
+
+test('compatibility createModuleRegistrar surface delegates to atomic registration', async () => {
+  const caps = createCapabilityRegistry();
+  caps.register(capability({ id: 'example.second' }));
+  const registrar = createModuleRegistrar({ capabilityRegistry: caps });
+  const result = await registrar.registerModule({
+    descriptor: buildMultiCapabilityDescriptor(),
+    register: registerCapabilities(
+      capability({ id: 'example.first' }),
+      capability({ id: 'example.second' })
+    ),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(caps.get('example.first'), null);
+  assert.equal(registrar.listModules().length, 0);
+});
+
+test('concurrent registration reserves module id before awaiting its callback', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  let releaseFirst;
+  let markEntered;
+  let secondCallbackCalled = false;
+  const entered = new Promise(resolve => {
+    markEntered = resolve;
+  });
+  const release = new Promise(resolve => {
+    releaseFirst = resolve;
+  });
+  const input = {
+    descriptor: buildValidDescriptor(),
+    async register({ capabilityRegistry }) {
+      markEntered();
+      await release;
+      capabilityRegistry.register(capability({ id: 'example.inspect' }));
+    },
+  };
+  const firstPromise = registrar.registerModule(input);
+  await entered;
+  const second = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register() {
+      secondCallbackCalled = true;
+    },
+  });
+  releaseFirst();
+  const first = await firstPromise;
+  assert.equal(first.ok, true);
+  assert.equal(second.ok, false);
+  assert.equal(second.status.reasonCode, REASON_CODES.DUPLICATE_MODULE_ID);
+  assert.equal(secondCallbackCalled, false);
+  assert.equal(registrar.listModules().length, 1);
 });
 
 test('duplicate module id fails closed', async () => {
@@ -164,6 +325,185 @@ test('module-reported entitlement status is display-only', async () => {
   assert.equal(result.ok, true);
   assert.equal(result.status.reasonCode, REASON_CODES.ENTITLEMENT_EXPIRED);
   assert.equal(result.status.coreEnforcesEntitlement, false);
+});
+
+test('unknown module reason code fails closed to a fixed neutral code', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: createMockRegister(),
+    status: { availability: 'available', reasonCode: 'VENDOR_INTERNAL_FAILURE_42' },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.MODULE_UNAVAILABLE);
+  assert.equal(registrar.capabilityRegistry.get('example.inspect'), null);
+  assert.equal(registrar.listModules().length, 0);
+});
+
+test('module cannot report core-owned registration reason codes', async () => {
+  for (const reasonCode of [
+    REASON_CODES.NOT_INSTALLED,
+    REASON_CODES.DESCRIPTOR_INVALID,
+    REASON_CODES.MODULE_API_INCOMPATIBLE,
+    REASON_CODES.DUPLICATE_MODULE_ID,
+    REASON_CODES.CAPABILITY_CONFLICT,
+    REASON_CODES.MODULE_INITIALIZATION_FAILED,
+  ]) {
+    const registrar = createAtomicModuleRegistrar();
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor(),
+      register: createMockRegister(),
+      status: { availability: 'unavailable', reasonCode },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status.lifecycle, LIFECYCLE.REJECTED);
+    assert.equal(result.status.reasonCode, REASON_CODES.MODULE_UNAVAILABLE);
+    assert.equal(registrar.capabilityRegistry.get('example.inspect'), null);
+    assert.equal(registrar.listModules().length, 0);
+  }
+});
+
+test('invalid or incoherent module availability fails closed', async () => {
+  for (const status of [
+    { availability: 'maybe', reasonCode: REASON_CODES.AVAILABLE },
+    { availability: 'available', reasonCode: REASON_CODES.ENTITLEMENT_EXPIRED },
+    { availability: 'unavailable', reasonCode: REASON_CODES.AVAILABLE },
+  ]) {
+    const registrar = createAtomicModuleRegistrar();
+    const result = await registrar.registerModule({
+      descriptor: buildValidDescriptor(),
+      register: createMockRegister(),
+      status,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.status.reasonCode, REASON_CODES.MODULE_UNAVAILABLE);
+    assert.equal(registrar.capabilityRegistry.get('example.inspect'), null);
+  }
+});
+
+test('secret-like module reason code is never published', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const supplied = 'TOKEN_customer-123_C:\\Users\\alice\\license.key';
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: createMockRegister(),
+    status: { availability: 'available', reasonCode: supplied },
+  });
+  const serialized = JSON.stringify(result);
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.MODULE_UNAVAILABLE);
+  assert.equal(serialized.includes(supplied), false);
+  assert.equal(serialized.includes('customer-123'), false);
+  assert.equal(serialized.includes('Users'), false);
+});
+
+test('registered capability version must exactly match the descriptor', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: registerCapabilities(capability({ id: 'example.inspect', version: 2 })),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(registrar.capabilityRegistry.get('example.inspect'), null);
+  assert.equal(registrar.listModules().length, 0);
+});
+
+test('additional undeclared capability is rejected', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: registerCapabilities(
+      capability({ id: 'example.inspect' }),
+      capability({ id: 'example.extra' })
+    ),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(registrar.capabilityRegistry.get('example.inspect'), null);
+  assert.equal(registrar.capabilityRegistry.get('example.extra'), null);
+  assert.equal(registrar.listModules().length, 0);
+});
+
+test('declared but missing capability is rejected', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildMultiCapabilityDescriptor(),
+    register: registerCapabilities(capability({ id: 'example.first' })),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(registrar.capabilityRegistry.get('example.first'), null);
+  assert.equal(registrar.listModules().length, 0);
+});
+
+test('capability side effects must be declared by the module', async () => {
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: registerCapabilities(
+      capability({ id: 'example.inspect', sideEffects: ['remote-write'] })
+    ),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(registrar.capabilityRegistry.get('example.inspect'), null);
+  assert.equal(registrar.listModules().length, 0);
+});
+
+test('unknown side effects fail closed in module and capability descriptors', async () => {
+  assert.equal(
+    normalizeModuleDescriptor(
+      buildValidDescriptor({ safety: { level: 'S1', sideEffects: ['unknown-effect'] } })
+    ).ok,
+    false
+  );
+  const registrar = createAtomicModuleRegistrar();
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register: registerCapabilities(
+      capability({ id: 'example.inspect', sideEffects: ['unknown-effect'] })
+    ),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(registrar.capabilityRegistry.get('example.inspect'), null);
+});
+
+test('atomic module registrar rejects a sealed host before invoking module code', () => {
+  const caps = createCapabilityRegistry();
+  caps.seal();
+  assert.throws(
+    () => createAtomicModuleRegistrar({ capabilityRegistry: caps }),
+    /registry is sealed/
+  );
+});
+
+test('host sealed after registrar creation rejects before invoking module code', async () => {
+  const caps = createCapabilityRegistry();
+  const registrar = createAtomicModuleRegistrar({ capabilityRegistry: caps });
+  let callbackCalled = false;
+  caps.seal();
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register() {
+      callbackCalled = true;
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.REGISTRATION_FAILED);
+  assert.equal(callbackCalled, false);
+});
+
+test('host sealed during staging rejects commit without partial state', async () => {
+  const caps = createCapabilityRegistry();
+  const registrar = createAtomicModuleRegistrar({ capabilityRegistry: caps });
+  const result = await registrar.registerModule({
+    descriptor: buildValidDescriptor(),
+    register({ capabilityRegistry }) {
+      capabilityRegistry.register(capability({ id: 'example.inspect' }));
+      caps.seal();
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.status.reasonCode, REASON_CODES.REGISTRATION_FAILED);
+  assert.equal(caps.get('example.inspect'), null);
+  assert.equal(registrar.listModules().length, 0);
 });
 
 test('createZeus exposes modules registrar without commercial deps', async () => {


### PR DESCRIPTION
## Summary

- make external module capability registration atomic across IDs and aliases
- enforce exact declared capabilities, versions, safety levels, and provider-neutral side effects
- close module status lifecycle, availability, reason-code provenance, and secret handling
- extend the public contract test kit and document the trusted in-process boundary

## Validation

- focused module/registry tests: 46/46 pass
- unit: 641 pass; smoke: 9 pass; corpus: 1 pass
- quality: 3 pass; benchmark: 1 pass
- format, lint, typecheck, discovery, package smoke, docs, demo safety, public claims, portability: pass
- runtime-config boundary: 44 pass; release integrity: 34 pass
- npm audit: 0 vulnerabilities; npm pack dry-run and diff/secret checks: pass

## Local platform notes

The complete contract category reports 180/182 locally on Windows. The two failures are unrelated to this diff:

- a 10 ms provider timeout assertion flakes only under the full parallel contract load and passes 6/6 in isolation
- the repository-control symlink escape fixture cannot create a Windows symlink (`EPERM`); platform CI is authoritative

## Scope

Iteration 30 baseline repair only. No licensing implementation, paid capability, sandbox claim, discovery/hot reload, or Iteration 31 work is included.

Exact reviewed SHA: `6ad7dc3502901e5033ee92df3d20cdd02b256732`.
