### PR TITLE
build: remediate brace-expansion audit baseline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -807,9 +807,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary
- refresh the locked production resolution for `brace-expansion` from `5.0.6` to `5.0.7`
- clear the reproduced high-severity production audit finding `GHSA-3jxr-9vmj-r5cp`
- keep scope limited to `package-lock.json`

## Scope
- separate Community baseline remediation PR
- no ZPI-01 docs changes
- no product/runtime feature work
- no Package 09 or live IBM i changes

## Verification
- `npm audit --omit=dev --audit-level=high`
- `npm run package:smoke`
- `npm run test:release-integrity`
- `npm run repo:control`

## Notes
- dependency path before remediation: `glob@13.0.6 -> minimatch@10.2.5 -> brace-expansion@5.0.6`
- branch head: `1ab750188d16dca4f6b01fea0db164b1918ace4f`