### PR TITLE
docs: freeze ZPI-01 architecture baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ out/
 .idea/
 *.iml
 .vscode/
+*.code-workspace
 
 # -----------------------------
 # Node

--- a/docs/architecture/adr-009-project-intelligence-ownership.md
+++ b/docs/architecture/adr-009-project-intelligence-ownership.md
@@ -65,19 +65,19 @@ never depend on Commercial code, entitlements, or proprietary store formats.
 
 ### Capability and artifact matrix
 
-| Area | Community | Commercial |
-| ---- | --------- | ---------- |
-| Contracts and schemas | owns | may consume and extend only through public versioned contracts |
-| SQLite metadata store | owns default implementation | may use through public interfaces only |
-| Content-addressed evidence store | owns default implementation | may use through public interfaces only |
-| Lucene lexical retrieval | owns default implementation | may add registered ranking or policy layers |
-| Full rebuild | owns | may orchestrate or invoke through public capability surfaces |
-| Incremental refresh | baseline invalidation rules and contracts | advanced planning and execution |
-| Context assembly | owns default offline bounded policy | may register advanced policy packs |
-| Artifact readers and validators | owns | may add entitlement-free readers for private artifact contracts |
-| CLI/MCP surface | thin neutral projections | paid capabilities appear only when registered |
-| Entitlement enforcement | forbidden | owns |
-| Proprietary diagnostics or policy data | forbidden | owns |
+| Area                                   | Community                                 | Commercial                                                      |
+| -------------------------------------- | ----------------------------------------- | --------------------------------------------------------------- |
+| Contracts and schemas                  | owns                                      | may consume and extend only through public versioned contracts  |
+| SQLite metadata store                  | owns default implementation               | may use through public interfaces only                          |
+| Content-addressed evidence store       | owns default implementation               | may use through public interfaces only                          |
+| Lucene lexical retrieval               | owns default implementation               | may add registered ranking or policy layers                     |
+| Full rebuild                           | owns                                      | may orchestrate or invoke through public capability surfaces    |
+| Incremental refresh                    | baseline invalidation rules and contracts | advanced planning and execution                                 |
+| Context assembly                       | owns default offline bounded policy       | may register advanced policy packs                              |
+| Artifact readers and validators        | owns                                      | may add entitlement-free readers for private artifact contracts |
+| CLI/MCP surface                        | thin neutral projections                  | paid capabilities appear only when registered                   |
+| Entitlement enforcement                | forbidden                                 | owns                                                            |
+| Proprietary diagnostics or policy data | forbidden                                 | owns                                                            |
 
 ### Non-negotiable boundary rules
 

--- a/docs/architecture/adr-009-project-intelligence-ownership.md
+++ b/docs/architecture/adr-009-project-intelligence-ownership.md
@@ -1,0 +1,109 @@
+---
+Title: ADR-009 Project Intelligence Ownership Split
+Description: Community and Commercial ownership boundaries for Zeus Project Intelligence contracts, default backends, and entitlement-gated operations.
+Last Updated: 2026-07-22
+---
+
+# ADR-009: Project Intelligence Ownership Split
+
+**Status:** Accepted for ZPI-01 documentation baseline
+
+## Context
+
+Zeus already defines a stable open-core boundary in ADR-006. Zeus Project Intelligence adds a
+persistent, versioned project-knowledge system that spans source evidence, derived symbols,
+relationships, retrieval, and bounded context assembly.
+
+Without an explicit ownership split, two failure modes become likely:
+
+- Community ships only inert contracts while useful local indexing and retrieval move behind a
+  private implementation.
+- Commercial code duplicates Community infrastructure or leaks proprietary orchestration into the
+  Apache-2.0 core for convenience.
+
+ZPI must remain local-first, offline by default, and compatible with the existing capability
+registry, safety model, and thin CLI/MCP projection strategy.
+
+Package 09 is closed. ZPI-01 must not reopen Package 09 or introduce new live IBM i behavior.
+
+## Decision
+
+### Community ownership
+
+Community owns the neutral, Apache-2.0 project-intelligence baseline:
+
+- versioned knowledge contracts and schema identifiers
+- evidence, source-span, provenance, derivation, and safety contracts
+- project, snapshot, analyzer-run, and migration contracts
+- store, content, search, and retrieval service provider interfaces
+- local default persistence and retrieval backends
+- full rebuild and read-only query behavior
+- deterministic bounded context-package contracts and default offline policy
+- artifact readers, validators, contract tests, and fail-closed reason-code catalogs
+- thin CLI, API, and MCP-neutral capability contracts and adapters
+
+Community must remain complete and useful without any Commercial module. A user must be able to:
+
+- build project knowledge from trusted local inputs
+- reopen and validate published snapshots
+- run deterministic local lexical retrieval
+- assemble bounded local context packages under the Community default policy
+- read and export Community-owned artifacts without entitlement
+
+### Commercial ownership
+
+Commercial owns entitlement-gated, separately distributed extensions only:
+
+- project-level registration and orchestration beyond the Community baseline
+- advanced incremental refresh planning and execution
+- advanced retrieval ranking or expansion policies that extend, not replace, Community contracts
+- advanced context assembly policies and redacted commercial diagnostics
+- resource-governance packs, entitlement-aware operations, and future enterprise integrations
+
+Commercial must depend only on public Community contracts and registration surfaces. Community must
+never depend on Commercial code, entitlements, or proprietary store formats.
+
+### Capability and artifact matrix
+
+| Area | Community | Commercial |
+| ---- | --------- | ---------- |
+| Contracts and schemas | owns | may consume and extend only through public versioned contracts |
+| SQLite metadata store | owns default implementation | may use through public interfaces only |
+| Content-addressed evidence store | owns default implementation | may use through public interfaces only |
+| Lucene lexical retrieval | owns default implementation | may add registered ranking or policy layers |
+| Full rebuild | owns | may orchestrate or invoke through public capability surfaces |
+| Incremental refresh | baseline invalidation rules and contracts | advanced planning and execution |
+| Context assembly | owns default offline bounded policy | may register advanced policy packs |
+| Artifact readers and validators | owns | may add entitlement-free readers for private artifact contracts |
+| CLI/MCP surface | thin neutral projections | paid capabilities appear only when registered |
+| Entitlement enforcement | forbidden | owns |
+| Proprietary diagnostics or policy data | forbidden | owns |
+
+### Non-negotiable boundary rules
+
+- Community default backends must not be dormant paid features.
+- Commercial modules must not require Community core to branch on product ID, edition, or
+  entitlement state.
+- Any persisted format needed to read Community-owned project knowledge must remain documented and
+  readable without Commercial code.
+- Retrieval hits, rankings, and context packages are derived aids, not canonical source evidence.
+- Package 09 remains closed. ZPI does not add live IBM i compile, execute, or differential flows.
+
+## Consequences
+
+- ZPI can evolve as an open-core system without making Community a stub.
+- Commercial features can add value through registration and policy without redefining core data
+  ownership.
+- Later implementation packages must treat Community full rebuild and artifact readers as the
+  reference behavior that Commercial extensions may optimize but not replace.
+
+## Alternatives considered
+
+- **Commercial owns all useful project-intelligence operations.** Rejected because it would make
+  Community contracts nominal only and violate the open-core baseline.
+- **Duplicate contracts in Commercial.** Rejected because schema forks would fragment compatibility,
+  testing, and artifact portability.
+- **Put entitlement checks into Community adapters.** Rejected because ADR-006 keeps entitlement out
+  of the core.
+- **Reopen Package 09 for project-intelligence runtime hooks.** Rejected because ZPI-01 is a docs
+  package and Package 09 is explicitly closed.

--- a/docs/architecture/adr-010-default-store-and-search.md
+++ b/docs/architecture/adr-010-default-store-and-search.md
@@ -36,11 +36,11 @@ embedding service, or mandatory daemon is required.
 
 ### Backend roles
 
-| Backend | Role |
-| ------- | ---- |
-| SQLite | canonical derived metadata, indexes of record, lifecycle state, migrations, current pointer |
-| Content-addressed files | immutable evidence blobs and preserved source payloads |
-| Lucene | lexical retrieval over published snapshot content and metadata |
+| Backend                 | Role                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------- |
+| SQLite                  | canonical derived metadata, indexes of record, lifecycle state, migrations, current pointer |
+| Content-addressed files | immutable evidence blobs and preserved source payloads                                      |
+| Lucene                  | lexical retrieval over published snapshot content and metadata                              |
 
 ### Determinism requirements
 

