### PR TITLE
Iteration 33: add Community deployment reference

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.local
+node_modules
+*.tgz
+config/local-only
+examples/*/output*
+tests
+docs/maintainers
+*.env
+*.env.*
+!.env.example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
       - run: npm ci
       - run: npm run test:deployment:community
       - name: Validate Compose model
-        run: docker compose --profile zeus config --quiet
+        run: ZEUS_PROVIDER_ENDPOINT=http://127.0.0.1:11434 ZEUS_PROVIDER_MODEL=ci-synthetic docker compose --profile zeus config --quiet
       - name: Build community image
         run: docker build --pull --tag zeus-rpg-promptkit:community-ci .
       - name: Run offline non-root help smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,27 @@ jobs:
       - run: npm ci
       - run: npm run package:smoke
 
+  community-container:
+    name: Community Container Reference
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test:deployment:community
+      - name: Validate Compose model
+        run: docker compose --profile zeus config --quiet
+      - name: Build community image
+        run: docker build --pull --tag zeus-rpg-promptkit:community-ci .
+      - name: Run offline non-root help smoke
+        run: >-
+          docker run --rm --read-only --tmpfs /tmp:rw,noexec,nosuid,size=64m
+          --mount type=tmpfs,destination=/data/artifacts
+          zeus-rpg-promptkit:community-ci --help
   # Boundary guards run in parallel via their own workflows (distinct security value).
   # See demo-safety-check.yml, public-knowledge-claims.yml, runtime-config-boundary.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Community reference image. The Node image tag is pinned to a tested release.
+FROM node:22.18.0-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev \
+    && npm cache clean --force
+
+COPY --chown=node:node . .
+
+RUN mkdir -p /data/artifacts /tmp/zeus-home \
+    && chown -R node:node /data/artifacts /tmp/zeus-home
+
+ENV HOME=/tmp/zeus-home
+ENV ZEUS_OUTPUT_ROOT=/data/artifacts
+
+USER node
+
+ENTRYPOINT ["node", "cli/zeus.js"]
+CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  zeus:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: zeus-rpg-promptkit:community
+    profiles: [zeus]
+    command:
+      ['serve', '--host', '127.0.0.1', '--port', '4782', '--source-output-root', '/data/artifacts']
+    ports:
+      - '127.0.0.1:4782:4782'
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64m
+    volumes:
+      - zeus-artifacts:/data/artifacts
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: [ALL]
+    restart: 'no'
+
+  local-provider:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: zeus-rpg-promptkit:community
+    profiles: [local-provider]
+    command:
+      ['serve', '--host', '127.0.0.1', '--port', '4782', '--source-output-root', '/data/artifacts']
+    ports:
+      - '127.0.0.1:4782:4782'
+    environment:
+      ZEUS_PROVIDER_ENDPOINT: '${ZEUS_PROVIDER_ENDPOINT:?Set ZEUS_PROVIDER_ENDPOINT to an operator-approved private endpoint}'
+      ZEUS_PROVIDER_MODEL: '${ZEUS_PROVIDER_MODEL:?Set ZEUS_PROVIDER_MODEL to an operator-approved model name}'
+    read_only: true
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=64m
+    volumes:
+      - zeus-artifacts:/data/artifacts
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: [ALL]
+    restart: 'no'
+
+volumes:
+  zeus-artifacts:

--- a/docs/deployment/community-container.md
+++ b/docs/deployment/community-container.md
@@ -1,0 +1,65 @@
+# Community container reference
+
+The repository includes a local reference container for trying the existing
+Zeus viewer without an IBM i system or a model. It is an example for local
+development, not a production certification or hardened enterprise
+deployment.
+
+## Defaults and boundaries
+
+- The image uses the pinned `node:22.18.0-bookworm-slim` release and runs as
+  the non-root `node` user.
+- Compose enables a read-only root filesystem, drops Linux capabilities,
+  disallows privilege escalation, and exposes the viewer only on
+  `127.0.0.1:4782`.
+- Only `/data/artifacts` is writable. `/tmp` is an ephemeral, bounded tmpfs.
+- No model is downloaded and no IBM i or Db2 connection is attempted by the
+  default help/demo path.
+- No credential is included. Operator-supplied values must come from the
+  environment or an external secret mechanism; do not place them in Compose,
+  source control, logs, or generated artifacts.
+- The image does not create a public ingress, host-network access, host mounts,
+  or cluster permissions.
+
+## Zeus-only profile
+
+Build and start the local viewer with existing artifacts:
+
+```bash
+docker compose --profile zeus up --build
+```
+
+Open `http://127.0.0.1:4782` locally. The named `zeus-artifacts` volume is the
+only persistent writable location. The image's default command is `zeus
+--help`, which is useful for a build/package smoke test without IBM i or model
+access.
+
+## Local-provider profile
+
+The profile documents operator-supplied provider metadata without probing,
+downloading, or falling back to a model automatically:
+
+```bash
+ZEUS_PROVIDER_ENDPOINT=http://127.0.0.1:11434 \
+ZEUS_PROVIDER_MODEL=operator-selected-model \
+  docker compose --profile local-provider up --build
+```
+
+These are placeholders for an operator-approved private endpoint and model.
+They are not credentials and are not embedded in the image. Provider access
+still requires the application's explicit provider configuration and policy;
+starting this reference profile alone does not authorize remote access.
+
+## Validation
+
+Run the repository's local checks first:
+
+```bash
+npm run test:deployment:community
+```
+
+If Docker is installed, an operator may additionally run `docker compose
+config` and a local build. CI/static tests must not claim a Docker build when
+Docker is unavailable. This reference intentionally makes no claim of
+Kubernetes, VPC, registry, backup, retention, certification, or production
+readiness; those operational concerns belong to the private Enterprise module.

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "sbom:validate": "node scripts/validate-sbom.js",
     "repo:control": "node scripts/repository-control.js",
     "test:repository-control": "node --test tests/repository-control.test.js",
+    "test:deployment:community": "node --test tests/community-deployment.test.js",
     "test:release-integrity": "node --test tests/release-integrity.test.js",
     "test:cli-help": "node --test tests/cli-help.test.js && npm run package:smoke"
   },

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -19,6 +19,7 @@ module.exports = {
       'tests/provider-local-adapters.test.js',
       'tests/module-sdk.test.js',
       'tests/workflow-presets.test.js',
+      'tests/community-deployment.test.js',
     ],
     smoke: [
       'tests/reproducible-output.test.js',

--- a/tests/community-deployment.test.js
+++ b/tests/community-deployment.test.js
@@ -1,0 +1,71 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const dockerfile = fs.readFileSync(path.join(ROOT, 'Dockerfile'), 'utf8');
+const compose = fs.readFileSync(path.join(ROOT, 'docker-compose.yml'), 'utf8');
+const docs = fs.readFileSync(path.join(ROOT, 'docs/deployment/community-container.md'), 'utf8');
+const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/ci.yml'), 'utf8');
+
+test('community image is pinned and runs as a non-root user', () => {
+  assert.match(dockerfile, /^FROM node:22\.18\.0-bookworm-slim$/m);
+  assert.match(dockerfile, /^USER node$/m);
+  assert.match(dockerfile, /npm ci --omit=dev/);
+  assert.match(dockerfile, /ENTRYPOINT \["node", "cli\/zeus\.js"\]/);
+  assert.match(dockerfile, /CMD \["--help"\]/);
+  assert.doesNotMatch(dockerfile, /USER root|sudo|curl .*https?:/i);
+});
+
+test('compose profiles keep local access and writable artifacts bounded', () => {
+  assert.match(compose, /profiles: \[zeus\]/);
+  assert.match(compose, /profiles: \[local-provider\]/);
+  assert.equal((compose.match(/127\.0\.0\.1:4782:4782/g) || []).length, 2);
+  assert.equal((compose.match(/read_only: true/g) || []).length, 2);
+  assert.equal((compose.match(/zeus-artifacts:\/data\/artifacts/g) || []).length, 2);
+  assert.equal((compose.match(/tmpfs:/g) || []).length, 2);
+  assert.equal((compose.match(/no-new-privileges:true/g) || []).length, 2);
+  assert.equal((compose.match(/cap_drop: \[ALL\]/g) || []).length, 2);
+  assert.match(compose, /ZEUS_PROVIDER_ENDPOINT/);
+  assert.match(compose, /ZEUS_PROVIDER_MODEL/);
+  assert.doesNotMatch(compose, /privileged:\s*true|network_mode:\s*host|pid:\s*host/i);
+  assert.doesNotMatch(compose, /0\.0\.0\.0|hostPath:|docker\.sock/i);
+  assert.doesNotMatch(compose, /(password|token|secret|private[_-]?key)\s*[:=]\s*[^$\s}]+/i);
+});
+
+test('community docs state reference limitations and secret/model boundaries', () => {
+  assert.match(docs, /not a production certification/i);
+  assert.match(docs, /non-root/i);
+  assert.match(docs, /read-only root filesystem/i);
+  assert.match(docs, /127\.0\.0\.1:4782/);
+  assert.match(docs, /No model is downloaded/i);
+  assert.match(docs, /No credential is included/i);
+  assert.match(docs, /private Enterprise module/i);
+  assert.doesNotMatch(docs, /production-ready|certified for production/i);
+});
+
+test('CI provides real container evidence without suppressing failures', () => {
+  const section = workflow.slice(
+    workflow.indexOf('community-container:'),
+    workflow.indexOf('  # Boundary guards')
+  );
+  assert.match(section, /runs-on: ubuntu-latest/);
+  assert.match(section, /npm run test:deployment:community/);
+  assert.match(section, /docker compose --profile zeus config --quiet/);
+  assert.match(section, /docker build --pull/);
+  assert.match(section, /docker run --rm --read-only/);
+  assert.match(section, /--mount type=tmpfs,destination=\/data\/artifacts/);
+  assert.doesNotMatch(section, /continue-on-error|\|\|\s*true/);
+});
+test('local CLI help smoke is offline and does not require a provider', () => {
+  const result = spawnSync(process.execPath, [path.join(ROOT, 'cli/zeus.js'), '--help'], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    env: { PATH: process.env.PATH },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Usage:/);
+  assert.match(result.stdout, /zeus.*analyze/);
+});


### PR DESCRIPTION
## Scope
Community half of Iteration 33 from baseline 0ce4e57beb61cad3e610696a4225d2a7c51b2569.

Adds a local reference container and Compose profiles with non-root/read-only defaults, loopback-only binding, a dedicated artifact volume, operator-supplied provider metadata placeholders, offline help smoke, and explicit non-certification/security documentation.

## Safety and non-goals
- No Enterprise/Kubernetes/Kustomize implementation.
- No credentials, customer data, model download, telemetry, public ingress, privileged/root/host-network defaults, or production certification claim.
- Existing public contracts and production behavior remain unchanged.
- Docker is not available locally; CI contains the real Compose render, image build, and read-only help smoke.

## Validation
- npm ci
- npm test (641 tests)
- npm run test:deployment:community
- discovery, quality, benchmark, format, lint, typecheck, package smoke, docs, demo safety, public claims, portability, repository control, audit, pack dry-run, diff check

Feature commit: 702a2c2053f20593c39e8a49f25ca6982f8109b1