### PR TITLE
fix: make community Compose viewer reachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,12 +134,36 @@ jobs:
       - name: Validate Compose model
         run: ZEUS_PROVIDER_ENDPOINT=http://127.0.0.1:11434 ZEUS_PROVIDER_MODEL=ci-synthetic docker compose --profile zeus config --quiet
       - name: Build community image
-        run: docker build --pull --tag zeus-rpg-promptkit:community-ci .
+        run: docker build --pull --tag zeus-rpg-promptkit:community .
+      - name: Start and reach community Compose service
+        shell: bash
+        run: |
+          set -euo pipefail
+          export ZEUS_PROVIDER_ENDPOINT=http://127.0.0.1:11434
+          export ZEUS_PROVIDER_MODEL=ci-synthetic
+          project="zeus-community-ci-${GITHUB_RUN_ID}"
+          cleanup() {
+            docker compose -p "$project" --profile zeus down --volumes --remove-orphans
+          }
+          trap cleanup EXIT
+          docker compose -p "$project" --profile zeus up -d
+          for attempt in $(seq 1 30); do
+            if response=$(curl --fail --silent --show-error --max-time 2 \
+              http://127.0.0.1:4782/api/health); then
+              node -e 'const body = JSON.parse(process.argv[1]); if (body.ok !== true) process.exit(1);' "$response"
+              exit 0
+            fi
+            sleep 1
+          done
+          docker compose -p "$project" --profile zeus ps
+          docker compose -p "$project" --profile zeus logs --no-color
+          echo 'Community Compose service did not become reachable within 30 seconds.' >&2
+          exit 1
       - name: Run offline non-root help smoke
         run: >-
           docker run --rm --read-only --tmpfs /tmp:rw,noexec,nosuid,size=64m
           --mount type=tmpfs,destination=/data/artifacts
-          zeus-rpg-promptkit:community-ci --help
+          zeus-rpg-promptkit:community --help
   # Boundary guards run in parallel via their own workflows (distinct security value).
   # See demo-safety-check.yml, public-knowledge-claims.yml, runtime-config-boundary.yml
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: zeus-rpg-promptkit:community
     profiles: [zeus]
     command:
-      ['serve', '--host', '127.0.0.1', '--port', '4782', '--source-output-root', '/data/artifacts']
+      ['serve', '--host', '0.0.0.0', '--port', '4782', '--source-output-root', '/data/artifacts']
     ports:
       - '127.0.0.1:4782:4782'
     read_only: true
@@ -26,7 +26,7 @@ services:
     image: zeus-rpg-promptkit:community
     profiles: [local-provider]
     command:
-      ['serve', '--host', '127.0.0.1', '--port', '4782', '--source-output-root', '/data/artifacts']
+      ['serve', '--host', '0.0.0.0', '--port', '4782', '--source-output-root', '/data/artifacts']
     ports:
       - '127.0.0.1:4782:4782'
     environment:

--- a/docs/deployment/community-container.md
+++ b/docs/deployment/community-container.md
@@ -11,7 +11,9 @@ deployment.
   the non-root `node` user.
 - Compose enables a read-only root filesystem, drops Linux capabilities,
   disallows privilege escalation, and exposes the viewer only on
-  `127.0.0.1:4782`.
+  `127.0.0.1:4782`. Inside the container, Zeus listens on the container
+  interface (`0.0.0.0`); Docker's host publishing remains explicitly bound to
+  host loopback.
 - Only `/data/artifacts` is writable. `/tmp` is an ephemeral, bounded tmpfs.
 - No model is downloaded and no IBM i or Db2 connection is attempted by the
   default help/demo path.
@@ -32,7 +34,8 @@ docker compose --profile zeus up --build
 Open `http://127.0.0.1:4782` locally. The named `zeus-artifacts` volume is the
 only persistent writable location. The image's default command is `zeus
 --help`, which is useful for a build/package smoke test without IBM i or model
-access.
+access. The default reachability check uses the existing read-only
+`GET /api/health` route; it needs no provider, IBM i, or Db2 access.
 
 ## Local-provider profile
 

--- a/src/ui/localUiServer.js
+++ b/src/ui/localUiServer.js
@@ -45,10 +45,10 @@ function normalizeHost(host) {
   if (!normalized || normalized === 'localhost') {
     return DEFAULT_UI_HOST;
   }
-  if (normalized === '127.0.0.1' || normalized === '::1') {
+  if (normalized === '127.0.0.1' || normalized === '::1' || normalized === '0.0.0.0') {
     return normalized;
   }
-  throw new Error('Local UI server only supports localhost/loopback binding');
+  throw new Error('Local UI server only supports localhost/loopback or explicit container binding');
 }
 
 function parsePositiveInteger(value, fallback) {

--- a/tests/community-deployment.test.js
+++ b/tests/community-deployment.test.js
@@ -3,6 +3,7 @@ const { test } = require('node:test');
 const fs = require('node:fs');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { startLocalUiServer } = require('../src/ui/localUiServer');
 
 const ROOT = path.resolve(__dirname, '..');
 const dockerfile = fs.readFileSync(path.join(ROOT, 'Dockerfile'), 'utf8');
@@ -31,8 +32,20 @@ test('compose profiles keep local access and writable artifacts bounded', () => 
   assert.match(compose, /ZEUS_PROVIDER_ENDPOINT/);
   assert.match(compose, /ZEUS_PROVIDER_MODEL/);
   assert.doesNotMatch(compose, /privileged:\s*true|network_mode:\s*host|pid:\s*host/i);
-  assert.doesNotMatch(compose, /0\.0\.0\.0|hostPath:|docker\.sock/i);
+  assert.equal((compose.match(/'--host', '0\.0\.0\.0'/g) || []).length, 2);
+  assert.doesNotMatch(compose, /0\.0\.0\.0:4782:4782|hostPath:|docker\.sock/i);
   assert.doesNotMatch(compose, /(password|token|secret|private[_-]?key)\s*[:=]\s*[^$\s}]+/i);
+});
+
+test('container listener bind is explicitly supported without changing the local default', async () => {
+  const started = await startLocalUiServer({ outputRoot: ROOT, host: '0.0.0.0', port: 0 });
+  try {
+    const response = await fetch(`http://127.0.0.1:${started.port}/api/health`);
+    assert.equal(response.status, 200);
+    assert.equal((await response.json()).ok, true);
+  } finally {
+    await new Promise(resolve => started.server.close(resolve));
+  }
 });
 
 test('community docs state reference limitations and secret/model boundaries', () => {
@@ -57,6 +70,11 @@ test('CI provides real container evidence without suppressing failures', () => {
   assert.match(section, /docker build --pull/);
   assert.match(section, /docker run --rm --read-only/);
   assert.match(section, /--mount type=tmpfs,destination=\/data\/artifacts/);
+  assert.match(section, /docker compose .* up -d/);
+  assert.match(section, /127\.0\.0\.1:4782\/api\/health/);
+  assert.match(section, /docker compose .* down .*--volumes/);
+  assert.match(section, /curl .*--fail/);
+  assert.match(section, /trap cleanup EXIT/);
   assert.doesNotMatch(section, /continue-on-error|\|\|\s*true/);
 });
 test('local CLI help smoke is offline and does not require a provider', () => {


### PR DESCRIPTION
## Root cause\nCompose published host loopback correctly but both services bound Zeus to container loopback, so Docker forwarding could not reach the listener. CI did not start the Compose service or probe HTTP.\n\n## Repair\n- bind both Compose services to container 