--- a/docs/architecture/adr-010-default-store-and-search.md
+++ b/docs/architecture/adr-010-default-store-and-search.md
@@ -1,0 +1,96 @@
+---
+Title: ADR-010 Default Store and Search Architecture
+Description: SQLite metadata, content-addressed evidence storage, and Lucene lexical retrieval as the Community default project-intelligence backends.
+Last Updated: 2026-07-22
+---
+
+# ADR-010: Default Store and Search Architecture
+
+**Status:** Accepted for ZPI-01 documentation baseline
+
+## Context
+
+Zeus Project Intelligence needs a deterministic local persistence and retrieval baseline that works
+without network access, external services, or proprietary dependencies.
+
+The default backend must support:
+
+- durable project and snapshot metadata
+- content-addressed evidence storage
+- deterministic lexical retrieval
+- bounded local resource usage
+- Windows-compatible local operation
+- compatibility with Community artifact portability and Commercial extension points
+
+## Decision
+
+Community adopts this default backend architecture:
+
+- SQLite for canonical project, snapshot, source-unit, symbol, relationship, and migration
+  metadata
+- content-addressed local files for preserved evidence payloads and large immutable source content
+- Apache Lucene for lexical retrieval over published Community snapshots
+
+This baseline is local-first and offline by default. No external database, search service,
+embedding service, or mandatory daemon is required.
+
+### Backend roles
+
+| Backend | Role |
+| ------- | ---- |
+| SQLite | canonical derived metadata, indexes of record, lifecycle state, migrations, current pointer |
+| Content-addressed files | immutable evidence blobs and preserved source payloads |
+| Lucene | lexical retrieval over published snapshot content and metadata |
+
+### Determinism requirements
+
+The Community default backends must document and preserve deterministic behavior:
+
+- explicit canonical path normalization rules
+- explicit analyzer identity and analyzer version for Lucene-backed retrieval
+- stable document identifiers and deterministic tie-break ordering
+- explicit query result bounds and omission reporting
+- single-writer publish semantics for SQLite, Lucene, and content-store state
+- reproducibility guidance for metadata that is intentionally non-canonical
+
+Scores may be advisory, but ordered hit identifiers must be deterministic for a pinned engine
+version, analyzer version, and snapshot.
+
+### Fail-closed requirements
+
+If any required backend is unavailable, corrupt, mismatched, or only partially published:
+
+- project-intelligence read or write operations must fail closed with stable reason codes
+- the system must not silently serve partial or mixed-generation data as current
+- Community readers must prefer refusal or explicit degraded status over fabricated empty success
+
+### Explicit exclusions for the default baseline
+
+The Community default backend does not require:
+
+- vector databases or external embedding services
+- live IBM i access
+- remote activation, telemetry, or entitlement checks
+- commercial policy modules
+- a second proprietary registry for retrieval or search behavior
+
+Vector-ready schema fields may be added later only as optional extensions. Lexical retrieval remains
+the mandatory Community baseline.
+
+## Consequences
+
+- Community implementation packages can target a clear local baseline before advanced policy work.
+- Commercial modules can add orchestration or advanced ranking through public contracts without
+  replacing the default storage and search foundations.
+- Dependency selection for actual SQLite and Lucene bindings becomes a governance event that must
+  preserve Apache-2.0 compatibility and offline operation.
+
+## Alternatives considered
+
+- **Remote database and hosted search.** Rejected because ZPI must remain local-first and offline by
+  default.
+- **Lucene-only storage.** Rejected because canonical metadata, migrations, and lifecycle state need
+  a transactional metadata store separate from search indexes.
+- **SQLite full-text only.** Rejected because ZPI needs a stronger lexical retrieval baseline and a
+  clear path to bounded search-specific schema evolution.
+- **Commercial-only default backends.** Rejected because Community must remain complete and useful.

--- a/docs/architecture/adr-011-evidence-and-provenance.md
+++ b/docs/architecture/adr-011-evidence-and-provenance.md
@@ -1,0 +1,87 @@
+---
+Title: ADR-011 Evidence and Provenance Model
+Description: Canonical evidence, derivation lineage, and export-disclosure provenance rules for Zeus Project Intelligence.
+Last Updated: 2026-07-22
+---
+
+# ADR-011: Evidence and Provenance Model
+
+**Status:** Accepted for ZPI-01 documentation baseline
+
+## Context
+
+Zeus Project Intelligence needs precise provenance to remain auditable, deterministic, and safe.
+Existing Zeus documentation already distinguishes evidence, summaries, and generated artifacts, but
+ZPI introduces longer-lived project knowledge, retrieval results, and context packages.
+
+Using one vague concept of provenance would mix three different concerns:
+
+- where source evidence came from
+- how derived facts were produced
+- what can safely leave the local trust zone
+
+## Decision
+
+ZPI uses three distinct provenance classes.
+
+### 1. Source evidence provenance
+
+Source evidence provenance identifies the trusted origin of preserved facts:
+
+- project identity
+- snapshot identity
+- trusted root identity
+- source-unit identity
+- canonical path or member identity under the trusted root
+- content hash and source span references
+
+This provenance supports audit, reproducibility, and stale detection.
+
+### 2. Derivation lineage provenance
+
+Derivation lineage records how a fact was produced:
+
+- analyzer identity and analyzer version
+- derivation class such as `VERIFIED`, `INFERRED`, `UNRESOLVED`, `STALE`, or `INVALIDATED`
+- dependency edges or source-evidence references used to derive the fact
+- snapshot-local ordering or publication metadata needed for deterministic replay
+
+Derived retrieval ranks, heuristics, and context assembly outputs are not source evidence. They must
+carry lineage, but they must not mint new canonical evidence identities.
+
+### 3. Export-disclosure provenance
+
+Export-disclosure provenance records what a shareable or external-facing artifact omits, redacts, or
+normalizes:
+
+- redaction or omission reason codes
+- whether a package is local-only or safe-sharing eligible
+- non-claims such as `sourceOfTruth: false` for summaries, ranks, and context packages
+- disclosure-safe placeholders for local paths or sensitive roots when applicable
+
+### Canonical evidence rules
+
+- Canonical evidence is always anchored to source evidence provenance.
+- Derived facts without current evidence references cannot be promoted to `VERIFIED`.
+- Retrieval hits, ranked result lists, and context packages are derived views and must remain
+  explicitly non-canonical.
+- Community and Commercial modules must use the same provenance vocabulary and schema families.
+- Proprietary modules may add private artifacts, but they must not redefine Community provenance
+  meanings.
+
+## Consequences
+
+- Later implementation packages can separate auditability from privacy and export concerns.
+- Security and testing work can target provenance spoofing, stale serving, and export leakage as
+  distinct failure modes.
+- Community contract tests can enforce that derived retrieval or context layers never masquerade as
+  source evidence.
+
+## Alternatives considered
+
+- **Single generic provenance object everywhere.** Rejected because audit, derivation, and export
+  disclosure have different threat models.
+- **Commercial-only provenance extensions for advanced workflows.** Rejected because core project
+  knowledge must remain portable and verifiable without proprietary readers.
+- **Treat retrieval results as evidence.** Rejected because ranks and snippets are derived aids, not
+  authoritative facts.

