### PR TITLE
docs: add synthetic community secret injection example

### DIFF
--- a/docs/deployment/community-container.md
+++ b/docs/deployment/community-container.md
@@ -53,6 +53,34 @@ They are not credentials and are not embedded in the image. Provider access
 still requires the application's explicit provider configuration and policy;
 starting this reference profile alone does not authorize remote access.
 
+## Synthetic secret-injection example
+
+The following is a copyable **synthetic-only** example of supplying an existing
+runtime secret from outside the image. The value is intentionally fake and is
+not used by the local help/health smoke path; it only demonstrates the
+operator-to-container boundary for an existing environment-backed setting.
+
+```bash
+# Synthetic placeholder only; never use a real credential in this file.
+cat > .env.zeus.local <<'EOF'
+ZEUS_FETCH_PASSWORD=synthetic-placeholder-only
+EOF
+
+# --env-file reads the local operator file; --env passes that variable into
+# this one-shot container. The image and repository remain unchanged.
+docker compose --env-file .env.zeus.local --profile zeus run --rm \
+  --env ZEUS_FETCH_PASSWORD zeus --help
+
+# Remove the local-only file after the smoke.
+rm -f .env.zeus.local
+```
+
+Keep `.env.zeus.local` outside source control and replace the synthetic value
+only in the operator's private environment. Do not add it to the image,
+Compose YAML, logs, artifacts, or this repository. This example does not
+configure a provider, authorize remote access, or claim Kubernetes/Enterprise
+secret management.
+
 ## Validation
 
 Run the repository's local checks first:

--- a/tests/community-deployment.test.js
+++ b/tests/community-deployment.test.js
@@ -59,6 +59,17 @@ test('community docs state reference limitations and secret/model boundaries', (
   assert.doesNotMatch(docs, /production-ready|certified for production/i);
 });
 
+test('community docs provide a synthetic external secret-injection example', () => {
+  assert.match(docs, /Synthetic secret-injection example/);
+  assert.match(docs, /\.env\.zeus\.local/);
+  assert.match(docs, /ZEUS_FETCH_PASSWORD=synthetic-placeholder-only/);
+  assert.match(docs, /--env-file \.env\.zeus\.local/);
+  assert.match(docs, /--env ZEUS_FETCH_PASSWORD/);
+  assert.match(docs, /outside the image/i);
+  assert.match(docs, /outside source control/i);
+  assert.doesNotMatch(docs, /AKIA[0-9A-Z]{16}|BEGIN (RSA|OPENSSH|PRIVATE) KEY/i);
+});
+
 test('CI provides real container evidence without suppressing failures', () => {
   const section = workflow.slice(
     workflow.indexOf('community-container:'),


### PR DESCRIPTION
Corrective repair for Roadmap 08 Community gap. Adds a copyable synthetic-only external env-file example using existing runtime environment semantics and a focused documentation contract test. No credentials, provider API, container security defaults, reachability behavior, or Enterprise scope changed.