--- a/docs/architecture/adr-012-snapshots-and-migrations.md
+++ b/docs/architecture/adr-012-snapshots-and-migrations.md
@@ -1,0 +1,79 @@
+---
+Title: ADR-012 Snapshots and Migrations
+Description: Immutable publication, current-pointer semantics, and Community-owned migration rules for Zeus Project Intelligence.
+Last Updated: 2026-07-22
+---
+
+# ADR-012: Snapshots and Migrations
+
+**Status:** Accepted for ZPI-01 documentation baseline
+
+## Context
+
+Zeus already uses manifests, reproducible artifacts, and versioned contracts. ZPI adds longer-lived
+project state that must survive rebuilds, reopen safely, and reject torn or stale generations.
+
+The term `snapshot` is already overloaded across Zeus. ZPI needs a tighter glossary and publication
+model before persistence code lands.
+
+## Decision
+
+### Snapshot glossary
+
+ZPI uses these terms:
+
+- **Project**: stable identity for one bounded trusted-root knowledge space
+- **Source inventory**: the canonical list of source units and hashes for one input view
+- **Analyzer run**: one deterministic derivation pass over a source inventory
+- **Published snapshot**: one immutable published knowledge generation with stable identifiers and
+  bound backend schema versions
+- **Current pointer**: a single pointer naming the published snapshot that unpinned reads may serve
+
+### Publication rules
+
+- Published snapshots are immutable.
+- Unpinned read operations may serve only the current published snapshot.
+- Publish is atomic across SQLite metadata, content-addressed evidence, Lucene index generation, and
+  current-pointer update.
+- Readers must never observe a mixed-generation current state.
+- Failed publish leaves the previous current snapshot intact or yields a fail-closed unavailable
+  state. It must not advance the current pointer partially.
+
+### Migration rules
+
+Community owns migration rules for Community-owned project-intelligence formats and stores.
+Commercial modules may add private artifacts or additive metadata, but they must not make Community
+stores unreadable without proprietary code.
+
+Migration requirements:
+
+- store schema version, search schema version, and artifact schema versions are explicit and
+  independently versioned
+- unknown future required schema versions fail closed
+- migrations are auditable and deterministic
+- migration state must not be mistaken for a published current snapshot
+- rollback behavior must be explicit: either revert to the last good published snapshot or refuse
+  current reads
+
+### Stale and invalidated data
+
+If source deletion, rename, corruption, or migration mismatch means a published snapshot can no
+longer be treated as current, ZPI must surface that state explicitly through closed reason codes and
+lineage classes such as `STALE` or `INVALIDATED`.
+
+## Consequences
+
+- ZPI can support deterministic reopen, rebuild, and validation behavior without hiding torn state.
+- Later implementation packages have a clear separation between canonical published state and
+  transient build state.
+- Commercial incremental refresh work must converge on the same published-snapshot model rather than
+  inventing a parallel state machine.
+
+## Alternatives considered
+
+- **Mutable current snapshot updated in place.** Rejected because it increases corruption and stale
+  serving risk.
+- **Commercial-only migration path.** Rejected because Community-owned stores and readers must remain
+  self-sufficient.
+- **Best-effort reads from mixed generations.** Rejected because stale or partial data must fail
+  closed.

--- a/docs/architecture/adr-013-retrieval-and-context-policy.md
+++ b/docs/architecture/adr-013-retrieval-and-context-policy.md
@@ -1,0 +1,77 @@
+---
+Title: ADR-013 Retrieval and Context Policy
+Description: Deterministic Community retrieval and context-package policy with optional Commercial extensions.
+Last Updated: 2026-07-22
+---
+
+# ADR-013: Retrieval and Context Policy
+
+**Status:** Accepted for ZPI-01 documentation baseline
+
+## Context
+
+Zeus already prepares evidence and AI-consumable artifacts, but ZPI introduces persistent retrieval
+and context assembly over project knowledge.
+
+Without a default policy, Commercial modules could become the only useful context path. Without a
+clear boundary, retrieval or context packages could also drift into unsafe snippet export, hidden
+policy changes, or Package 09-style scope creep.
+
+## Decision
+
+### Community default policy
+
+Community owns a complete default retrieval and context-assembly policy that is:
+
+- local-only and offline by default
+- bounded by explicit result and token limits
+- deterministic for a pinned snapshot, query, and engine version
+- evidence-first, with explicit omission reporting
+- compatible with thin CLI, API, and MCP-neutral capability contracts
+
+The Community default policy must be able to:
+
+- retrieve bounded lexical results from published Community snapshots
+- apply documented metadata and snapshot-safety filters
+- assemble bounded context packages with explicit evidence references
+- emit non-claims for summaries, rankings, and omitted material
+
+### Commercial extensions
+
+Commercial modules may register advanced retrieval or context policies only through public
+Community contracts. They may improve ranking, graph expansion, incremental orchestration, or
+resource governance, but they must not:
+
+- redefine Community provenance classes
+- weaken safety levels or trust-zone declarations
+- change thin adapter discovery semantics without a contract revision
+- make Community-owned artifacts unreadable without proprietary code
+- reopen Package 09 or add live IBM i execution behavior
+
+### Context-package rules
+
+Every context package must:
+
+- identify the project and published snapshot it was built from
+- record the retrieval policy or assembler identity and version
+- include evidence references for any source-derived claim intended for change or impact work
+- include omission reasons when limits exclude material
+- declare itself non-canonical and non-authoritative relative to preserved source evidence
+
+A token budget constrains size, not sensitivity. Export or egress controls remain separate safety
+concerns and must fail closed when the destination policy does not permit disclosure.
+
+## Consequences
+
+- Community remains able to build useful local context packages without paid policy modules.
+- Commercial modules gain a clear extension surface that does not fork CLI/MCP adapter behavior.
+- Later implementation packages can test deterministic retrieval and omission behavior against one
+  documented baseline.
+
+## Alternatives considered
+
+- **Commercial-only context assembly.** Rejected because Community would cease to be a complete
+  local evidence platform.
+- **Treat context packages as canonical evidence.** Rejected because assembly output is a derived aid.
+- **Use retrieval or context policy to reopen Package 09 behaviors.** Rejected because ZPI-01 is
+  documentation-only and Package 09 remains closed.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Zeus RPG PromptKit Architecture Documentation
-Description: Accepted architecture decisions, kernel definition, dependency rules, contracts, capability model, safety trust zones, and open-core module boundaries for the Zeus evidence-preparation toolkit.
-Last Updated: 2026-07-16
+Description: Accepted architecture decisions, kernel definition, dependency rules, contracts, capability model, safety trust zones, open-core module boundaries, and ZPI baseline contracts.
+Last Updated: 2026-07-22
 ---
 
 # Architecture Documentation
@@ -12,20 +12,25 @@ All subsequent implementation and agent guidance must be consistent with these d
 
 ## Accepted Architecture Decision Records (ADRs)
 
-| ADR                                                 | Title                             | Status                 |
-| --------------------------------------------------- | --------------------------------- | ---------------------- |
-| [001](adr-001-product-kernel.md)                    | Product Kernel                    | Accepted               |
-| [002](adr-002-dependency-direction.md)              | Dependency Direction              | Accepted               |
-| [003](adr-003-versioned-contracts.md)               | Versioned Contracts               | Accepted               |
-| [004](adr-004-capability-registry.md)               | Capability Registry               | Accepted               |
-| [005](adr-005-safety-trust-zones.md)                | Safety Trust Zones                | Accepted               |
+| ADR | Title | Status |
+| --- | ----- | ------ |
+| [001](adr-001-product-kernel.md) | Product Kernel | Accepted |
+| [002](adr-002-dependency-direction.md) | Dependency Direction | Accepted |
+| [003](adr-003-versioned-contracts.md) | Versioned Contracts | Accepted |
+| [004](adr-004-capability-registry.md) | Capability Registry | Accepted |
+| [005](adr-005-safety-trust-zones.md) | Safety Trust Zones | Accepted |
 | [006](adr-006-commercial-extension-architecture.md) | Commercial Extension Architecture | Accepted specification |
-| [007](adr-007-provider-neutral-contracts.md)        | Provider-Neutral AI Contracts     | Accepted               |
-| [008](adr-008-generation-validation-foundation.md)  | Generation Validation Foundation  | Accepted               |
+| [007](adr-007-provider-neutral-contracts.md) | Provider-Neutral AI Contracts | Accepted |
+| [008](adr-008-generation-validation-foundation.md) | Generation Validation Foundation | Accepted |
+| [009](adr-009-project-intelligence-ownership.md) | Project Intelligence Ownership Split | Accepted for ZPI-01 |
+| [010](adr-010-default-store-and-search.md) | Default Store and Search Architecture | Accepted for ZPI-01 |
+| [011](adr-011-evidence-and-provenance.md) | Evidence and Provenance Model | Accepted for ZPI-01 |
+| [012](adr-012-snapshots-and-migrations.md) | Snapshots and Migrations | Accepted for ZPI-01 |
+| [013](adr-013-retrieval-and-context-policy.md) | Retrieval and Context Policy | Accepted for ZPI-01 |
 
 ## Related Reviews
 
-- [Runtime Config Model Review](runtime-config-model-review.md) — details the layered profile and runtime configuration system (pre-dates formal ADRs).
+- [Runtime Config Model Review](runtime-config-model-review.md) - details the layered profile and runtime configuration system (pre-dates formal ADRs).
 
 ## How to Use These Documents
 
@@ -40,6 +45,8 @@ All subsequent implementation and agent guidance must be consistent with these d
   private-by-default transport policy, redaction, and evidence-separation rules in ADR-007.
 - Structured generation candidates must follow the offline validation, path/scope safety,
   evidence-reference, and non-mutation rules in ADR-008. `review-ready` is never compile readiness.
+- ZPI work must follow the ownership, default-backend, provenance, snapshot, and retrieval-policy
+  rules captured in ADR-009 through ADR-013.
 - External modules must use the trusted in-process registrar and module descriptor contracts
   (ADR-006 executable subset; see `docs/modules/authoring-external-module-registration.md`).
   The core never enforces commercial licenses.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -12,21 +12,21 @@ All subsequent implementation and agent guidance must be consistent with these d
 
 ## Accepted Architecture Decision Records (ADRs)
 
-| ADR | Title | Status |
-| --- | ----- | ------ |
-| [001](adr-001-product-kernel.md) | Product Kernel | Accepted |
-| [002](adr-002-dependency-direction.md) | Dependency Direction | Accepted |
-| [003](adr-003-versioned-contracts.md) | Versioned Contracts | Accepted |
-| [004](adr-004-capability-registry.md) | Capability Registry | Accepted |
-| [005](adr-005-safety-trust-zones.md) | Safety Trust Zones | Accepted |
-| [006](adr-006-commercial-extension-architecture.md) | Commercial Extension Architecture | Accepted specification |
-| [007](adr-007-provider-neutral-contracts.md) | Provider-Neutral AI Contracts | Accepted |
-| [008](adr-008-generation-validation-foundation.md) | Generation Validation Foundation | Accepted |
-| [009](adr-009-project-intelligence-ownership.md) | Project Intelligence Ownership Split | Accepted for ZPI-01 |
-| [010](adr-010-default-store-and-search.md) | Default Store and Search Architecture | Accepted for ZPI-01 |
-| [011](adr-011-evidence-and-provenance.md) | Evidence and Provenance Model | Accepted for ZPI-01 |
-| [012](adr-012-snapshots-and-migrations.md) | Snapshots and Migrations | Accepted for ZPI-01 |
-| [013](adr-013-retrieval-and-context-policy.md) | Retrieval and Context Policy | Accepted for ZPI-01 |
+| ADR                                                 | Title                                 | Status                 |
+| --------------------------------------------------- | ------------------------------------- | ---------------------- |
+| [001](adr-001-product-kernel.md)                    | Product Kernel                        | Accepted               |
+| [002](adr-002-dependency-direction.md)              | Dependency Direction                  | Accepted               |
+| [003](adr-003-versioned-contracts.md)               | Versioned Contracts                   | Accepted               |
+| [004](adr-004-capability-registry.md)               | Capability Registry                   | Accepted               |
+| [005](adr-005-safety-trust-zones.md)                | Safety Trust Zones                    | Accepted               |
+| [006](adr-006-commercial-extension-architecture.md) | Commercial Extension Architecture     | Accepted specification |
+| [007](adr-007-provider-neutral-contracts.md)        | Provider-Neutral AI Contracts         | Accepted               |
+| [008](adr-008-generation-validation-foundation.md)  | Generation Validation Foundation      | Accepted               |
+| [009](adr-009-project-intelligence-ownership.md)    | Project Intelligence Ownership Split  | Accepted for ZPI-01    |
+| [010](adr-010-default-store-and-search.md)          | Default Store and Search Architecture | Accepted for ZPI-01    |
+| [011](adr-011-evidence-and-provenance.md)           | Evidence and Provenance Model         | Accepted for ZPI-01    |
+| [012](adr-012-snapshots-and-migrations.md)          | Snapshots and Migrations              | Accepted for ZPI-01    |
+| [013](adr-013-retrieval-and-context-policy.md)      | Retrieval and Context Policy          | Accepted for ZPI-01    |
 
 ## Related Reviews
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,94 +1,68 @@
 ---
-Title: Zeus RPG PromptKit Documentation Hub (v2.1)
-Description: Zentrale, KI-freundliche Navigation über alle Dokumentationsdomänen inklusive Safety-First-Einstieg, Open-Core-Grenzen und schnellen Referenzpfaden.
-Last Updated: 2026-07-16
+Title: Zeus RPG PromptKit Documentation Hub (v2.2)
+Description: Central, AI-friendly navigation across documentation domains including safety-first onboarding, open-core boundaries, and the ZPI architecture baseline.
+Last Updated: 2026-07-22
 ---
 
-# Zeus RPG PromptKit Documentation Hub (v2.1)
+# Zeus RPG PromptKit Documentation Hub (v2.2)
 
-Diese Seite ist der zentrale Einstiegspunkt für Menschen und KI-Assistenten.
+This page is the central entry point for humans and AI assistants.
 
 ## The Product Golden Path (Canonical Journey)
 
 The primary user journey is documented in [`quickstart/5-minutes.md`](quickstart/5-minutes.md):
-Question → Analyze → Investigate (search/trace/xref) → Impact/Risk → Generate (tests/checklist/QA) → Bundle (safe & reproducible) → Verify → (optional MCP) → Human review.
+Question -> Analyze -> Investigate (search/trace/xref) -> Impact/Risk -> Generate (tests/checklist/QA) -> Bundle (safe and reproducible) -> Verify -> (optional MCP) -> Human review.
 
-See the lifecycle diagram and "What Zeus is / is not" there.
-
-**What Zeus is:** Evidence & investigation platform. Produces reproducible, reviewable artifacts. Humans decide. Local control.
+**What Zeus is:** Evidence and investigation platform. Produces reproducible, reviewable artifacts. Humans decide. Local control.
 
 **What Zeus is not:** Autonomous generator, correctness guarantee, production mutator, hosted service.
 
 ## Start Sequence (CLI/MCP-First)
 
-1. Lade die Umgebung explizit in der Shell (`config/load-env.sh` oder `config/load-env.ps1`).
-2. Fuehre `doctor` aus, bevor du weitere Aktionen planst.
-3. Nutze [`tool-catalog.md`](tool-catalog.md) als verbindliche Command-, Safety- und Scope-Referenz.
-4. Starte AI-Sessions mit [`ai/session-prompt.md`](ai/session-prompt.md).
-5. Arbeite evidence-first ueber CLI oder MCP und nutze erzeugte Artefakte als Belege.
+1. Load the environment explicitly in the shell (`config/load-env.sh` or `config/load-env.ps1`).
+2. Run `doctor` before planning further actions.
+3. Use [`tool-catalog.md`](tool-catalog.md) as the authoritative command, safety, and scope reference.
+4. Start AI sessions with [`ai/session-prompt.md`](ai/session-prompt.md).
+5. Work evidence-first through CLI or MCP and use generated artifacts as proof.
 
 ## Documentation Domains
 
-| Domain          | Purpose                                                                                                 | Primary Entry                                                                                                                                                                                                                            | Typical Audience                          |
-| --------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `ai/`           | KI-Verträge, Session-Patterns, Validierung                                                              | [`ai/session-prompt.md`](ai/session-prompt.md)                                                                                                                                                                                           | AI Agents, Prompt Engineers               |
-| `cli/`          | Referenz und praxisnahe Kommando-Beispiele                                                              | [`cli/reference.md`](cli/reference.md)                                                                                                                                                                                                   | Entwickler:innen, Operatoren              |
-| `quickstart/`   | **Canonical Evidence Investigation Golden Path** + credential how-to + onboarding                       | [`quickstart/5-minutes.md`](quickstart/5-minutes.md) (the product golden path), [`quickstart/secrets-and-overrides.md`](quickstart/secrets-and-overrides.md), [`quickstart/onboarding-new-ibm-i.md`](quickstart/onboarding-new-ibm-i.md) | Alle Rollen – start here                  |
-| `architecture/` | Architecture baseline, ADRs, runtime config, dependency rules, capability model, and safety trust zones | [`architecture/index.md`](architecture/index.md)                                                                                                                                                                                         | Maintainer, Tooling Engineers, Architects |
-| `mcp/`          | Lokaler MCP-Betrieb, Policy-Grenzen und Troubleshooting                                                 | [`mcp/operator-guide.md`](mcp/operator-guide.md)                                                                                                                                                                                         | Operatoren, AI-Integratoren               |
-| `maintainers/`  | Release-integrity policy and historical exception record                                                | [`maintainers/release-integrity.md`](maintainers/release-integrity.md)                                                                                                                                                                   | Maintainers, Release Reviewers            |
-| `workflows/`    | Geführte Analyse- und Agenten-Workflows                                                                 | [`workflows/investigation-workflows.md`](workflows/investigation-workflows.md)                                                                                                                                                           | Analysten, Architekten                    |
-| `safety/`       | Safety-Guidance, Governance, Sharing                                                                    | [`safety/best-practice-guide.md`](safety/best-practice-guide.md)                                                                                                                                                                         | Reviewer, Security, Leads                 |
-| `viewer/`       | Optionaler lokaler Artefakt-Viewer und experimentelle UI-Shell                                          | [`viewer/local-ui-shell.md`](viewer/local-ui-shell.md)                                                                                                                                                                                   | Tooling Engineers                         |
-| `sql/`          | Reproduzierbare SQL-Discovery-Skripte fuer IBM i/DB2                                                    | [`sql/index.md`](sql/index.md)                                                                                                                                                                                                           | Analysts, DB2 Engineers                   |
+| Domain | Purpose | Primary Entry | Typical Audience |
+| ------ | ------- | ------------- | ---------------- |
+| `ai/` | AI contracts, session patterns, validation | [`ai/session-prompt.md`](ai/session-prompt.md) | AI agents, prompt engineers |
+| `cli/` | Reference and practical command examples | [`cli/reference.md`](cli/reference.md) | Developers, operators |
+| `quickstart/` | Canonical evidence-investigation golden path plus credential and onboarding guides | [`quickstart/5-minutes.md`](quickstart/5-minutes.md), [`quickstart/secrets-and-overrides.md`](quickstart/secrets-and-overrides.md), [`quickstart/onboarding-new-ibm-i.md`](quickstart/onboarding-new-ibm-i.md) | All roles |
+| `architecture/` | Architecture baseline, ADRs, runtime config, dependency rules, capability model, safety trust zones, and ZPI contracts | [`architecture/index.md`](architecture/index.md) | Maintainers, tooling engineers, architects |
+| `knowledgebase/` | Project-neutral knowledge reset, ZPI threat model, license inventory, and test strategy | [`knowledgebase/README.md`](knowledgebase/README.md) | Architects, security, maintainers |
+| `mcp/` | Local MCP operation, policy boundaries, troubleshooting | [`mcp/operator-guide.md`](mcp/operator-guide.md) | Operators, AI integrators |
+| `maintainers/` | Release-integrity policy and historical exception record | [`maintainers/release-integrity.md`](maintainers/release-integrity.md) | Maintainers, release reviewers |
+| `safety/` | Safety guidance, governance, sharing | [`safety/best-practice-guide.md`](safety/best-practice-guide.md) | Reviewers, security, leads |
+| `viewer/` | Optional local artifact viewer and experimental UI shell | [`viewer/local-ui-shell.md`](viewer/local-ui-shell.md) | Tooling engineers |
+| `sql/` | Reproducible IBM i and DB2 discovery SQL | [`sql/index.md`](sql/index.md) | Analysts, DB2 engineers |
 
 ## Quick Links For AI Assistants
 
-| Need                              | Go To                                                                                                                    | Why                                                                                      |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| Authoritative command behavior    | [`tool-catalog.md`](tool-catalog.md)                                                                                     | Single source of truth für Commands, Safety und Beispiele                                |
-| Session bootstrap                 | [`ai/session-prompt.md`](ai/session-prompt.md)                                                                           | Standardisierte Arbeitsweise mit Safety-Gates                                            |
-| MCP operator setup                | [`mcp/operator-guide.md`](mcp/operator-guide.md)                                                                         | Start-/Policy-/Audit-Referenz fuer lokalen MCP-Betrieb                                   |
-| Prompt schema and constraints     | [`ai/prompt-contracts.md`](ai/prompt-contracts.md)                                                                       | Verhindert inkonsistente Prompt-Ausgaben                                                 |
-| Workflow options                  | [`workflows/investigation-workflows.md`](workflows/investigation-workflows.md)                                           | Zeigt Opt-in Vertiefungsfeatures                                                         |
-| Architecture decisions & baseline | [`architecture/index.md`](architecture/index.md)                                                                         | ADRs for kernel, dependencies, contracts, registry, and safety zones                     |
-| Open-core module boundary         | [`architecture/adr-006-commercial-extension-architecture.md`](architecture/adr-006-commercial-extension-architecture.md) | Public/private ownership, explicit registration, compatibility, and artifact portability |
-| Optional provider contracts       | [`architecture/adr-007-provider-neutral-contracts.md`](architecture/adr-007-provider-neutral-contracts.md)               | Private-by-default provider API, egress policy, redaction, and offline test doubles      |
-| Safe sharing guidance             | [`safety/safe-sharing.md`](safety/safe-sharing.md)                                                                       | Reduktions-/Sanitization-Regeln für externe Nutzung                                      |
-| CLI examples                      | [`cli/examples.md`](cli/examples.md)                                                                                     | Schnell nutzbare, reproduzierbare Befehlsmuster                                          |
-| DB2 discovery SQL                 | [`sql/system-environment-discovery.sql`](sql/system-environment-discovery.sql)                                           | Standardisierte Discovery-Queries fuer System- und Ticketkontext                         |
-
-## Visual Map
-
-```mermaid
-flowchart TD
-    A[docs/index.md\nDocumentation Hub] --> B[docs/tool-catalog.md\nAuthoritative Command Reference]
-    A --> C[docs/ai/session-prompt.md\nAI Session Bootstrap]
-    A --> D[docs/quickstart/5-minutes.md\nFast Start]
-
-    A --> E[docs/ai]
-    A --> F[docs/cli]
-    A --> G[docs/quickstart]
-    A --> G2[docs/architecture]
-    A --> H[docs/mcp]
-    A --> I[docs/workflows]
-    A --> J[docs/safety]
-    A --> K[docs/viewer]
-    A --> L[docs/internal]
-    A --> M[docs/sql]
-
-    H --> B
-    C --> B
-    F --> B
-    I --> B
-```
+| Need | Go To | Why |
+| ---- | ----- | --- |
+| Authoritative command behavior | [`tool-catalog.md`](tool-catalog.md) | Single source of truth for commands, safety, and examples |
+| Session bootstrap | [`ai/session-prompt.md`](ai/session-prompt.md) | Standardized workflow with safety gates |
+| MCP operator setup | [`mcp/operator-guide.md`](mcp/operator-guide.md) | Start, policy, and audit reference for local MCP operation |
+| Prompt schema and constraints | [`ai/prompt-contracts.md`](ai/prompt-contracts.md) | Prevents inconsistent prompt outputs |
+| Architecture decisions and baseline | [`architecture/index.md`](architecture/index.md) | ADRs for kernel, dependencies, contracts, registry, and ZPI |
+| Open-core module boundary | [`architecture/adr-006-commercial-extension-architecture.md`](architecture/adr-006-commercial-extension-architecture.md) | Public and private ownership, registration, and portability |
+| ZPI security and rollout gates | [`knowledgebase/zpi-threat-model.md`](knowledgebase/zpi-threat-model.md), [`knowledgebase/zpi-test-strategy.md`](knowledgebase/zpi-test-strategy.md) | Freeze the pre-implementation threat and acceptance baseline |
+| Safe sharing guidance | [`safety/safe-sharing.md`](safety/safe-sharing.md) | Reduction and sanitization rules for external use |
+| CLI examples | [`cli/examples.md`](cli/examples.md) | Fast reproducible command patterns |
+| DB2 discovery SQL | [`sql/system-environment-discovery.sql`](sql/system-environment-discovery.sql) | Standardized discovery queries for system and ticket context |
 
 ## Governance Notes
 
-- `docs/tool-catalog.md` bleibt die verbindliche Referenz für KI-Assistenten.
-- `docs/architecture/index.md` (und die ADRs darin) sind die autoritative Quelle für Produkt-Kernel, Abhängigkeitsrichtung, versionierte Verträge, Capability-Registry, Safety-Trust-Zones und Open-Core-Modulgrenzen.
-- CLI und MCP bleiben der unterstützte Produktpfad; der lokale Viewer ist optional und experimentell.
-- Dokumentänderungen sollen Safety-Level und Scope-Terminologie konsistent halten (`S0` bis `S4`).
-- Regenerierung funktioniert direkt ueber `zeus docs:generate-catalog` oder `zeus docs generate-catalog` und haelt den Tool-Katalog aktuell.
-- Optional maschinenlesbar: `zeus docs:generate-catalog --json-output docs/tool-catalog.json`.
-- Tool catalog is auto-generated from code (see `zeus docs:generate-catalog`).
+- `docs/tool-catalog.md` remains the authoritative command reference for AI assistants.
+- `docs/architecture/index.md` and its ADRs are the authoritative source for product kernel,
+  dependency direction, versioned contracts, capability registry, safety trust zones, open-core
+  module boundaries, and the ZPI architecture baseline.
+- `docs/knowledgebase/README.md` and the ZPI documents beneath it define the documentation-only
+  security, licensing, and test baseline for project-intelligence implementation packages.
+- CLI and MCP remain the supported product path; the local viewer is optional and experimental.
+- Documentation changes should keep safety levels and scope terminology consistent (`S0` to `S4`).
+- The tool catalog is generated from code via `zeus docs:generate-catalog`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,33 +27,33 @@ Question -> Analyze -> Investigate (search/trace/xref) -> Impact/Risk -> Generat
 
 ## Documentation Domains
 
-| Domain | Purpose | Primary Entry | Typical Audience |
-| ------ | ------- | ------------- | ---------------- |
-| `ai/` | AI contracts, session patterns, validation | [`ai/session-prompt.md`](ai/session-prompt.md) | AI agents, prompt engineers |
-| `cli/` | Reference and practical command examples | [`cli/reference.md`](cli/reference.md) | Developers, operators |
-| `quickstart/` | Canonical evidence-investigation golden path plus credential and onboarding guides | [`quickstart/5-minutes.md`](quickstart/5-minutes.md), [`quickstart/secrets-and-overrides.md`](quickstart/secrets-and-overrides.md), [`quickstart/onboarding-new-ibm-i.md`](quickstart/onboarding-new-ibm-i.md) | All roles |
-| `architecture/` | Architecture baseline, ADRs, runtime config, dependency rules, capability model, safety trust zones, and ZPI contracts | [`architecture/index.md`](architecture/index.md) | Maintainers, tooling engineers, architects |
-| `knowledgebase/` | Project-neutral knowledge reset, ZPI threat model, license inventory, and test strategy | [`knowledgebase/README.md`](knowledgebase/README.md) | Architects, security, maintainers |
-| `mcp/` | Local MCP operation, policy boundaries, troubleshooting | [`mcp/operator-guide.md`](mcp/operator-guide.md) | Operators, AI integrators |
-| `maintainers/` | Release-integrity policy and historical exception record | [`maintainers/release-integrity.md`](maintainers/release-integrity.md) | Maintainers, release reviewers |
-| `safety/` | Safety guidance, governance, sharing | [`safety/best-practice-guide.md`](safety/best-practice-guide.md) | Reviewers, security, leads |
-| `viewer/` | Optional local artifact viewer and experimental UI shell | [`viewer/local-ui-shell.md`](viewer/local-ui-shell.md) | Tooling engineers |
-| `sql/` | Reproducible IBM i and DB2 discovery SQL | [`sql/index.md`](sql/index.md) | Analysts, DB2 engineers |
+| Domain           | Purpose                                                                                                                | Primary Entry                                                                                                                                                                                                  | Typical Audience                           |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `ai/`            | AI contracts, session patterns, validation                                                                             | [`ai/session-prompt.md`](ai/session-prompt.md)                                                                                                                                                                 | AI agents, prompt engineers                |
+| `cli/`           | Reference and practical command examples                                                                               | [`cli/reference.md`](cli/reference.md)                                                                                                                                                                         | Developers, operators                      |
+| `quickstart/`    | Canonical evidence-investigation golden path plus credential and onboarding guides                                     | [`quickstart/5-minutes.md`](quickstart/5-minutes.md), [`quickstart/secrets-and-overrides.md`](quickstart/secrets-and-overrides.md), [`quickstart/onboarding-new-ibm-i.md`](quickstart/onboarding-new-ibm-i.md) | All roles                                  |
+| `architecture/`  | Architecture baseline, ADRs, runtime config, dependency rules, capability model, safety trust zones, and ZPI contracts | [`architecture/index.md`](architecture/index.md)                                                                                                                                                               | Maintainers, tooling engineers, architects |
+| `knowledgebase/` | Project-neutral knowledge reset, ZPI threat model, license inventory, and test strategy                                | [`knowledgebase/README.md`](knowledgebase/README.md)                                                                                                                                                           | Architects, security, maintainers          |
+| `mcp/`           | Local MCP operation, policy boundaries, troubleshooting                                                                | [`mcp/operator-guide.md`](mcp/operator-guide.md)                                                                                                                                                               | Operators, AI integrators                  |
+| `maintainers/`   | Release-integrity policy and historical exception record                                                               | [`maintainers/release-integrity.md`](maintainers/release-integrity.md)                                                                                                                                         | Maintainers, release reviewers             |
+| `safety/`        | Safety guidance, governance, sharing                                                                                   | [`safety/best-practice-guide.md`](safety/best-practice-guide.md)                                                                                                                                               | Reviewers, security, leads                 |
+| `viewer/`        | Optional local artifact viewer and experimental UI shell                                                               | [`viewer/local-ui-shell.md`](viewer/local-ui-shell.md)                                                                                                                                                         | Tooling engineers                          |
+| `sql/`           | Reproducible IBM i and DB2 discovery SQL                                                                               | [`sql/index.md`](sql/index.md)                                                                                                                                                                                 | Analysts, DB2 engineers                    |
 
 ## Quick Links For AI Assistants
 
-| Need | Go To | Why |
-| ---- | ----- | --- |
-| Authoritative command behavior | [`tool-catalog.md`](tool-catalog.md) | Single source of truth for commands, safety, and examples |
-| Session bootstrap | [`ai/session-prompt.md`](ai/session-prompt.md) | Standardized workflow with safety gates |
-| MCP operator setup | [`mcp/operator-guide.md`](mcp/operator-guide.md) | Start, policy, and audit reference for local MCP operation |
-| Prompt schema and constraints | [`ai/prompt-contracts.md`](ai/prompt-contracts.md) | Prevents inconsistent prompt outputs |
-| Architecture decisions and baseline | [`architecture/index.md`](architecture/index.md) | ADRs for kernel, dependencies, contracts, registry, and ZPI |
-| Open-core module boundary | [`architecture/adr-006-commercial-extension-architecture.md`](architecture/adr-006-commercial-extension-architecture.md) | Public and private ownership, registration, and portability |
-| ZPI security and rollout gates | [`knowledgebase/zpi-threat-model.md`](knowledgebase/zpi-threat-model.md), [`knowledgebase/zpi-test-strategy.md`](knowledgebase/zpi-test-strategy.md) | Freeze the pre-implementation threat and acceptance baseline |
-| Safe sharing guidance | [`safety/safe-sharing.md`](safety/safe-sharing.md) | Reduction and sanitization rules for external use |
-| CLI examples | [`cli/examples.md`](cli/examples.md) | Fast reproducible command patterns |
-| DB2 discovery SQL | [`sql/system-environment-discovery.sql`](sql/system-environment-discovery.sql) | Standardized discovery queries for system and ticket context |
+| Need                                | Go To                                                                                                                                                | Why                                                          |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Authoritative command behavior      | [`tool-catalog.md`](tool-catalog.md)                                                                                                                 | Single source of truth for commands, safety, and examples    |
+| Session bootstrap                   | [`ai/session-prompt.md`](ai/session-prompt.md)                                                                                                       | Standardized workflow with safety gates                      |
+| MCP operator setup                  | [`mcp/operator-guide.md`](mcp/operator-guide.md)                                                                                                     | Start, policy, and audit reference for local MCP operation   |
+| Prompt schema and constraints       | [`ai/prompt-contracts.md`](ai/prompt-contracts.md)                                                                                                   | Prevents inconsistent prompt outputs                         |
+| Architecture decisions and baseline | [`architecture/index.md`](architecture/index.md)                                                                                                     | ADRs for kernel, dependencies, contracts, registry, and ZPI  |
+| Open-core module boundary           | [`architecture/adr-006-commercial-extension-architecture.md`](architecture/adr-006-commercial-extension-architecture.md)                             | Public and private ownership, registration, and portability  |
+| ZPI security and rollout gates      | [`knowledgebase/zpi-threat-model.md`](knowledgebase/zpi-threat-model.md), [`knowledgebase/zpi-test-strategy.md`](knowledgebase/zpi-test-strategy.md) | Freeze the pre-implementation threat and acceptance baseline |
+| Safe sharing guidance               | [`safety/safe-sharing.md`](safety/safe-sharing.md)                                                                                                   | Reduction and sanitization rules for external use            |
+| CLI examples                        | [`cli/examples.md`](cli/examples.md)                                                                                                                 | Fast reproducible command patterns                           |
+| DB2 discovery SQL                   | [`sql/system-environment-discovery.sql`](sql/system-environment-discovery.sql)                                                                       | Standardized discovery queries for system and ticket context |
 
 ## Governance Notes
 

--- a/docs/knowledgebase/README.md
+++ b/docs/knowledgebase/README.md
@@ -1,14 +1,19 @@
 ---
 Title: Knowledgebase Reset
-Description: Reset notice and safety rules for future knowledgebase work.
-Last Updated: 2026-05-24
+Description: Reset notice, ZPI architecture references, and safety rules for future knowledgebase work.
+Last Updated: 2026-07-22
 ---
 
 # Knowledgebase Reset
 
 The previous source-derived persistent knowledge path was removed/reset.
 
-Future knowledgebase work must follow [project-neutral-knowledgebase-architecture.md](./project-neutral-knowledgebase-architecture.md).
+Future knowledgebase work must follow:
+
+- [project-neutral-knowledgebase-architecture.md](./project-neutral-knowledgebase-architecture.md)
+- [zpi-threat-model.md](./zpi-threat-model.md)
+- [zpi-license-inventory.md](./zpi-license-inventory.md)
+- [zpi-test-strategy.md](./zpi-test-strategy.md)
 
 Non-negotiable rules:
 

--- a/docs/knowledgebase/zpi-license-inventory.md
+++ b/docs/knowledgebase/zpi-license-inventory.md
@@ -1,0 +1,66 @@
+---
+Title: ZPI License Inventory and Dependency Governance
+Description: ZPI-01 licensing baseline, planned engine compatibility notes, and unresolved dependency decisions.
+Last Updated: 2026-07-22
+---
+
+# ZPI License Inventory and Dependency Governance
+
+This document records the ZPI-01 licensing baseline. It is not legal advice.
+
+## Repository baseline
+
+| Repository | Current status |
+| ---------- | -------------- |
+| Community `zeus-rpg-promptkit` | Apache-2.0 |
+| Commercial `zeus-rpg-promptkit-commercial` | `UNLICENSED` proprietary placeholder |
+
+Commercial depends on the public Community repository pinned to commit
+`3a6586dca648e41dbd74ef48e0848e9830cfc113`.
+
+## Planned default engines
+
+| Planned engine | Expected role | Licensing baseline | ZPI-01 note |
+| -------------- | ------------- | ------------------ | ----------- |
+| SQLite | local metadata store | upstream SQLite is commonly distributed as public domain | exact runtime binding still undecided; binding license must be reviewed separately |
+| Apache Lucene | lexical retrieval index | Apache-2.0 | exact runtime binding still undecided; transitive dependencies must be reviewed separately |
+
+## Governance rules for later implementation packages
+
+- Community defaults must remain redistributable under the Community Apache-2.0 release model.
+- Commercial code may depend on Community public exports, but Community must not depend on
+  proprietary code or entitlements.
+- Exact dependency selection for SQLite and Lucene bindings is a governance event and must document:
+  runtime vs dev/test role, native vs pure-JS footprint, transitive licenses, SBOM impact, and
+  offline-install behavior.
+- Avoid SSPL, source-available, field-of-use, or network-restricted licenses for Community default
+  backends.
+- Optional future vector or embedding dependencies require a separate review and must remain optional
+  relative to the Community lexical baseline.
+
+## Attribution and release-process notes
+
+ZPI implementation packages must preserve or establish:
+
+- Community Apache-2.0 `LICENSE` continuity
+- any required third-party attribution or `NOTICE` material for selected bindings
+- SBOM coverage for store and search dependencies in Community releases and combined commercial
+  distributions
+- explicit review of native binary or toolchain implications if a chosen binding is not pure-JS
+
+## Resolved baseline statements
+
+- The ownership split is license-compatible if Community owns the default engines and Commercial
+  remains separately distributed.
+- Commercial policy modules do not relicense the Community pin.
+- Raw user project data portability is separate from dependency attribution obligations.
+
+## Unresolved decisions
+
+- exact SQLite runtime package or binding
+- exact Lucene runtime package, bridge, or hosting strategy
+- whether any selected binding adds native compilation or bundled binaries
+- what Community `NOTICE` or third-party attribution process will be used once concrete packages are
+  chosen
+- whether future optional embedding or vector packages introduce new redistribution or model-license
+  constraints

--- a/docs/knowledgebase/zpi-license-inventory.md
+++ b/docs/knowledgebase/zpi-license-inventory.md
@@ -10,9 +10,9 @@ This document records the ZPI-01 licensing baseline. It is not legal advice.
 
 ## Repository baseline
 
-| Repository | Current status |
-| ---------- | -------------- |
-| Community `zeus-rpg-promptkit` | Apache-2.0 |
+| Repository                                 | Current status                       |
+| ------------------------------------------ | ------------------------------------ |
+| Community `zeus-rpg-promptkit`             | Apache-2.0                           |
 | Commercial `zeus-rpg-promptkit-commercial` | `UNLICENSED` proprietary placeholder |
 
 Commercial depends on the public Community repository pinned to commit
@@ -20,10 +20,10 @@ Commercial depends on the public Community repository pinned to commit
 
 ## Planned default engines
 
-| Planned engine | Expected role | Licensing baseline | ZPI-01 note |
-| -------------- | ------------- | ------------------ | ----------- |
-| SQLite | local metadata store | upstream SQLite is commonly distributed as public domain | exact runtime binding still undecided; binding license must be reviewed separately |
-| Apache Lucene | lexical retrieval index | Apache-2.0 | exact runtime binding still undecided; transitive dependencies must be reviewed separately |
+| Planned engine | Expected role           | Licensing baseline                                       | ZPI-01 note                                                                                |
+| -------------- | ----------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| SQLite         | local metadata store    | upstream SQLite is commonly distributed as public domain | exact runtime binding still undecided; binding license must be reviewed separately         |
+| Apache Lucene  | lexical retrieval index | Apache-2.0                                               | exact runtime binding still undecided; transitive dependencies must be reviewed separately |
 
 ## Governance rules for later implementation packages
 

--- a/docs/knowledgebase/zpi-test-strategy.md
+++ b/docs/knowledgebase/zpi-test-strategy.md
@@ -1,0 +1,90 @@
+---
+Title: ZPI Test Strategy Baseline
+Description: Minimum deterministic acceptance matrix for later Zeus Project Intelligence implementation packages.
+Last Updated: 2026-07-22
+---
+
+# ZPI Test Strategy Baseline
+
+ZPI-01 is documentation-only. Its job is to freeze the acceptance matrix for later implementation
+packages, not to claim runtime coverage.
+
+## Principles
+
+- preserved source evidence is authoritative; retrieval and context layers are derived aids
+- full rebuild and incremental refresh must converge on the same published semantics
+- fail-closed reason codes are part of the contract surface
+- privacy, redaction, and safe-sharing behavior are tested as safety controls, not cosmetic output
+- Package 09 remains closed; no live IBM i dependency enters ZPI runtime packages
+
+## Minimum test matrix
+
+### Unit tests
+
+Required unit coverage before runtime rollout:
+
+- valid and invalid contract fixtures for projects, snapshots, source units, evidence, provenance,
+  diagnostics, and context packages
+- canonical path and content-hash normalization rules
+- closed enums and reason-code validation
+- corruption detectors for content-hash mismatch, malformed metadata, and index integrity checks
+- single-writer lock behavior and stale-lock handling policy
+- deterministic diff planning for add, change, delete, and unchanged inputs
+- deterministic token-budget and omission-manifest calculations
+- redaction helpers for host paths, secret-like values, and forbidden source classes
+
+### Contract tests
+
+Community-owned contract tests must later cover:
+
+- exact schema validation and explicit unknown-version failure
+- snapshot publish semantics and current-pointer behavior
+- migration-open refusal on unknown future required versions
+- retrieval result envelopes, bounds, and ordering rules
+- context-package evidence references, non-claims, and omission reporting
+- absence or denial behavior for optional Commercial capabilities
+- public-claims consistency so docs do not imply Package 09 reopen or live IBM i support
+
+### Integration tests
+
+Use a pinned synthetic corpus only. Required integration themes:
+
+- create, publish, reopen, and query a Community-owned snapshot
+- atomic publish and rollback behavior for interrupted writes
+- path traversal and symlink or junction escape refusal under trusted roots
+- corrupt or partially published search state refusal or documented rebuild path
+- full rebuild versus incremental semantic equivalence
+- deterministic retrieval hit ordering for a pinned snapshot and query
+- bounded context-package assembly with explicit omission reasons
+- Community-only operation when no Commercial module is registered
+
+### Adversarial tests
+
+High-severity adversarial themes that must become release gates:
+
+- project-ID or path escape attempts
+- stale current-pointer or mixed-generation reads
+- forged provenance or `VERIFIED` facts without matching evidence
+- secret or absolute-path leakage through diagnostics, search snippets, MCP, or exports
+- partial index publish presented as complete current data
+- entitlement denial mid-operation with no partial capability success
+- token-budget compliance without unsafe disclosure fallback
+
+## Acceptance criteria for later packages
+
+ZPI implementation packages must not advance without:
+
+- a closed reason-code catalog exercised by tests
+- a published equality definition for full-rebuild and incremental equivalence
+- a documented retrieval tie-break and analyzer identity policy
+- a documented serve-during-write policy
+- reproducibility guidance identifying which metadata is canonical and which is observational only
+
+## External review inputs captured in ZPI-01
+
+This matrix incorporates independent Grok review themes for:
+
+- determinism and ordering risks
+- path, symlink, and oversized-input failure modes
+- entitlement-boundary regression risks
+- redaction and disclosure controls

--- a/docs/knowledgebase/zpi-threat-model.md
+++ b/docs/knowledgebase/zpi-threat-model.md
@@ -37,13 +37,13 @@ Protected assets:
 
 ## Trust boundaries
 
-| Boundary | Notes |
-| -------- | ----- |
-| Trusted local roots | only explicitly authorized source roots may be inventoried |
-| Local project-intelligence store | sensitive local state; not safe-sharing by default |
-| Thin CLI/API/MCP projection | read-mostly projection of approved capability surfaces only |
-| Commercial extension boundary | entitlement-gated, separately distributed, never required for Community-owned readers |
-| External sharing or model egress | deny by default unless a future policy explicitly allows it |
+| Boundary                         | Notes                                                                                 |
+| -------------------------------- | ------------------------------------------------------------------------------------- |
+| Trusted local roots              | only explicitly authorized source roots may be inventoried                            |
+| Local project-intelligence store | sensitive local state; not safe-sharing by default                                    |
+| Thin CLI/API/MCP projection      | read-mostly projection of approved capability surfaces only                           |
+| Commercial extension boundary    | entitlement-gated, separately distributed, never required for Community-owned readers |
+| External sharing or model egress | deny by default unless a future policy explicitly allows it                           |
 
 ## Primary threats
 

--- a/docs/knowledgebase/zpi-threat-model.md
+++ b/docs/knowledgebase/zpi-threat-model.md
@@ -1,0 +1,142 @@
+---
+Title: ZPI Threat Model
+Description: Documentation baseline threat model for Zeus Project Intelligence before runtime implementation.
+Last Updated: 2026-07-22
+---
+
+# ZPI Threat Model
+
+This document records the security baseline for ZPI-01. It is a documentation artifact, not a
+runtime security claim.
+
+## Scope
+
+In scope:
+
+- Community project-intelligence contracts and default backend boundaries
+- Commercial extension boundaries that must not bleed into Community
+- local trusted roots, preserved evidence, published snapshots, retrieval, and context packages
+- thin CLI/API/MCP-neutral capability exposure
+
+Out of scope:
+
+- live IBM i runtime operations
+- Package 09 reopen or new S4 execution paths
+- production entitlement infrastructure details
+
+## Assets
+
+Protected assets:
+
+- trusted local source trees and source-unit identities
+- preserved evidence blobs and source spans
+- published project snapshots and current-pointer state
+- retrieval indexes and query results
+- bounded context packages and omission manifests
+- local diagnostics and audit artifacts
+
+## Trust boundaries
+
+| Boundary | Notes |
+| -------- | ----- |
+| Trusted local roots | only explicitly authorized source roots may be inventoried |
+| Local project-intelligence store | sensitive local state; not safe-sharing by default |
+| Thin CLI/API/MCP projection | read-mostly projection of approved capability surfaces only |
+| Commercial extension boundary | entitlement-gated, separately distributed, never required for Community-owned readers |
+| External sharing or model egress | deny by default unless a future policy explicitly allows it |
+
+## Primary threats
+
+### Path and filesystem escape
+
+Threats:
+
+- path traversal through source units, project IDs, or export paths
+- symlink or junction escape outside trusted roots
+- partial writes into attacker-controlled or world-readable paths
+
+Required mitigations:
+
+- canonical path validation before open or write
+- trusted-root containment checks
+- project ID and run ID character restrictions
+- symlink and junction escape rejection
+- create-or-rollback semantics for staged writes
+
+### Resource exhaustion and oversized input
+
+Threats:
+
+- oversized projects exhausting memory, disk, or CPU
+- dense graphs or retrieval expansions causing unbounded work
+- repeated partial publishes consuming local storage
+
+Required mitigations:
+
+- numeric limits for file counts, bytes, graph expansion, and token budgets
+- explicit reject-or-omit policy with reason codes
+- single-writer publication model
+- no silent partial current snapshot
+
+### Provenance spoofing and stale serving
+
+Threats:
+
+- forged hashes, snapshot IDs, or `VERIFIED` facts
+- current pointer referencing mixed or stale generations
+- retrieval results presented as canonical evidence
+
+Required mitigations:
+
+- explicit source evidence, derivation lineage, and export-disclosure provenance classes
+- published snapshots immutable after publish
+- closed stale or invalidated reason codes
+- retrieval and context packages marked non-canonical
+
+### Leakage and unsafe export
+
+Threats:
+
+- absolute host paths in diagnostics or manifests
+- credential-like files or source snippets leaking through search, MCP, or exports
+- omission manifests leaking sensitive identifiers even when content is excluded
+
+Required mitigations:
+
+- redaction and safe-sharing rules distinct from token budgets
+- deny-by-default export or egress behavior
+- closed reason codes for forbidden source classes and disclosure denial
+- explicit non-claims on derived packages and rankings
+
+### Entitlement bleed and open-core boundary erosion
+
+Threats:
+
+- Community adapters that only function when Commercial is present
+- paid capability discovery leaking as always-available in Community
+- proprietary formats becoming required to read Community-owned project knowledge
+
+Required mitigations:
+
+- Community complete offline baseline
+- entitlement enforcement only in Commercial modules
+- Community-owned readers and migrations remain Community-owned
+- capability discovery reflects actual registered state only
+
+## Mandatory negative-test themes
+
+The later runtime packages must include negative tests for at least:
+
+- path traversal and project-ID escape
+- symlink or junction escape
+- oversized project refusal without partial publish
+- provenance mismatch and stale current-pointer refusal
+- snippet or path leakage through diagnostics, search, MCP, or exports
+- Community-only operation with Commercial capability absence or entitlement denial
+- context-package disclosure denial even when token budget would allow more content
+
+## Owner decisions still required
+
+- exact numeric default limits for storage, graph expansion, and token budgets
+- exact community default destination policy for future external context egress
+- exact closed reason-code vocabulary for all fail-closed states


### PR DESCRIPTION
## Summary
- add ZPI-01 ADRs for ownership, default backends, provenance, snapshots, and retrieval policy
- add ZPI threat model, license inventory, and test-strategy baseline
- update architecture and knowledgebase indexes, plus ignore local `*.code-workspace` files

## Scope
- docs-only ZPI-01 package
- no runtime implementation
- no Package 09 reopen
- no commercial repository change required for this package

## Verification
- `npm run docs:check`
- `npm run check:public-knowledge-claims`
- `npm run repo:control`

## Notes
- Community baseline verified against `3a6586dca648e41dbd74ef48e0848e9830cfc113`
- Commercial baseline verified against `98f9b39044b0474c2a03de0bb5ae49033800043d`
- Commercial dependency pin to Community remained `3a6586dca648e41dbd74ef48e0848e9830cfc113`