### PR TITLE
feat: ZPI-02 project intelligence contract kit

### DIFF
--- a/docs/knowledgebase/README.md
+++ b/docs/knowledgebase/README.md
@@ -28,6 +28,9 @@ Current implementation status:
 - `src/knowledge/` now contains a skeleton with `raw/`, `sanitized/`, `final/`, and `privacy/` boundaries
 - no runtime extractor or persistence is implemented yet
 - the privacy gate is fail-closed and rejects malformed or suspicious final-catalog candidates
+- **ZPI-02 (contracts only):** `src/projectIntelligence/` provides versioned project-knowledge
+  contracts, closed reason codes, validators, fixtures, and a contract test kit — still no
+  store, search, analyzer runtime, CLI, or MCP adapters
 
 Local risk handling:
 

--- a/docs/knowledgebase/zpi-test-strategy.md
+++ b/docs/knowledgebase/zpi-test-strategy.md
@@ -6,8 +6,8 @@ Last Updated: 2026-07-22
 
 # ZPI Test Strategy Baseline
 
-ZPI-01 is documentation-only. Its job is to freeze the acceptance matrix for later implementation
-packages, not to claim runtime coverage.
+ZPI-01 froze the acceptance matrix. ZPI-02 implements Community contract validators and the closed
+reason-code catalog only — still no store, search, or analyzer runtime coverage claims.
 
 ## Principles
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     ".": "./cli/zeus.js",
     "./api": "./src/api/zeusApi.js",
     "./module-contract-test": "./src/modules/contractTestKit.js",
+    "./project-intelligence-contracts": "./src/projectIntelligence/index.js",
     "./package.json": "./package.json"
   },
   "bin": {

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,18 +1,41 @@
 # Zeus Domain Schemas
 
-This directory is the home for versioned domain contract schemas.
+This directory is the home for versioned domain contract documentation.
 
-**Status (package 02):** Initial metadata-only shells have been registered in code
-(`src/core/contracts/schemas.js`). Full structural definitions and producers/consumers
-will be migrated in subsequent packages.
+**Status:**
+
+- Package 02 baseline contracts live in code (`src/core/contracts/schemas.js`).
+- Generation Validation contracts: `src/generationValidation/contracts.js`.
+- Module descriptor contracts: `src/modules/`.
+- **Project Intelligence contracts (ZPI-02):** `src/projectIntelligence/`.
+
+Full structural definitions and producers/consumers for later ZPI packages
+(store, search, analyzers) will land in subsequent work packages.
 
 ## Contract IDs (stable)
+
+### Core baseline
 
 - `zeus.evidence-model`
 - `zeus.run-manifest`
 - `zeus.artifact-reference`
 - `zeus.investigation-session`
 - `zeus.safety-policy`
+
+### Project Intelligence (ZPI-02)
+
+- `zeus.project-knowledge-project`
+- `zeus.project-knowledge-snapshot`
+- `zeus.project-knowledge-source-unit`
+- `zeus.project-knowledge-source-span`
+- `zeus.project-knowledge-symbol`
+- `zeus.project-knowledge-relationship`
+- `zeus.project-knowledge-analyzer-run`
+- `zeus.project-knowledge-evidence`
+- `zeus.project-knowledge-summary`
+- `zeus.project-knowledge-diagnostic`
+- `zeus.project-knowledge-context-package`
+- `zeus.project-knowledge-operation-result`
 
 ## Usage (via registry)
 
@@ -25,7 +48,20 @@ for (const [id, { version, schema }] of Object.entries(INITIAL_SCHEMAS)) {
   registry.register({ id, version, schema });
 }
 
-const result = registry.validate('zeus.run-manifest', 1, manifestData);
+const result = registry.validate('zeus.project-knowledge-project', 1, projectData);
 ```
 
-See `src/core/contracts/schemaRegistry.js` and the package 02 ADR baseline for policy.
+## Package export
+
+```js
+const zpi = require('zeus-rpg-promptkit/project-intelligence-contracts');
+// or: require('./src/projectIntelligence')
+
+const result = zpi.validateProjectIntelligenceContract(zpi.CONTRACT_IDS.SNAPSHOT, snapshotValue);
+```
+
+See:
+
+- `src/projectIntelligence/` — validators, reason codes, fixtures, contract test kit
+- `docs/architecture/adr-009-project-intelligence-ownership.md` and following ZPI ADRs
+- `docs/knowledgebase/zpi-test-strategy.md`

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -20,6 +20,7 @@ module.exports = {
       'tests/module-sdk.test.js',
       'tests/workflow-presets.test.js',
       'tests/community-deployment.test.js',
+      'tests/project-intelligence-contracts.test.js',
     ],
     smoke: [
       'tests/reproducible-output.test.js',

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -22,6 +22,7 @@ const providerRedaction = require('../providers/redaction');
 const providerTesting = require('../providers/testing');
 const providerAdapters = require('../providers/adapters');
 const generationValidation = require('../generationValidation');
+const projectIntelligence = require('../projectIntelligence');
 const modulesApi = require('../modules');
 const { createAtomicModuleRegistrar } = require('../modules/moduleRegistrar');
 const { executeQueryTable } = require('../core/queryService');
@@ -861,6 +862,9 @@ const zeus = {
   // Generation Validation Foundation (Iteration 29): offline candidate validation.
   // Never mutates the analyzed source workspace. review-ready is not compile readiness.
   generationValidation,
+  // Project Intelligence contract kit (ZPI-02): validators and reason codes only.
+  // No store/search/analyzer runtime, CLI, or MCP adapters in this package.
+  projectIntelligence,
   // External module contracts (Iteration 30): trusted in-process registration only.
   // Core does not parse licenses or enforce commercial entitlement.
   modules: createAtomicModuleRegistrar({
@@ -943,6 +947,9 @@ module.exports = {
   // Generation Validation Foundation (Community safety baseline)
   generationValidation,
 
+  // Project Intelligence Community contract kit (ZPI-02; no persistence runtime)
+  projectIntelligence,
+
   // Module descriptor / registrar contracts (Community; no license enforcement)
   modules: zeus.modules,
   moduleContracts: modulesApi,
@@ -956,6 +963,7 @@ module.exports = {
       ...zeus,
       providers: createProviderNamespace(),
       generationValidation,
+      projectIntelligence,
       capabilities: caps,
       modules: createAtomicModuleRegistrar({ capabilityRegistry: caps }),
       moduleContracts: modulesApi,

--- a/src/core/contracts/contractIds.js
+++ b/src/core/contracts/contractIds.js
@@ -42,4 +42,17 @@ module.exports = Object.freeze({
   EXTERNAL_LINTER_ADAPTER: 'zeus.external-linter-adapter',
   MODULE_DESCRIPTOR: 'zeus.module-descriptor',
   MODULE_STATUS: 'zeus.module-status',
+  // Zeus Project Intelligence (ZPI-02) knowledge contracts
+  PROJECT_KNOWLEDGE_PROJECT: 'zeus.project-knowledge-project',
+  PROJECT_KNOWLEDGE_SNAPSHOT: 'zeus.project-knowledge-snapshot',
+  PROJECT_KNOWLEDGE_SOURCE_UNIT: 'zeus.project-knowledge-source-unit',
+  PROJECT_KNOWLEDGE_SOURCE_SPAN: 'zeus.project-knowledge-source-span',
+  PROJECT_KNOWLEDGE_SYMBOL: 'zeus.project-knowledge-symbol',
+  PROJECT_KNOWLEDGE_RELATIONSHIP: 'zeus.project-knowledge-relationship',
+  PROJECT_KNOWLEDGE_ANALYZER_RUN: 'zeus.project-knowledge-analyzer-run',
+  PROJECT_KNOWLEDGE_EVIDENCE: 'zeus.project-knowledge-evidence',
+  PROJECT_KNOWLEDGE_SUMMARY: 'zeus.project-knowledge-summary',
+  PROJECT_KNOWLEDGE_DIAGNOSTIC: 'zeus.project-knowledge-diagnostic',
+  PROJECT_KNOWLEDGE_CONTEXT_PACKAGE: 'zeus.project-knowledge-context-package',
+  PROJECT_KNOWLEDGE_OPERATION_RESULT: 'zeus.project-knowledge-operation-result',
 });

--- a/src/core/contracts/index.js
+++ b/src/core/contracts/index.js
@@ -18,6 +18,7 @@ const artifactReference = require('./artifactReference');
 const runManifest = require('./runManifest');
 const providerContracts = require('../../providers/contracts');
 const generationValidation = require('../../generationValidation');
+const projectIntelligence = require('../../projectIntelligence');
 
 module.exports = {
   createSchemaRegistry,
@@ -27,4 +28,5 @@ module.exports = {
   runManifest,
   providerContracts,
   generationValidation,
+  projectIntelligence,
 };

--- a/src/core/contracts/schemas.js
+++ b/src/core/contracts/schemas.js
@@ -270,6 +270,7 @@ const safetyPolicySchema = value => {
 
 const { PROVIDER_SCHEMAS } = require('../../providers/contracts');
 const { GENERATION_SCHEMAS } = require('../../generationValidation/contracts');
+const { PROJECT_INTELLIGENCE_SCHEMAS } = require('../../projectIntelligence/contracts');
 const { moduleDescriptorSchema } = require('../../modules/descriptor');
 const { REASON_CODES, LIFECYCLE, AVAILABILITY } = require('../../modules/constants');
 
@@ -310,6 +311,7 @@ const INITIAL_SCHEMAS = Object.freeze({
   [CONTRACT_IDS.SAFETY_POLICY]: { version: 1, schema: safetyPolicySchema },
   ...PROVIDER_SCHEMAS,
   ...GENERATION_SCHEMAS,
+  ...PROJECT_INTELLIGENCE_SCHEMAS,
   [CONTRACT_IDS.MODULE_DESCRIPTOR]: { version: 1, schema: moduleDescriptorSchema },
   [CONTRACT_IDS.MODULE_STATUS]: { version: 1, schema: moduleStatusSchema },
 });

--- a/src/projectIntelligence/constants.js
+++ b/src/projectIntelligence/constants.js
@@ -1,0 +1,275 @@
+'use strict';
+
+/**
+ * Zeus Project Intelligence (ZPI) — closed Community contract vocabulary.
+ *
+ * ZPI-02 freezes contracts, reason codes, and validators only.
+ * No store, search, analyzer runtime, CLI, or MCP adapters live here.
+ *
+ * Package 09 remains closed: no live IBM i compile/execute behavior.
+ */
+
+/** Semantic version of the Community project-knowledge contract family. */
+const CONTRACT_FAMILY_VERSION = 1;
+
+/**
+ * Fact / derivation classes (ADR-011).
+ * VERIFIED requires current source-evidence references.
+ */
+const DERIVATION_CLASSES = Object.freeze({
+  VERIFIED: 'VERIFIED',
+  INFERRED: 'INFERRED',
+  UNRESOLVED: 'UNRESOLVED',
+  STALE: 'STALE',
+  INVALIDATED: 'INVALIDATED',
+});
+
+/** Published-snapshot lifecycle statuses (ADR-012). */
+const SNAPSHOT_STATUSES = Object.freeze({
+  BUILDING: 'building',
+  PUBLISHED: 'published',
+  SUPERSEDED: 'superseded',
+  INVALIDATED: 'invalidated',
+  FAILED: 'failed',
+});
+
+/** Analyzer-run terminal statuses. */
+const ANALYZER_RUN_STATUSES = Object.freeze({
+  SUCCEEDED: 'succeeded',
+  FAILED: 'failed',
+  PARTIAL: 'partial',
+});
+
+/** Evidence classes — only `source` may underpin VERIFIED facts. */
+const EVIDENCE_CLASSES = Object.freeze({
+  SOURCE: 'source',
+  DERIVED_REFERENCE: 'derived-reference',
+});
+
+const DIAGNOSTIC_SEVERITIES = Object.freeze({
+  INFO: 'info',
+  WARNING: 'warning',
+  ERROR: 'error',
+  BLOCKING: 'blocking',
+});
+
+/**
+ * Baseline symbol kinds for RPG/IBM i project knowledge.
+ * Additive kinds may appear later; unknown kinds fail closed in v1 contracts.
+ */
+const SYMBOL_KINDS = Object.freeze([
+  'PROGRAM',
+  'MODULE',
+  'PROCEDURE',
+  'SUBROUTINE',
+  'SERVICE_PROGRAM',
+  'BINDING_DIRECTORY',
+  'COPY_MEMBER',
+  'INCLUDE',
+  'PROTOTYPE',
+  'DATA_STRUCTURE',
+  'FILE',
+  'TABLE',
+  'VIEW',
+  'FIELD',
+  'CL_COMMAND',
+  'SQL_OBJECT',
+  'UNRESOLVED_SYMBOL',
+]);
+
+/**
+ * Baseline relationship types.
+ * Unknown types fail closed in v1 contracts.
+ */
+const RELATIONSHIP_TYPES = Object.freeze([
+  'PROGRAM_CALL',
+  'BOUND_PROCEDURE_CALL',
+  'SUBROUTINE_CALL',
+  'COPY_INCLUDE',
+  'FILE_READ',
+  'FILE_WRITE',
+  'TABLE_REFERENCE',
+  'FIELD_REFERENCE',
+  'SQL_REFERENCE',
+  'CL_CALL',
+  'SERVICE_PROGRAM_EXPORT',
+  'SERVICE_PROGRAM_IMPORT',
+  'BINDING_CANDIDATE',
+  'DYNAMIC_UNRESOLVED_CALL',
+  'DEPENDS_ON',
+]);
+
+const CONTENT_HASH_ALGORITHMS = Object.freeze(['sha256']);
+
+const SAFETY_LEVELS = Object.freeze(['S0', 'S1', 'S2', 'S3', 'S4']);
+
+/**
+ * Closed fail-closed reason-code catalog for project-intelligence operations.
+ * Messages must remain redacted / free of secrets and host paths when surfaced.
+ */
+const REASON_CODES = Object.freeze({
+  // Contract validation
+  SCHEMA_INVALID: 'ZPI.SCHEMA_INVALID',
+  SCHEMA_VERSION_UNSUPPORTED: 'ZPI.SCHEMA_VERSION_UNSUPPORTED',
+  UNKNOWN_ENUM_VALUE: 'ZPI.UNKNOWN_ENUM_VALUE',
+  PROVENANCE_INVALID: 'ZPI.PROVENANCE_INVALID',
+  VERIFIED_WITHOUT_EVIDENCE: 'ZPI.VERIFIED_WITHOUT_EVIDENCE',
+  CANONICALITY_VIOLATION: 'ZPI.CANONICALITY_VIOLATION',
+
+  // Project / identity
+  PROJECT_NOT_FOUND: 'ZPI.PROJECT_NOT_FOUND',
+  PROJECT_ID_INVALID: 'ZPI.PROJECT_ID_INVALID',
+
+  // Snapshot lifecycle
+  SNAPSHOT_NOT_FOUND: 'ZPI.SNAPSHOT_NOT_FOUND',
+  SNAPSHOT_NOT_PUBLISHED: 'ZPI.SNAPSHOT_NOT_PUBLISHED',
+  SNAPSHOT_STALE: 'ZPI.SNAPSHOT_STALE',
+  SNAPSHOT_NOT_CURRENT: 'ZPI.SNAPSHOT_NOT_CURRENT',
+  SNAPSHOT_IMMUTABLE: 'ZPI.SNAPSHOT_IMMUTABLE',
+  PUBLISH_INCOMPLETE: 'ZPI.PUBLISH_INCOMPLETE',
+  CURRENT_POINTER_MISMATCH: 'ZPI.CURRENT_POINTER_MISMATCH',
+  MIXED_GENERATION: 'ZPI.MIXED_GENERATION',
+
+  // Migrations
+  MIGRATION_REQUIRED: 'ZPI.MIGRATION_REQUIRED',
+  MIGRATION_UNSUPPORTED: 'ZPI.MIGRATION_UNSUPPORTED',
+  MIGRATION_FAILED: 'ZPI.MIGRATION_FAILED',
+
+  // Store / concurrency
+  STORE_UNAVAILABLE: 'ZPI.STORE_UNAVAILABLE',
+  STORE_CORRUPT: 'ZPI.STORE_CORRUPT',
+  STORE_LOCKED: 'ZPI.STORE_LOCKED',
+  WRITER_CONFLICT: 'ZPI.WRITER_CONFLICT',
+  TRANSACTION_FAILED: 'ZPI.TRANSACTION_FAILED',
+
+  // Content store
+  CONTENT_NOT_FOUND: 'ZPI.CONTENT_NOT_FOUND',
+  CONTENT_HASH_MISMATCH: 'ZPI.CONTENT_HASH_MISMATCH',
+  CONTENT_CORRUPT: 'ZPI.CONTENT_CORRUPT',
+
+  // Path / trust
+  UNTRUSTED_ROOT: 'ZPI.UNTRUSTED_ROOT',
+  PATH_UNSAFE: 'ZPI.PATH_UNSAFE',
+  PATH_TRAVERSAL: 'ZPI.PATH_TRAVERSAL',
+  PATH_ESCAPE: 'ZPI.PATH_ESCAPE',
+  SYMLINK_ESCAPE: 'ZPI.SYMLINK_ESCAPE',
+
+  // Resource bounds
+  SOURCE_TOO_LARGE: 'ZPI.SOURCE_TOO_LARGE',
+  PROJECT_TOO_LARGE: 'ZPI.PROJECT_TOO_LARGE',
+  RESULT_LIMIT_EXCEEDED: 'ZPI.RESULT_LIMIT_EXCEEDED',
+  TOKEN_BUDGET_EXCEEDED: 'ZPI.TOKEN_BUDGET_EXCEEDED',
+
+  // Search index
+  INDEX_UNAVAILABLE: 'ZPI.INDEX_UNAVAILABLE',
+  INDEX_CORRUPT: 'ZPI.INDEX_CORRUPT',
+  INDEX_REBUILD_REQUIRED: 'ZPI.INDEX_REBUILD_REQUIRED',
+  INDEX_SCHEMA_MISMATCH: 'ZPI.INDEX_SCHEMA_MISMATCH',
+
+  // Retrieval / context
+  EVIDENCE_MISSING: 'ZPI.EVIDENCE_MISSING',
+  EVIDENCE_STALE: 'ZPI.EVIDENCE_STALE',
+  RETRIEVAL_FAILED: 'ZPI.RETRIEVAL_FAILED',
+  CONTEXT_ASSEMBLY_FAILED: 'ZPI.CONTEXT_ASSEMBLY_FAILED',
+  OMISSION_REPORTED: 'ZPI.OMISSION_REPORTED',
+
+  // Safety / export
+  POLICY_DENIED: 'ZPI.POLICY_DENIED',
+  EXPORT_DENIED: 'ZPI.EXPORT_DENIED',
+  REDACTION_REQUIRED: 'ZPI.REDACTION_REQUIRED',
+  SECRET_LIKE_CONTENT: 'ZPI.SECRET_LIKE_CONTENT',
+
+  // Capability boundary (Community may surface absence without entitlement logic)
+  CAPABILITY_UNAVAILABLE: 'ZPI.CAPABILITY_UNAVAILABLE',
+  ENTITLEMENT_REQUIRED: 'ZPI.ENTITLEMENT_REQUIRED',
+
+  // Generic fail-closed
+  OPERATION_UNAVAILABLE: 'ZPI.OPERATION_UNAVAILABLE',
+  INTERNAL_ERROR: 'ZPI.INTERNAL_ERROR',
+});
+
+/** Stable human-safe messages for public reason codes (no secrets/paths). */
+const REASON_CODE_MESSAGES = Object.freeze({
+  [REASON_CODES.SCHEMA_INVALID]: 'Project knowledge contract validation failed',
+  [REASON_CODES.SCHEMA_VERSION_UNSUPPORTED]: 'Unsupported project knowledge schema version',
+  [REASON_CODES.UNKNOWN_ENUM_VALUE]: 'Unknown closed enum value in project knowledge contract',
+  [REASON_CODES.PROVENANCE_INVALID]: 'Provenance is missing required fields or is invalid',
+  [REASON_CODES.VERIFIED_WITHOUT_EVIDENCE]: 'VERIFIED facts require current source evidence',
+  [REASON_CODES.CANONICALITY_VIOLATION]:
+    'Derived artifact must not claim source-of-truth authority',
+  [REASON_CODES.PROJECT_NOT_FOUND]: 'Project was not found',
+  [REASON_CODES.PROJECT_ID_INVALID]: 'Project identity is invalid',
+  [REASON_CODES.SNAPSHOT_NOT_FOUND]: 'Snapshot was not found',
+  [REASON_CODES.SNAPSHOT_NOT_PUBLISHED]: 'Snapshot is not published',
+  [REASON_CODES.SNAPSHOT_STALE]: 'Snapshot is stale relative to current sources',
+  [REASON_CODES.SNAPSHOT_NOT_CURRENT]: 'Snapshot is not the current published pointer',
+  [REASON_CODES.SNAPSHOT_IMMUTABLE]: 'Published snapshots are immutable',
+  [REASON_CODES.PUBLISH_INCOMPLETE]: 'Snapshot publish did not complete atomically',
+  [REASON_CODES.CURRENT_POINTER_MISMATCH]: 'Current snapshot pointer is inconsistent',
+  [REASON_CODES.MIXED_GENERATION]: 'Mixed-generation project knowledge state refused',
+  [REASON_CODES.MIGRATION_REQUIRED]: 'Store migration is required before open',
+  [REASON_CODES.MIGRATION_UNSUPPORTED]: 'Required migration version is unsupported',
+  [REASON_CODES.MIGRATION_FAILED]: 'Store migration failed',
+  [REASON_CODES.STORE_UNAVAILABLE]: 'Knowledge store is unavailable',
+  [REASON_CODES.STORE_CORRUPT]: 'Knowledge store integrity check failed',
+  [REASON_CODES.STORE_LOCKED]: 'Knowledge store is locked by another writer',
+  [REASON_CODES.WRITER_CONFLICT]: 'Parallel writer rejected',
+  [REASON_CODES.TRANSACTION_FAILED]: 'Knowledge store transaction failed',
+  [REASON_CODES.CONTENT_NOT_FOUND]: 'Content-addressed evidence was not found',
+  [REASON_CODES.CONTENT_HASH_MISMATCH]: 'Content hash does not match stored payload',
+  [REASON_CODES.CONTENT_CORRUPT]: 'Content store integrity check failed',
+  [REASON_CODES.UNTRUSTED_ROOT]: 'Path is outside trusted roots',
+  [REASON_CODES.PATH_UNSAFE]: 'Path is unsafe for project knowledge storage',
+  [REASON_CODES.PATH_TRAVERSAL]: 'Path traversal is not allowed',
+  [REASON_CODES.PATH_ESCAPE]: 'Path escapes the trusted root',
+  [REASON_CODES.SYMLINK_ESCAPE]: 'Symlink or junction escape is not allowed',
+  [REASON_CODES.SOURCE_TOO_LARGE]: 'Source unit exceeds configured size limits',
+  [REASON_CODES.PROJECT_TOO_LARGE]: 'Project exceeds configured size limits',
+  [REASON_CODES.RESULT_LIMIT_EXCEEDED]: 'Result set exceeds configured bounds',
+  [REASON_CODES.TOKEN_BUDGET_EXCEEDED]: 'Context package exceeds token budget',
+  [REASON_CODES.INDEX_UNAVAILABLE]: 'Search index is unavailable',
+  [REASON_CODES.INDEX_CORRUPT]: 'Search index integrity check failed',
+  [REASON_CODES.INDEX_REBUILD_REQUIRED]: 'Search index rebuild is required',
+  [REASON_CODES.INDEX_SCHEMA_MISMATCH]: 'Search index schema version mismatch',
+  [REASON_CODES.EVIDENCE_MISSING]: 'Required evidence reference is missing',
+  [REASON_CODES.EVIDENCE_STALE]: 'Evidence no longer matches current snapshot',
+  [REASON_CODES.RETRIEVAL_FAILED]: 'Retrieval operation failed',
+  [REASON_CODES.CONTEXT_ASSEMBLY_FAILED]: 'Context package assembly failed',
+  [REASON_CODES.OMISSION_REPORTED]: 'Material was omitted under explicit budget or policy',
+  [REASON_CODES.POLICY_DENIED]: 'Project knowledge policy denied the operation',
+  [REASON_CODES.EXPORT_DENIED]: 'Export or disclosure is denied by policy',
+  [REASON_CODES.REDACTION_REQUIRED]: 'Redaction is required before disclosure',
+  [REASON_CODES.SECRET_LIKE_CONTENT]: 'Secret-like content was refused',
+  [REASON_CODES.CAPABILITY_UNAVAILABLE]: 'Project intelligence capability is unavailable',
+  [REASON_CODES.ENTITLEMENT_REQUIRED]: 'Entitlement is required for this capability',
+  [REASON_CODES.OPERATION_UNAVAILABLE]: 'Project intelligence operation is unavailable',
+  [REASON_CODES.INTERNAL_ERROR]: 'Internal project intelligence error',
+});
+
+const DEFAULT_LIMITS = Object.freeze({
+  maxIdChars: 256,
+  maxNameChars: 512,
+  maxPathChars: 2048,
+  maxMessageChars: 4000,
+  maxSummaryChars: 16000,
+  maxArrayItems: 10000,
+  maxEvidenceRefs: 1000,
+  maxOmissions: 1000,
+  sha256HexLength: 64,
+});
+
+module.exports = {
+  CONTRACT_FAMILY_VERSION,
+  DERIVATION_CLASSES,
+  SNAPSHOT_STATUSES,
+  ANALYZER_RUN_STATUSES,
+  EVIDENCE_CLASSES,
+  DIAGNOSTIC_SEVERITIES,
+  SYMBOL_KINDS,
+  RELATIONSHIP_TYPES,
+  CONTENT_HASH_ALGORITHMS,
+  SAFETY_LEVELS,
+  REASON_CODES,
+  REASON_CODE_MESSAGES,
+  DEFAULT_LIMITS,
+};

--- a/src/projectIntelligence/contractIds.js
+++ b/src/projectIntelligence/contractIds.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * Stable Community contract identifiers for Zeus Project Intelligence.
+ * Major version is carried separately via schemaVersion / registry version.
+ */
+module.exports = Object.freeze({
+  PROJECT: 'zeus.project-knowledge-project',
+  SNAPSHOT: 'zeus.project-knowledge-snapshot',
+  SOURCE_UNIT: 'zeus.project-knowledge-source-unit',
+  SOURCE_SPAN: 'zeus.project-knowledge-source-span',
+  SYMBOL: 'zeus.project-knowledge-symbol',
+  RELATIONSHIP: 'zeus.project-knowledge-relationship',
+  ANALYZER_RUN: 'zeus.project-knowledge-analyzer-run',
+  EVIDENCE: 'zeus.project-knowledge-evidence',
+  SUMMARY: 'zeus.project-knowledge-summary',
+  DIAGNOSTIC: 'zeus.project-knowledge-diagnostic',
+  CONTEXT_PACKAGE: 'zeus.project-knowledge-context-package',
+  OPERATION_RESULT: 'zeus.project-knowledge-operation-result',
+});

--- a/src/projectIntelligence/contractTestKit.js
+++ b/src/projectIntelligence/contractTestKit.js
@@ -1,0 +1,203 @@
+'use strict';
+
+/**
+ * Public Project Intelligence Contract Test Kit (ZPI-02).
+ * External and internal consumers can require this kit to assert Community
+ * contract behavior without depending on persistence implementations.
+ *
+ * Usage:
+ *   const { runProjectIntelligenceContractTests } =
+ *     require('zeus-rpg-promptkit/project-intelligence-contracts');
+ */
+
+const assert = require('node:assert/strict');
+const { createSchemaRegistry } = require('../core/contracts/schemaRegistry');
+const { INITIAL_SCHEMAS } = require('../core/contracts/schemas');
+const CORE_IDS = require('../core/contracts/contractIds');
+const {
+  CONTRACT_IDS,
+  PROJECT_INTELLIGENCE_SCHEMAS,
+  projectSchema,
+  symbolSchema,
+  summarySchema,
+  contextPackageSchema,
+  diagnosticSchema,
+} = require('./contracts');
+const {
+  DERIVATION_CLASSES,
+  REASON_CODES,
+  REASON_CODE_MESSAGES,
+  SNAPSHOT_STATUSES,
+} = require('./constants');
+const fixtures = require('./fixtures');
+const {
+  createProjectIntelligenceRegistry,
+  validateProjectIntelligenceContract,
+  registerProjectIntelligenceSchemas,
+} = require('./validate');
+const { isSafeRelativePath } = require('./helpers');
+
+async function runProjectIntelligenceContractTests() {
+  const results = [];
+
+  function check(name, fn) {
+    try {
+      const out = fn();
+      if (out && typeof out.then === 'function') {
+        return out
+          .then(() => results.push({ name, ok: true }))
+          .catch(err => {
+            results.push({ name, ok: false, error: String(err && err.message) });
+            throw err;
+          });
+      }
+      results.push({ name, ok: true });
+    } catch (err) {
+      results.push({ name, ok: false, error: String(err && err.message) });
+      throw err;
+    }
+  }
+
+  await check('all ZPI schemas are registered with version 1', () => {
+    const registry = createProjectIntelligenceRegistry();
+    for (const id of Object.keys(PROJECT_INTELLIGENCE_SCHEMAS)) {
+      assert.equal(registry.hasContract(id, 1), true, `missing ${id}@1`);
+    }
+  });
+
+  await check('minimal fixtures validate for every entity', () => {
+    const cases = [
+      [CONTRACT_IDS.PROJECT, fixtures.project()],
+      [CONTRACT_IDS.SNAPSHOT, fixtures.snapshot()],
+      [CONTRACT_IDS.SOURCE_UNIT, fixtures.sourceUnit()],
+      [CONTRACT_IDS.SOURCE_SPAN, fixtures.sourceSpan()],
+      [CONTRACT_IDS.SYMBOL, fixtures.symbol()],
+      [CONTRACT_IDS.RELATIONSHIP, fixtures.relationship()],
+      [CONTRACT_IDS.ANALYZER_RUN, fixtures.analyzerRun()],
+      [CONTRACT_IDS.EVIDENCE, fixtures.evidence()],
+      [CONTRACT_IDS.SUMMARY, fixtures.summary()],
+      [CONTRACT_IDS.DIAGNOSTIC, fixtures.diagnostic()],
+      [CONTRACT_IDS.CONTEXT_PACKAGE, fixtures.contextPackage()],
+      [CONTRACT_IDS.OPERATION_RESULT, fixtures.operationResultOk()],
+      [CONTRACT_IDS.OPERATION_RESULT, fixtures.operationResultFail()],
+    ];
+    for (const [id, value] of cases) {
+      const result = validateProjectIntelligenceContract(id, value);
+      assert.equal(result.ok, true, `${id}: ${JSON.stringify(result.errors)}`);
+    }
+  });
+
+  await check('unknown schema version fails closed', () => {
+    const result = validateProjectIntelligenceContract(
+      CONTRACT_IDS.PROJECT,
+      fixtures.project({ schemaVersion: 99 })
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.reasonCode, REASON_CODES.SCHEMA_VERSION_UNSUPPORTED);
+    assert.ok(result.errors.some(e => e.path === '/schemaVersion'));
+  });
+
+  await check('unknown derivation class fails closed', () => {
+    const errors = symbolSchema(
+      fixtures.symbol({
+        provenance: fixtures.provenance({ derivationClass: 'GUESSED' }),
+        evidenceReferences: [{ id: 'ev-1' }],
+      })
+    );
+    assert.ok(errors.some(e => e.path === '/provenance/derivationClass'));
+  });
+
+  await check('unknown reason code fails closed', () => {
+    const errors = diagnosticSchema(fixtures.diagnostic({ reasonCode: 'NOT_A_REAL_CODE' }));
+    assert.ok(errors.some(e => e.path === '/reasonCode'));
+  });
+
+  await check('VERIFIED without evidence fails closed', () => {
+    const errors = symbolSchema(
+      fixtures.symbol({
+        provenance: fixtures.provenance({ derivationClass: DERIVATION_CLASSES.VERIFIED }),
+        evidenceReferences: [],
+      })
+    );
+    assert.ok(errors.some(e => e.path === '/evidenceReferences'));
+  });
+
+  await check('summary and context package cannot claim sourceOfTruth', () => {
+    assert.ok(
+      summarySchema(fixtures.summary({ sourceOfTruth: true })).some(
+        e => e.path === '/sourceOfTruth'
+      )
+    );
+    assert.ok(
+      contextPackageSchema(fixtures.contextPackage({ sourceOfTruth: true })).some(
+        e => e.path === '/sourceOfTruth'
+      )
+    );
+  });
+
+  await check('summary cannot be VERIFIED', () => {
+    const errors = summarySchema(
+      fixtures.summary({ derivationClass: DERIVATION_CLASSES.VERIFIED })
+    );
+    assert.ok(errors.some(e => e.path === '/derivationClass'));
+  });
+
+  await check('relative path safety rejects traversal and absolute forms', () => {
+    assert.equal(isSafeRelativePath('../escape.rpgle'), false);
+    assert.equal(isSafeRelativePath('/etc/passwd'), false);
+    assert.equal(isSafeRelativePath('C:\\Windows\\a.rpgle'), false);
+    assert.equal(isSafeRelativePath('\\\\server\\share\\a.rpgle'), false);
+    assert.equal(isSafeRelativePath('QRPGLESRC/ORDERPGM.rpgle'), true);
+
+    const bad = projectSchema(
+      fixtures.project({
+        trustedRoots: [{ rootId: 'r1', relativeLabel: '../escape' }],
+      })
+    );
+    assert.ok(bad.some(e => e.path.includes('relativeLabel')));
+  });
+
+  await check('reason code catalog has messages for every code', () => {
+    for (const code of Object.values(REASON_CODES)) {
+      assert.equal(typeof REASON_CODE_MESSAGES[code], 'string');
+      assert.ok(REASON_CODE_MESSAGES[code].length > 0);
+      assert.ok(code.startsWith('ZPI.'));
+    }
+  });
+
+  await check('snapshot statuses are closed', () => {
+    const errors = require('./contracts').snapshotSchema(fixtures.snapshot({ status: 'maybe' }));
+    assert.ok(errors.some(e => e.path === '/status'));
+    assert.ok(Object.values(SNAPSHOT_STATUSES).includes('published'));
+  });
+
+  await check('ZPI contracts integrate with core INITIAL_SCHEMAS registry', () => {
+    const registry = createSchemaRegistry();
+    for (const [id, { version, schema }] of Object.entries(INITIAL_SCHEMAS)) {
+      registry.register({ id, version, schema });
+    }
+    for (const id of Object.keys(PROJECT_INTELLIGENCE_SCHEMAS)) {
+      assert.equal(registry.hasContract(id, 1), true, `INITIAL_SCHEMAS missing ${id}`);
+    }
+    // Core IDs mirror ZPI contract ids for discovery
+    assert.equal(CORE_IDS.PROJECT_KNOWLEDGE_PROJECT, CONTRACT_IDS.PROJECT);
+    assert.equal(CORE_IDS.PROJECT_KNOWLEDGE_CONTEXT_PACKAGE, CONTRACT_IDS.CONTEXT_PACKAGE);
+
+    const ok = registry.validate(CONTRACT_IDS.PROJECT, 1, fixtures.project());
+    assert.equal(ok.ok, true);
+  });
+
+  await check('registerProjectIntelligenceSchemas is idempotent only once per registry', () => {
+    const registry = createSchemaRegistry();
+    registerProjectIntelligenceSchemas(registry);
+    assert.throws(() => registerProjectIntelligenceSchemas(registry), /Duplicate registration/);
+  });
+
+  return { ok: true, results };
+}
+
+module.exports = {
+  runProjectIntelligenceContractTests,
+  fixtures,
+  CONTRACT_IDS,
+};

--- a/src/projectIntelligence/contracts.js
+++ b/src/projectIntelligence/contracts.js
@@ -1,0 +1,542 @@
+'use strict';
+
+const CONTRACT_IDS = require('./contractIds');
+const {
+  DERIVATION_CLASSES,
+  SNAPSHOT_STATUSES,
+  ANALYZER_RUN_STATUSES,
+  EVIDENCE_CLASSES,
+  DIAGNOSTIC_SEVERITIES,
+  SYMBOL_KINDS,
+  RELATIONSHIP_TYPES,
+  SAFETY_LEVELS,
+  REASON_CODES,
+  DEFAULT_LIMITS,
+} = require('./constants');
+const h = require('./helpers');
+
+const DERIVATION_VALUES = Object.values(DERIVATION_CLASSES);
+const REASON_CODE_VALUES = Object.values(REASON_CODES);
+
+function header(errors, value, expectedKind, expectedContractId) {
+  if (!h.requireObject(errors, value, '')) return false;
+  h.requireSchemaVersion(errors, value.schemaVersion, 1);
+  h.requireKind(errors, value.kind, expectedKind);
+  h.requireContractId(errors, value.contractId, expectedContractId);
+  return true;
+}
+
+function requireProjectSnapshotIds(errors, value) {
+  h.requireNonEmptyString(errors, value.projectId, '/projectId');
+  h.requireNonEmptyString(errors, value.snapshotId, '/snapshotId');
+}
+
+function validateSafety(errors, safety, basePath = '/safety') {
+  if (safety == null) return;
+  if (!h.requireObject(errors, safety, basePath)) return;
+  if (safety.level != null) {
+    h.requireClosedEnum(errors, safety.level, `${basePath}/level`, SAFETY_LEVELS, 'safety level');
+  }
+  if (safety.localOnly != null && typeof safety.localOnly !== 'boolean') {
+    h.push(errors, `${basePath}/localOnly`, 'localOnly must be a boolean when present');
+  }
+  if (safety.sideEffects != null && !Array.isArray(safety.sideEffects)) {
+    h.push(errors, `${basePath}/sideEffects`, 'sideEffects must be an array when present');
+  }
+}
+
+function requireDerivationClass(errors, value, path = '/derivationClass') {
+  return h.requireClosedEnum(errors, value, path, DERIVATION_VALUES, 'derivationClass');
+}
+
+/**
+ * VERIFIED facts must cite at least one evidence reference (ADR-011).
+ */
+function enforceVerifiedEvidence(errors, derivationClass, evidenceReferences, path) {
+  if (derivationClass !== DERIVATION_CLASSES.VERIFIED) return;
+  if (!Array.isArray(evidenceReferences) || evidenceReferences.length === 0) {
+    h.push(errors, path, 'VERIFIED requires one or more evidenceReferences');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entity schemas
+// ---------------------------------------------------------------------------
+
+function projectSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-project', CONTRACT_IDS.PROJECT)) return errors;
+
+  h.requireNonEmptyString(errors, value.projectId, '/projectId');
+  h.optionalString(errors, value.displayName, '/displayName');
+
+  if (!h.requireArray(errors, value.trustedRoots, '/trustedRoots', { maxItems: 64 })) {
+    return errors;
+  }
+  value.trustedRoots.forEach((root, i) => {
+    const base = `/trustedRoots/${i}`;
+    if (!h.requireObject(errors, root, base)) return;
+    h.requireNonEmptyString(errors, root.rootId, `${base}/rootId`);
+    // Local-only stores may keep host paths; export contracts must redact separately.
+    if (root.canonicalPath != null) {
+      h.optionalString(errors, root.canonicalPath, `${base}/canonicalPath`, {
+        maxChars: DEFAULT_LIMITS.maxPathChars,
+      });
+    }
+    if (root.relativeLabel != null) {
+      h.requireSafeRelativePath(errors, root.relativeLabel, `${base}/relativeLabel`);
+    }
+  });
+
+  if (value.schemaBindings != null) {
+    if (h.requireObject(errors, value.schemaBindings, '/schemaBindings')) {
+      h.optionalNonNegativeInteger(
+        errors,
+        value.schemaBindings.storeSchemaVersion,
+        '/schemaBindings/storeSchemaVersion'
+      );
+      h.optionalNonNegativeInteger(
+        errors,
+        value.schemaBindings.searchSchemaVersion,
+        '/schemaBindings/searchSchemaVersion'
+      );
+      h.optionalNonNegativeInteger(
+        errors,
+        value.schemaBindings.artifactSchemaVersion,
+        '/schemaBindings/artifactSchemaVersion'
+      );
+    }
+  }
+
+  validateSafety(errors, value.safety);
+  return errors;
+}
+
+function snapshotSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-snapshot', CONTRACT_IDS.SNAPSHOT)) return errors;
+
+  requireProjectSnapshotIds(errors, value);
+  h.requireClosedEnum(errors, value.status, '/status', Object.values(SNAPSHOT_STATUSES), 'status');
+  h.requireContentHash(errors, value.sourceInventoryHash, '/sourceInventoryHash');
+  h.requirePositiveInteger(errors, value.storeSchemaVersion, '/storeSchemaVersion');
+  h.requirePositiveInteger(errors, value.searchSchemaVersion, '/searchSchemaVersion');
+  h.requirePositiveInteger(errors, value.artifactSchemaVersion, '/artifactSchemaVersion');
+
+  if (value.isCurrent != null && typeof value.isCurrent !== 'boolean') {
+    h.push(errors, '/isCurrent', 'isCurrent must be a boolean when present');
+  }
+  if (value.contentAddressing != null) {
+    if (h.requireObject(errors, value.contentAddressing, '/contentAddressing')) {
+      h.requireHashAlgorithm(
+        errors,
+        value.contentAddressing.algorithm,
+        '/contentAddressing/algorithm'
+      );
+    }
+  }
+  if (value.analyzerRunIds != null) {
+    if (h.optionalArray(errors, value.analyzerRunIds, '/analyzerRunIds')) {
+      value.analyzerRunIds.forEach((id, i) => {
+        h.requireNonEmptyString(errors, id, `/analyzerRunIds/${i}`);
+      });
+    }
+  }
+  h.optionalString(errors, value.publishedAt, '/publishedAt', { maxChars: 64 });
+  validateSafety(errors, value.safety);
+  return errors;
+}
+
+function sourceUnitSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-source-unit', CONTRACT_IDS.SOURCE_UNIT)) {
+    return errors;
+  }
+
+  requireProjectSnapshotIds(errors, value);
+  h.requireNonEmptyString(errors, value.sourceUnitId, '/sourceUnitId');
+  h.requireSafeRelativePath(errors, value.relativePath, '/relativePath');
+  h.requireContentHash(errors, value.contentHash, '/contentHash');
+  h.requireNonEmptyString(errors, value.trustedRootId, '/trustedRootId');
+  h.optionalString(errors, value.language, '/language', { maxChars: 64 });
+  h.optionalString(errors, value.mediaType, '/mediaType', { maxChars: 128 });
+  h.optionalNonNegativeInteger(errors, value.sizeBytes, '/sizeBytes');
+  h.requireHashAlgorithm(errors, value.hashAlgorithm, '/hashAlgorithm');
+  return errors;
+}
+
+function sourceSpanSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-source-span', CONTRACT_IDS.SOURCE_SPAN)) {
+    return errors;
+  }
+
+  requireProjectSnapshotIds(errors, value);
+  h.requireNonEmptyString(errors, value.spanId, '/spanId');
+  h.requireNonEmptyString(errors, value.sourceUnitId, '/sourceUnitId');
+  h.requireContentHash(errors, value.contentHash, '/contentHash');
+  h.validateLinePosition(errors, value.start, '/start', { required: true });
+  h.validateLinePosition(errors, value.end, '/end', { required: true });
+  return errors;
+}
+
+function symbolSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-symbol', CONTRACT_IDS.SYMBOL)) return errors;
+
+  requireProjectSnapshotIds(errors, value);
+  h.requireNonEmptyString(errors, value.symbolId, '/symbolId');
+  h.requireNonEmptyString(errors, value.name, '/name', { maxChars: DEFAULT_LIMITS.maxNameChars });
+  h.requireClosedEnum(errors, value.symbolKind, '/symbolKind', SYMBOL_KINDS, 'symbolKind');
+
+  h.validateProvenance(errors, value.provenance);
+  if (value.provenance && typeof value.provenance === 'object') {
+    requireDerivationClass(errors, value.provenance.derivationClass, '/provenance/derivationClass');
+  }
+
+  if (value.evidenceReferences != null) {
+    if (
+      h.optionalArray(errors, value.evidenceReferences, '/evidenceReferences', {
+        maxItems: DEFAULT_LIMITS.maxEvidenceRefs,
+      })
+    ) {
+      value.evidenceReferences.forEach((ref, i) => {
+        h.validateEvidenceReference(errors, ref, `/evidenceReferences/${i}`);
+      });
+    }
+  }
+  if (value.sourceSpanIds != null) {
+    if (h.optionalArray(errors, value.sourceSpanIds, '/sourceSpanIds')) {
+      value.sourceSpanIds.forEach((id, i) => {
+        h.requireNonEmptyString(errors, id, `/sourceSpanIds/${i}`);
+      });
+    }
+  }
+
+  const derivation =
+    value.provenance && typeof value.provenance === 'object'
+      ? value.provenance.derivationClass
+      : null;
+  enforceVerifiedEvidence(errors, derivation, value.evidenceReferences, '/evidenceReferences');
+
+  h.optionalString(errors, value.confidence, '/confidence', { maxChars: 64 });
+  return errors;
+}
+
+function relationshipSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-relationship', CONTRACT_IDS.RELATIONSHIP)) {
+    return errors;
+  }
+
+  requireProjectSnapshotIds(errors, value);
+  h.requireNonEmptyString(errors, value.relationshipId, '/relationshipId');
+  h.requireClosedEnum(
+    errors,
+    value.relationshipType,
+    '/relationshipType',
+    RELATIONSHIP_TYPES,
+    'relationshipType'
+  );
+  h.requireNonEmptyString(errors, value.fromSymbolId, '/fromSymbolId');
+  h.requireNonEmptyString(errors, value.toSymbolId, '/toSymbolId');
+
+  h.validateProvenance(errors, value.provenance);
+  if (value.provenance && typeof value.provenance === 'object') {
+    requireDerivationClass(errors, value.provenance.derivationClass, '/provenance/derivationClass');
+  }
+
+  if (value.evidenceReferences != null) {
+    if (
+      h.optionalArray(errors, value.evidenceReferences, '/evidenceReferences', {
+        maxItems: DEFAULT_LIMITS.maxEvidenceRefs,
+      })
+    ) {
+      value.evidenceReferences.forEach((ref, i) => {
+        h.validateEvidenceReference(errors, ref, `/evidenceReferences/${i}`);
+      });
+    }
+  }
+
+  const derivation =
+    value.provenance && typeof value.provenance === 'object'
+      ? value.provenance.derivationClass
+      : null;
+  enforceVerifiedEvidence(errors, derivation, value.evidenceReferences, '/evidenceReferences');
+
+  h.optionalString(errors, value.confidence, '/confidence', { maxChars: 64 });
+  return errors;
+}
+
+function analyzerRunSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-analyzer-run', CONTRACT_IDS.ANALYZER_RUN)) {
+    return errors;
+  }
+
+  requireProjectSnapshotIds(errors, value);
+  h.requireNonEmptyString(errors, value.analyzerRunId, '/analyzerRunId');
+  h.requireNonEmptyString(errors, value.analyzerId, '/analyzerId');
+  h.requireNonEmptyString(errors, value.analyzerVersion, '/analyzerVersion');
+  h.requireContentHash(errors, value.inputInventoryHash, '/inputInventoryHash');
+  h.requireClosedEnum(
+    errors,
+    value.status,
+    '/status',
+    Object.values(ANALYZER_RUN_STATUSES),
+    'status'
+  );
+  h.optionalString(errors, value.startedAt, '/startedAt', { maxChars: 64 });
+  h.optionalString(errors, value.completedAt, '/completedAt', { maxChars: 64 });
+  return errors;
+}
+
+function evidenceSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-evidence', CONTRACT_IDS.EVIDENCE)) return errors;
+
+  requireProjectSnapshotIds(errors, value);
+  h.requireNonEmptyString(errors, value.evidenceId, '/evidenceId');
+  h.requireNonEmptyString(errors, value.sourceUnitId, '/sourceUnitId');
+  h.requireContentHash(errors, value.contentHash, '/contentHash');
+  h.requireClosedEnum(
+    errors,
+    value.evidenceClass,
+    '/evidenceClass',
+    Object.values(EVIDENCE_CLASSES),
+    'evidenceClass'
+  );
+  h.requireNonEmptyString(errors, value.trustedRootId, '/trustedRootId');
+
+  if (value.sourceSpanIds != null) {
+    if (h.optionalArray(errors, value.sourceSpanIds, '/sourceSpanIds')) {
+      value.sourceSpanIds.forEach((id, i) => {
+        h.requireNonEmptyString(errors, id, `/sourceSpanIds/${i}`);
+      });
+    }
+  }
+  // Source evidence provenance subset
+  h.optionalString(errors, value.relativePath, '/relativePath', {
+    maxChars: DEFAULT_LIMITS.maxPathChars,
+  });
+  if (value.relativePath != null) {
+    h.requireSafeRelativePath(errors, value.relativePath, '/relativePath');
+  }
+  return errors;
+}
+
+function summarySchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-summary', CONTRACT_IDS.SUMMARY)) return errors;
+
+  requireProjectSnapshotIds(errors, value);
+  h.requireNonEmptyString(errors, value.summaryId, '/summaryId');
+  h.requireNonEmptyString(errors, value.text, '/text', {
+    maxChars: DEFAULT_LIMITS.maxSummaryChars,
+  });
+
+  // Summaries are derived aids, never canonical source evidence (ADR-011 / ADR-013).
+  if (value.sourceOfTruth !== false) {
+    h.push(errors, '/sourceOfTruth', 'sourceOfTruth must be false for summaries');
+  }
+  if (value.advisory != null && value.advisory !== true) {
+    h.push(errors, '/advisory', 'advisory must be true when present for summaries');
+  }
+
+  requireDerivationClass(errors, value.derivationClass);
+  if (value.derivationClass === DERIVATION_CLASSES.VERIFIED) {
+    h.push(errors, '/derivationClass', 'summaries cannot be VERIFIED');
+  }
+
+  if (
+    h.requireArray(errors, value.evidenceReferences, '/evidenceReferences', {
+      maxItems: DEFAULT_LIMITS.maxEvidenceRefs,
+    })
+  ) {
+    value.evidenceReferences.forEach((ref, i) => {
+      h.validateEvidenceReference(errors, ref, `/evidenceReferences/${i}`);
+    });
+  }
+  return errors;
+}
+
+function diagnosticSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-diagnostic', CONTRACT_IDS.DIAGNOSTIC)) {
+    return errors;
+  }
+
+  h.requireNonEmptyString(errors, value.projectId, '/projectId');
+  h.optionalString(errors, value.snapshotId, '/snapshotId');
+  h.requireNonEmptyString(errors, value.diagnosticId, '/diagnosticId');
+  h.requireClosedEnum(
+    errors,
+    value.severity,
+    '/severity',
+    Object.values(DIAGNOSTIC_SEVERITIES),
+    'severity'
+  );
+  h.requireClosedEnum(errors, value.reasonCode, '/reasonCode', REASON_CODE_VALUES, 'reasonCode');
+  h.requireNonEmptyString(errors, value.message, '/message', {
+    maxChars: DEFAULT_LIMITS.maxMessageChars,
+  });
+
+  if (value.relatedIds != null) {
+    if (h.optionalArray(errors, value.relatedIds, '/relatedIds')) {
+      value.relatedIds.forEach((id, i) => {
+        h.requireNonEmptyString(errors, id, `/relatedIds/${i}`);
+      });
+    }
+  }
+  return errors;
+}
+
+function contextPackageSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-context-package', CONTRACT_IDS.CONTEXT_PACKAGE)) {
+    return errors;
+  }
+
+  requireProjectSnapshotIds(errors, value);
+  h.requireNonEmptyString(errors, value.packageId, '/packageId');
+  h.requireNonEmptyString(errors, value.policyId, '/policyId');
+  h.requireNonEmptyString(errors, value.policyVersion, '/policyVersion');
+
+  if (value.sourceOfTruth !== false) {
+    h.push(errors, '/sourceOfTruth', 'sourceOfTruth must be false for context packages');
+  }
+  if (value.advisory != null && value.advisory !== true) {
+    h.push(errors, '/advisory', 'advisory must be true when present for context packages');
+  }
+  if (typeof value.tokenBudget !== 'number' || value.tokenBudget <= 0) {
+    h.push(errors, '/tokenBudget', 'positive tokenBudget is required');
+  }
+
+  if (h.requireArray(errors, value.selected, '/selected')) {
+    value.selected.forEach((item, i) => {
+      const base = `/selected/${i}`;
+      if (!h.requireObject(errors, item, base)) return;
+      h.requireNonEmptyString(errors, item.id, `${base}/id`);
+      h.optionalString(errors, item.kind, `${base}/kind`);
+      if (item.reasons != null && !Array.isArray(item.reasons)) {
+        h.push(errors, `${base}/reasons`, 'reasons must be an array when present');
+      }
+    });
+  }
+
+  if (
+    h.requireArray(errors, value.omissions, '/omissions', {
+      maxItems: DEFAULT_LIMITS.maxOmissions,
+    })
+  ) {
+    value.omissions.forEach((item, i) => {
+      const base = `/omissions/${i}`;
+      if (!h.requireObject(errors, item, base)) return;
+      h.requireClosedEnum(
+        errors,
+        item.reasonCode,
+        `${base}/reasonCode`,
+        REASON_CODE_VALUES,
+        'reasonCode'
+      );
+      h.optionalString(errors, item.description, `${base}/description`, {
+        maxChars: DEFAULT_LIMITS.maxMessageChars,
+      });
+      h.optionalString(errors, item.entityId, `${base}/entityId`);
+    });
+  }
+
+  if (
+    h.requireArray(errors, value.evidenceReferences, '/evidenceReferences', {
+      maxItems: DEFAULT_LIMITS.maxEvidenceRefs,
+    })
+  ) {
+    value.evidenceReferences.forEach((ref, i) => {
+      h.validateEvidenceReference(errors, ref, `/evidenceReferences/${i}`);
+    });
+  }
+
+  if (value.nonClaims != null && !Array.isArray(value.nonClaims)) {
+    h.push(errors, '/nonClaims', 'nonClaims must be an array when present');
+  }
+  return errors;
+}
+
+function operationResultSchema(value) {
+  const errors = [];
+  if (!header(errors, value, 'project-knowledge-operation-result', CONTRACT_IDS.OPERATION_RESULT)) {
+    return errors;
+  }
+
+  h.requireBoolean(errors, value.ok, '/ok');
+  if (value.ok === false) {
+    h.requireClosedEnum(errors, value.reasonCode, '/reasonCode', REASON_CODE_VALUES, 'reasonCode');
+    h.requireNonEmptyString(errors, value.message, '/message', {
+      maxChars: DEFAULT_LIMITS.maxMessageChars,
+    });
+  } else if (value.reasonCode != null) {
+    h.requireClosedEnum(errors, value.reasonCode, '/reasonCode', REASON_CODE_VALUES, 'reasonCode');
+  }
+  h.optionalString(errors, value.projectId, '/projectId');
+  h.optionalString(errors, value.snapshotId, '/snapshotId');
+  h.optionalString(errors, value.operation, '/operation', { maxChars: 128 });
+  if (value.diagnostics != null) {
+    if (h.optionalArray(errors, value.diagnostics, '/diagnostics')) {
+      value.diagnostics.forEach((d, i) => {
+        const base = `/diagnostics/${i}`;
+        if (!h.requireObject(errors, d, base)) return;
+        h.requireNonEmptyString(errors, d.diagnosticId, `${base}/diagnosticId`);
+        h.requireClosedEnum(
+          errors,
+          d.severity,
+          `${base}/severity`,
+          Object.values(DIAGNOSTIC_SEVERITIES),
+          'severity'
+        );
+        h.requireClosedEnum(
+          errors,
+          d.reasonCode,
+          `${base}/reasonCode`,
+          REASON_CODE_VALUES,
+          'reasonCode'
+        );
+        h.requireNonEmptyString(errors, d.message, `${base}/message`, {
+          maxChars: DEFAULT_LIMITS.maxMessageChars,
+        });
+      });
+    }
+  }
+  return errors;
+}
+
+const PROJECT_INTELLIGENCE_SCHEMAS = Object.freeze({
+  [CONTRACT_IDS.PROJECT]: { version: 1, schema: projectSchema },
+  [CONTRACT_IDS.SNAPSHOT]: { version: 1, schema: snapshotSchema },
+  [CONTRACT_IDS.SOURCE_UNIT]: { version: 1, schema: sourceUnitSchema },
+  [CONTRACT_IDS.SOURCE_SPAN]: { version: 1, schema: sourceSpanSchema },
+  [CONTRACT_IDS.SYMBOL]: { version: 1, schema: symbolSchema },
+  [CONTRACT_IDS.RELATIONSHIP]: { version: 1, schema: relationshipSchema },
+  [CONTRACT_IDS.ANALYZER_RUN]: { version: 1, schema: analyzerRunSchema },
+  [CONTRACT_IDS.EVIDENCE]: { version: 1, schema: evidenceSchema },
+  [CONTRACT_IDS.SUMMARY]: { version: 1, schema: summarySchema },
+  [CONTRACT_IDS.DIAGNOSTIC]: { version: 1, schema: diagnosticSchema },
+  [CONTRACT_IDS.CONTEXT_PACKAGE]: { version: 1, schema: contextPackageSchema },
+  [CONTRACT_IDS.OPERATION_RESULT]: { version: 1, schema: operationResultSchema },
+});
+
+module.exports = {
+  CONTRACT_IDS,
+  PROJECT_INTELLIGENCE_SCHEMAS,
+  projectSchema,
+  snapshotSchema,
+  sourceUnitSchema,
+  sourceSpanSchema,
+  symbolSchema,
+  relationshipSchema,
+  analyzerRunSchema,
+  evidenceSchema,
+  summarySchema,
+  diagnosticSchema,
+  contextPackageSchema,
+  operationResultSchema,
+};

--- a/src/projectIntelligence/fixtures.js
+++ b/src/projectIntelligence/fixtures.js
@@ -1,0 +1,292 @@
+'use strict';
+
+/**
+ * Synthetic fixtures for ZPI contract tests only.
+ * No real customer paths, hostnames, or source content.
+ */
+
+const CONTRACT_IDS = require('./contractIds');
+const {
+  DERIVATION_CLASSES,
+  SNAPSHOT_STATUSES,
+  ANALYZER_RUN_STATUSES,
+  EVIDENCE_CLASSES,
+  DIAGNOSTIC_SEVERITIES,
+  REASON_CODES,
+} = require('./constants');
+
+const HASH_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const HASH_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+function provenance(overrides = {}) {
+  return {
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    sourceHash: HASH_A,
+    analyzerId: 'zeus.rpg-baseline',
+    analyzerVersion: '1.0.0',
+    derivationClass: DERIVATION_CLASSES.INFERRED,
+    ...overrides,
+  };
+}
+
+function project(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-project',
+    contractId: CONTRACT_IDS.PROJECT,
+    projectId: 'proj-demo',
+    displayName: 'Synthetic demo project',
+    trustedRoots: [
+      {
+        rootId: 'root-src',
+        relativeLabel: 'QRPGLESRC',
+      },
+    ],
+    schemaBindings: {
+      storeSchemaVersion: 1,
+      searchSchemaVersion: 1,
+      artifactSchemaVersion: 1,
+    },
+    safety: { level: 'S1', localOnly: true },
+    ...overrides,
+  };
+}
+
+function snapshot(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-snapshot',
+    contractId: CONTRACT_IDS.SNAPSHOT,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    status: SNAPSHOT_STATUSES.PUBLISHED,
+    isCurrent: true,
+    sourceInventoryHash: HASH_B,
+    storeSchemaVersion: 1,
+    searchSchemaVersion: 1,
+    artifactSchemaVersion: 1,
+    contentAddressing: { algorithm: 'sha256' },
+    analyzerRunIds: ['run-001'],
+    publishedAt: '2026-07-22T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function sourceUnit(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-source-unit',
+    contractId: CONTRACT_IDS.SOURCE_UNIT,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    sourceUnitId: 'su-orderpgm',
+    relativePath: 'QRPGLESRC/ORDERPGM.rpgle',
+    contentHash: HASH_A,
+    trustedRootId: 'root-src',
+    language: 'rpgle',
+    sizeBytes: 128,
+    hashAlgorithm: 'sha256',
+    ...overrides,
+  };
+}
+
+function sourceSpan(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-source-span',
+    contractId: CONTRACT_IDS.SOURCE_SPAN,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    spanId: 'span-1',
+    sourceUnitId: 'su-orderpgm',
+    contentHash: HASH_A,
+    start: { line: 10, column: 1 },
+    end: { line: 20, column: 1 },
+    ...overrides,
+  };
+}
+
+function symbol(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-symbol',
+    contractId: CONTRACT_IDS.SYMBOL,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    symbolId: 'sym-orderpgm',
+    name: 'ORDERPGM',
+    symbolKind: 'PROGRAM',
+    provenance: provenance({ derivationClass: DERIVATION_CLASSES.VERIFIED }),
+    evidenceReferences: [{ id: 'ev-1', kind: 'source' }],
+    sourceSpanIds: ['span-1'],
+    confidence: 'high',
+    ...overrides,
+  };
+}
+
+function relationship(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-relationship',
+    contractId: CONTRACT_IDS.RELATIONSHIP,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    relationshipId: 'rel-1',
+    relationshipType: 'PROGRAM_CALL',
+    fromSymbolId: 'sym-orderpgm',
+    toSymbolId: 'sym-custinq',
+    provenance: provenance({ derivationClass: DERIVATION_CLASSES.INFERRED }),
+    evidenceReferences: [{ id: 'ev-1', kind: 'source' }],
+    ...overrides,
+  };
+}
+
+function analyzerRun(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-analyzer-run',
+    contractId: CONTRACT_IDS.ANALYZER_RUN,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    analyzerRunId: 'run-001',
+    analyzerId: 'zeus.rpg-baseline',
+    analyzerVersion: '1.0.0',
+    inputInventoryHash: HASH_B,
+    status: ANALYZER_RUN_STATUSES.SUCCEEDED,
+    startedAt: '2026-07-22T11:59:00.000Z',
+    completedAt: '2026-07-22T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function evidence(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-evidence',
+    contractId: CONTRACT_IDS.EVIDENCE,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    evidenceId: 'ev-1',
+    sourceUnitId: 'su-orderpgm',
+    contentHash: HASH_A,
+    evidenceClass: EVIDENCE_CLASSES.SOURCE,
+    trustedRootId: 'root-src',
+    relativePath: 'QRPGLESRC/ORDERPGM.rpgle',
+    sourceSpanIds: ['span-1'],
+    ...overrides,
+  };
+}
+
+function summary(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-summary',
+    contractId: CONTRACT_IDS.SUMMARY,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    summaryId: 'sum-1',
+    text: 'ORDERPGM appears to call CUSTINQ (inferred).',
+    sourceOfTruth: false,
+    advisory: true,
+    derivationClass: DERIVATION_CLASSES.INFERRED,
+    evidenceReferences: [{ id: 'ev-1', kind: 'source' }],
+    ...overrides,
+  };
+}
+
+function diagnostic(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-diagnostic',
+    contractId: CONTRACT_IDS.DIAGNOSTIC,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    diagnosticId: 'diag-1',
+    severity: DIAGNOSTIC_SEVERITIES.WARNING,
+    reasonCode: REASON_CODES.OMISSION_REPORTED,
+    message: 'Token budget excluded secondary copy members',
+    relatedIds: ['su-copy1'],
+    ...overrides,
+  };
+}
+
+function contextPackage(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-context-package',
+    contractId: CONTRACT_IDS.CONTEXT_PACKAGE,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    packageId: 'ctx-1',
+    policyId: 'zeus.community-default-context',
+    policyVersion: '1.0.0',
+    sourceOfTruth: false,
+    advisory: true,
+    tokenBudget: 4000,
+    selected: [
+      {
+        id: 'sym-orderpgm',
+        kind: 'symbol',
+        reasons: ['query-target'],
+      },
+    ],
+    omissions: [
+      {
+        reasonCode: REASON_CODES.TOKEN_BUDGET_EXCEEDED,
+        description: 'Secondary neighborhood omitted',
+        entityId: 'sym-other',
+      },
+    ],
+    evidenceReferences: [{ id: 'ev-1', kind: 'source' }],
+    nonClaims: ['Not a compile result', 'Not source of truth'],
+    ...overrides,
+  };
+}
+
+function operationResultOk(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-operation-result',
+    contractId: CONTRACT_IDS.OPERATION_RESULT,
+    ok: true,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+    operation: 'inspect-snapshot',
+    ...overrides,
+  };
+}
+
+function operationResultFail(overrides = {}) {
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-operation-result',
+    contractId: CONTRACT_IDS.OPERATION_RESULT,
+    ok: false,
+    reasonCode: REASON_CODES.SNAPSHOT_NOT_CURRENT,
+    message: 'Snapshot is not the current published pointer',
+    projectId: 'proj-demo',
+    snapshotId: 'snap-000',
+    operation: 'query',
+    ...overrides,
+  };
+}
+
+module.exports = {
+  HASH_A,
+  HASH_B,
+  provenance,
+  project,
+  snapshot,
+  sourceUnit,
+  sourceSpan,
+  symbol,
+  relationship,
+  analyzerRun,
+  evidence,
+  summary,
+  diagnostic,
+  contextPackage,
+  operationResultOk,
+  operationResultFail,
+};

--- a/src/projectIntelligence/helpers.js
+++ b/src/projectIntelligence/helpers.js
@@ -1,0 +1,239 @@
+'use strict';
+
+const { DEFAULT_LIMITS, CONTENT_HASH_ALGORITHMS } = require('./constants');
+
+function isPlainObject(value) {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function push(errors, path, message) {
+  errors.push({ path, message });
+}
+
+function requireObject(errors, value, path = '') {
+  if (!isPlainObject(value)) {
+    push(errors, path, 'expected an object');
+    return false;
+  }
+  return true;
+}
+
+function requireNonEmptyString(errors, value, path, { maxChars = DEFAULT_LIMITS.maxIdChars } = {}) {
+  if (typeof value !== 'string' || !value.trim()) {
+    push(errors, path, 'non-empty string is required');
+    return false;
+  }
+  if (value.length > maxChars) {
+    push(errors, path, `exceeds max length ${maxChars}`);
+    return false;
+  }
+  return true;
+}
+
+function optionalString(errors, value, path, { maxChars = DEFAULT_LIMITS.maxNameChars } = {}) {
+  if (value == null) return true;
+  if (typeof value !== 'string') {
+    push(errors, path, 'must be a string when present');
+    return false;
+  }
+  if (value.length > maxChars) {
+    push(errors, path, `exceeds max length ${maxChars}`);
+    return false;
+  }
+  return true;
+}
+
+function requireClosedEnum(errors, value, path, allowed, label = 'value') {
+  if (typeof value !== 'string' || !value.trim()) {
+    push(errors, path, `${label} is required`);
+    return false;
+  }
+  const set = Array.isArray(allowed) ? allowed : Object.values(allowed);
+  if (!set.includes(value)) {
+    push(errors, path, `${label} must be one of: ${set.join(', ')}`);
+    return false;
+  }
+  return true;
+}
+
+function requireSchemaVersion(errors, value, expected = 1) {
+  if (Number(value) !== expected) {
+    push(errors, '/schemaVersion', `expected ${expected}, got ${value}`);
+    return false;
+  }
+  return true;
+}
+
+function requireKind(errors, value, expectedKind) {
+  if (value != null && value !== expectedKind) {
+    push(errors, '/kind', `kind must be "${expectedKind}" when present`);
+    return false;
+  }
+  return true;
+}
+
+function requireContractId(errors, value, expectedId) {
+  if (value != null && value !== expectedId) {
+    push(errors, '/contractId', `contractId must be "${expectedId}" when present`);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Relative project paths only. Absolute, drive, UNC, traversal, and control
+ * characters are refused (fail-closed).
+ */
+function isSafeRelativePath(value) {
+  if (typeof value !== 'string' || !value.trim()) return false;
+  if (value.length > DEFAULT_LIMITS.maxPathChars) return false;
+  if (value.includes('\0') || /[\u0001-\u001f]/.test(value)) return false;
+  if (value.startsWith('/') || value.startsWith('\\')) return false;
+  if (/^[A-Za-z]:[\\/]/.test(value)) return false;
+  if (value.startsWith('\\\\') || value.startsWith('//')) return false;
+  const parts = value.split(/[\\/]+/);
+  if (parts.some(part => part === '..')) return false;
+  return true;
+}
+
+function requireSafeRelativePath(errors, value, path) {
+  if (typeof value !== 'string' || !value.trim()) {
+    push(errors, path, 'relative path is required');
+    return false;
+  }
+  if (!isSafeRelativePath(value)) {
+    push(errors, path, 'path must be relative and safe (no absolute, drive, UNC, or traversal)');
+    return false;
+  }
+  return true;
+}
+
+function isSha256Hex(value) {
+  return typeof value === 'string' && /^[a-f0-9]{64}$/.test(value);
+}
+
+function requireContentHash(errors, value, path) {
+  if (!isSha256Hex(value)) {
+    push(errors, path, 'content hash must be lowercase sha256 hex (64 chars)');
+    return false;
+  }
+  return true;
+}
+
+function requirePositiveInteger(errors, value, path) {
+  if (!Number.isInteger(value) || value < 1) {
+    push(errors, path, 'positive integer is required');
+    return false;
+  }
+  return true;
+}
+
+function optionalNonNegativeInteger(errors, value, path) {
+  if (value == null) return true;
+  if (!Number.isInteger(value) || value < 0) {
+    push(errors, path, 'must be a non-negative integer when present');
+    return false;
+  }
+  return true;
+}
+
+function requireArray(errors, value, path, { maxItems = DEFAULT_LIMITS.maxArrayItems } = {}) {
+  if (!Array.isArray(value)) {
+    push(errors, path, 'must be an array');
+    return false;
+  }
+  if (value.length > maxItems) {
+    push(errors, path, `exceeds max items ${maxItems}`);
+    return false;
+  }
+  return true;
+}
+
+function optionalArray(errors, value, path, { maxItems = DEFAULT_LIMITS.maxArrayItems } = {}) {
+  if (value == null) return true;
+  return requireArray(errors, value, path, { maxItems });
+}
+
+function requireBoolean(errors, value, path) {
+  if (typeof value !== 'boolean') {
+    push(errors, path, 'boolean is required');
+    return false;
+  }
+  return true;
+}
+
+function requireHashAlgorithm(errors, value, path) {
+  if (value == null) return true;
+  return requireClosedEnum(errors, value, path, CONTENT_HASH_ALGORITHMS, 'hash algorithm');
+}
+
+/**
+ * Required derivation provenance (ADR-011).
+ * sourceHash is the content hash of the primary source unit(s) used.
+ */
+function validateProvenance(errors, provenance, basePath = '/provenance') {
+  if (!requireObject(errors, provenance, basePath)) return false;
+  let ok = true;
+  ok = requireNonEmptyString(errors, provenance.projectId, `${basePath}/projectId`) && ok;
+  ok = requireNonEmptyString(errors, provenance.snapshotId, `${basePath}/snapshotId`) && ok;
+  ok = requireContentHash(errors, provenance.sourceHash, `${basePath}/sourceHash`) && ok;
+  ok = requireNonEmptyString(errors, provenance.analyzerId, `${basePath}/analyzerId`) && ok;
+  ok =
+    requireNonEmptyString(errors, provenance.analyzerVersion, `${basePath}/analyzerVersion`) && ok;
+  if (typeof provenance.derivationClass !== 'string' || !provenance.derivationClass.trim()) {
+    push(errors, `${basePath}/derivationClass`, 'derivationClass is required');
+    ok = false;
+  }
+  return ok;
+}
+
+function validateEvidenceReference(errors, ref, basePath) {
+  if (!requireObject(errors, ref, basePath)) return;
+  requireNonEmptyString(errors, ref.id, `${basePath}/id`);
+  if (ref.kind != null) {
+    optionalString(errors, ref.kind, `${basePath}/kind`, { maxChars: DEFAULT_LIMITS.maxIdChars });
+  }
+  if (ref.contractId != null) {
+    optionalString(errors, ref.contractId, `${basePath}/contractId`, {
+      maxChars: DEFAULT_LIMITS.maxIdChars,
+    });
+  }
+}
+
+function validateLinePosition(errors, value, basePath, { required = true } = {}) {
+  if (value == null) {
+    if (required) push(errors, basePath, 'position object is required');
+    return;
+  }
+  if (!requireObject(errors, value, basePath)) return;
+  if (!Number.isInteger(value.line) || value.line < 1) {
+    push(errors, `${basePath}/line`, 'line must be a positive integer');
+  }
+  optionalNonNegativeInteger(errors, value.column, `${basePath}/column`);
+  optionalNonNegativeInteger(errors, value.offset, `${basePath}/offset`);
+}
+
+module.exports = {
+  isPlainObject,
+  push,
+  requireObject,
+  requireNonEmptyString,
+  optionalString,
+  requireClosedEnum,
+  requireSchemaVersion,
+  requireKind,
+  requireContractId,
+  isSafeRelativePath,
+  requireSafeRelativePath,
+  isSha256Hex,
+  requireContentHash,
+  requirePositiveInteger,
+  optionalNonNegativeInteger,
+  requireArray,
+  optionalArray,
+  requireBoolean,
+  requireHashAlgorithm,
+  validateProvenance,
+  validateEvidenceReference,
+  validateLinePosition,
+};

--- a/src/projectIntelligence/index.js
+++ b/src/projectIntelligence/index.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * Zeus Project Intelligence — Community Knowledge Contract Kit (ZPI-02).
+ *
+ * Contracts, closed enums, reason codes, validators, fixtures, and a contract
+ * test kit. No persistence, search, analyzers, CLI, or MCP adapters.
+ */
+
+const constants = require('./constants');
+const CONTRACT_IDS = require('./contractIds');
+const contracts = require('./contracts');
+const helpers = require('./helpers');
+const fixtures = require('./fixtures');
+const validate = require('./validate');
+const { runProjectIntelligenceContractTests } = require('./contractTestKit');
+
+module.exports = {
+  // Vocabulary
+  ...constants,
+  CONTRACT_IDS,
+
+  // Schemas
+  PROJECT_INTELLIGENCE_SCHEMAS: contracts.PROJECT_INTELLIGENCE_SCHEMAS,
+  projectSchema: contracts.projectSchema,
+  snapshotSchema: contracts.snapshotSchema,
+  sourceUnitSchema: contracts.sourceUnitSchema,
+  sourceSpanSchema: contracts.sourceSpanSchema,
+  symbolSchema: contracts.symbolSchema,
+  relationshipSchema: contracts.relationshipSchema,
+  analyzerRunSchema: contracts.analyzerRunSchema,
+  evidenceSchema: contracts.evidenceSchema,
+  summarySchema: contracts.summarySchema,
+  diagnosticSchema: contracts.diagnosticSchema,
+  contextPackageSchema: contracts.contextPackageSchema,
+  operationResultSchema: contracts.operationResultSchema,
+
+  // Helpers
+  isSafeRelativePath: helpers.isSafeRelativePath,
+  isSha256Hex: helpers.isSha256Hex,
+  validateProvenance: helpers.validateProvenance,
+
+  // Validation API
+  registerProjectIntelligenceSchemas: validate.registerProjectIntelligenceSchemas,
+  createProjectIntelligenceRegistry: validate.createProjectIntelligenceRegistry,
+  validateProjectIntelligenceContract: validate.validateProjectIntelligenceContract,
+  createValidators: validate.createValidators,
+
+  // Fixtures + contract test kit
+  fixtures,
+  runProjectIntelligenceContractTests,
+};

--- a/src/projectIntelligence/validate.js
+++ b/src/projectIntelligence/validate.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const { createSchemaRegistry } = require('../core/contracts/schemaRegistry');
+const { normalizeValidationErrors } = require('../core/contracts/errors');
+const { PROJECT_INTELLIGENCE_SCHEMAS, CONTRACT_IDS } = require('./contracts');
+const { REASON_CODES, REASON_CODE_MESSAGES } = require('./constants');
+
+/**
+ * Register all Project Intelligence schemas into a schema registry.
+ */
+function registerProjectIntelligenceSchemas(registry) {
+  if (!registry || typeof registry.register !== 'function') {
+    throw new Error('schema registry is required');
+  }
+  for (const [id, { version, schema }] of Object.entries(PROJECT_INTELLIGENCE_SCHEMAS)) {
+    registry.register({ id, version, schema });
+  }
+  return registry;
+}
+
+/**
+ * Create a schema registry preloaded with ZPI contracts only.
+ */
+function createProjectIntelligenceRegistry() {
+  const registry = createSchemaRegistry();
+  registerProjectIntelligenceSchemas(registry);
+  return registry;
+}
+
+/**
+ * Validate a value against a named ZPI contract.
+ * @returns {{ ok: true, value } | { ok: false, errors: Array, reasonCode: string, message: string }}
+ */
+function validateProjectIntelligenceContract(contractId, value, options = {}) {
+  const version = options.version == null ? 1 : options.version;
+  const registry = options.registry || createProjectIntelligenceRegistry();
+
+  if (!PROJECT_INTELLIGENCE_SCHEMAS[contractId] && !registry.hasContract(contractId, version)) {
+    return {
+      ok: false,
+      errors: normalizeValidationErrors([
+        { path: '', message: `Unknown project intelligence contract: ${contractId}` },
+      ]),
+      reasonCode: REASON_CODES.SCHEMA_VERSION_UNSUPPORTED,
+      message: REASON_CODE_MESSAGES[REASON_CODES.SCHEMA_VERSION_UNSUPPORTED],
+    };
+  }
+
+  const result = registry.validate(contractId, version, value);
+  if (result.ok) {
+    return { ok: true, value: result.value };
+  }
+
+  const hasVersionError = (result.errors || []).some(
+    e => e.path === '/schemaVersion' || /unsupported version/i.test(e.message || '')
+  );
+  const reasonCode = hasVersionError
+    ? REASON_CODES.SCHEMA_VERSION_UNSUPPORTED
+    : REASON_CODES.SCHEMA_INVALID;
+
+  return {
+    ok: false,
+    errors: result.errors,
+    reasonCode,
+    message: REASON_CODE_MESSAGES[reasonCode],
+  };
+}
+
+/**
+ * Map of contract key -> validate helper for convenience.
+ */
+function createValidators(registry = createProjectIntelligenceRegistry()) {
+  const out = {};
+  for (const id of Object.keys(PROJECT_INTELLIGENCE_SCHEMAS)) {
+    const key = id.replace(/^zeus\.project-knowledge-/, '').replace(/-/g, '_');
+    out[key] = value => validateProjectIntelligenceContract(id, value, { registry });
+  }
+  return out;
+}
+
+module.exports = {
+  CONTRACT_IDS,
+  registerProjectIntelligenceSchemas,
+  createProjectIntelligenceRegistry,
+  validateProjectIntelligenceContract,
+  createValidators,
+};

--- a/tests/project-intelligence-contracts.test.js
+++ b/tests/project-intelligence-contracts.test.js
@@ -1,0 +1,202 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const projectIntelligence = require('../src/projectIntelligence');
+const {
+  CONTRACT_IDS,
+  DERIVATION_CLASSES,
+  REASON_CODES,
+  PROJECT_INTELLIGENCE_SCHEMAS,
+  validateProjectIntelligenceContract,
+  createProjectIntelligenceRegistry,
+  runProjectIntelligenceContractTests,
+  fixtures,
+  projectSchema,
+  symbolSchema,
+  sourceUnitSchema,
+  contextPackageSchema,
+  operationResultSchema,
+  isSafeRelativePath,
+} = projectIntelligence;
+
+const { createSchemaRegistry } = require('../src/core/contracts');
+const { CONTRACT_IDS: CORE_IDS, INITIAL_SCHEMAS } = require('../src/core/contracts/schemas');
+const { createZeus } = require('../src/api/zeusApi');
+
+test('ZPI contract ids are registered in INITIAL_SCHEMAS and core CONTRACT_IDS', () => {
+  for (const id of Object.values(CONTRACT_IDS)) {
+    assert.ok(INITIAL_SCHEMAS[id], `missing INITIAL_SCHEMAS entry for ${id}`);
+    assert.equal(INITIAL_SCHEMAS[id].version, 1);
+  }
+  assert.equal(CORE_IDS.PROJECT_KNOWLEDGE_PROJECT, CONTRACT_IDS.PROJECT);
+  assert.equal(CORE_IDS.PROJECT_KNOWLEDGE_OPERATION_RESULT, CONTRACT_IDS.OPERATION_RESULT);
+  assert.equal(Object.keys(PROJECT_INTELLIGENCE_SCHEMAS).length, 12);
+});
+
+test('package export surface is available via api createZeus', () => {
+  const api = createZeus();
+  assert.ok(api.projectIntelligence);
+  assert.equal(api.projectIntelligence.CONTRACT_IDS.PROJECT, CONTRACT_IDS.PROJECT);
+  assert.equal(typeof api.projectIntelligence.validateProjectIntelligenceContract, 'function');
+});
+
+test('valid fixtures pass schema validation', () => {
+  const cases = [
+    [CONTRACT_IDS.PROJECT, fixtures.project()],
+    [CONTRACT_IDS.SNAPSHOT, fixtures.snapshot()],
+    [CONTRACT_IDS.SOURCE_UNIT, fixtures.sourceUnit()],
+    [CONTRACT_IDS.SOURCE_SPAN, fixtures.sourceSpan()],
+    [CONTRACT_IDS.SYMBOL, fixtures.symbol()],
+    [CONTRACT_IDS.RELATIONSHIP, fixtures.relationship()],
+    [CONTRACT_IDS.ANALYZER_RUN, fixtures.analyzerRun()],
+    [CONTRACT_IDS.EVIDENCE, fixtures.evidence()],
+    [CONTRACT_IDS.SUMMARY, fixtures.summary()],
+    [CONTRACT_IDS.DIAGNOSTIC, fixtures.diagnostic()],
+    [CONTRACT_IDS.CONTEXT_PACKAGE, fixtures.contextPackage()],
+    [CONTRACT_IDS.OPERATION_RESULT, fixtures.operationResultOk()],
+    [CONTRACT_IDS.OPERATION_RESULT, fixtures.operationResultFail()],
+  ];
+  for (const [id, value] of cases) {
+    const result = validateProjectIntelligenceContract(id, value);
+    assert.equal(result.ok, true, `${id}: ${JSON.stringify(result.errors)}`);
+  }
+});
+
+test('unknown schema version fails closed with stable reason code', () => {
+  const result = validateProjectIntelligenceContract(
+    CONTRACT_IDS.SNAPSHOT,
+    fixtures.snapshot({ schemaVersion: 2 })
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.reasonCode, REASON_CODES.SCHEMA_VERSION_UNSUPPORTED);
+  assert.ok(result.errors.some(e => e.path === '/schemaVersion'));
+});
+
+test('unknown enum values fail closed', () => {
+  assert.ok(
+    symbolSchema(
+      fixtures.symbol({
+        symbolKind: 'NOT_A_KIND',
+        provenance: fixtures.provenance({ derivationClass: DERIVATION_CLASSES.INFERRED }),
+        evidenceReferences: undefined,
+      })
+    ).some(e => e.path === '/symbolKind')
+  );
+  assert.ok(
+    projectIntelligence
+      .diagnosticSchema(fixtures.diagnostic({ reasonCode: 'ZPI.NOT_REAL' }))
+      .some(e => e.path === '/reasonCode')
+  );
+});
+
+test('VERIFIED requires evidence references', () => {
+  const errors = symbolSchema(
+    fixtures.symbol({
+      provenance: fixtures.provenance({ derivationClass: DERIVATION_CLASSES.VERIFIED }),
+      evidenceReferences: [],
+    })
+  );
+  assert.ok(errors.some(e => e.path === '/evidenceReferences'));
+});
+
+test('derived packages cannot claim source of truth', () => {
+  assert.ok(
+    projectIntelligence
+      .summarySchema(fixtures.summary({ sourceOfTruth: true }))
+      .some(e => e.path === '/sourceOfTruth')
+  );
+  assert.ok(
+    contextPackageSchema(fixtures.contextPackage({ sourceOfTruth: true })).some(
+      e => e.path === '/sourceOfTruth'
+    )
+  );
+  assert.ok(
+    projectIntelligence
+      .summarySchema(fixtures.summary({ derivationClass: DERIVATION_CLASSES.VERIFIED }))
+      .some(e => e.path === '/derivationClass')
+  );
+});
+
+test('source unit relative paths reject traversal and absolute forms', () => {
+  const badPaths = [
+    '../escape.rpgle',
+    '/etc/passwd',
+    'C:\\Windows\\a.rpgle',
+    '\\\\server\\share\\a.rpgle',
+    'a\u0000b.rpgle',
+  ];
+  for (const relativePath of badPaths) {
+    assert.equal(isSafeRelativePath(relativePath), false, relativePath);
+    const errors = sourceUnitSchema(fixtures.sourceUnit({ relativePath }));
+    assert.ok(
+      errors.some(e => e.path === '/relativePath'),
+      `expected path error for ${relativePath}`
+    );
+  }
+  assert.equal(sourceUnitSchema(fixtures.sourceUnit()).length, 0);
+});
+
+test('content hash must be lowercase sha256 hex', () => {
+  const errors = sourceUnitSchema(fixtures.sourceUnit({ contentHash: 'NOT-A-HASH' }));
+  assert.ok(errors.some(e => e.path === '/contentHash'));
+});
+
+test('failed operation results require reasonCode and message', () => {
+  assert.equal(operationResultSchema(fixtures.operationResultFail()).length, 0);
+  const missing = operationResultSchema(
+    fixtures.operationResultFail({ reasonCode: undefined, message: undefined })
+  );
+  assert.ok(missing.some(e => e.path === '/reasonCode'));
+  assert.ok(missing.some(e => e.path === '/message'));
+});
+
+test('context package omissions require closed reason codes', () => {
+  const errors = contextPackageSchema(
+    fixtures.contextPackage({
+      omissions: [{ reasonCode: 'OPEN_ENDED', description: 'x' }],
+    })
+  );
+  assert.ok(errors.some(e => e.path === '/omissions/0/reasonCode'));
+});
+
+test('registry validation matches direct schema functions', () => {
+  const registry = createProjectIntelligenceRegistry();
+  const direct = projectSchema(fixtures.project());
+  const via = registry.validate(CONTRACT_IDS.PROJECT, 1, fixtures.project());
+  assert.equal(direct.length, 0);
+  assert.equal(via.ok, true);
+
+  const bad = registry.validate(CONTRACT_IDS.PROJECT, 1, { schemaVersion: 1 });
+  assert.equal(bad.ok, false);
+  assert.ok(bad.errors.some(e => e.path === '/projectId'));
+});
+
+test('core INITIAL_SCHEMAS registry accepts ZPI contracts', () => {
+  const registry = createSchemaRegistry();
+  for (const [id, { version, schema }] of Object.entries(INITIAL_SCHEMAS)) {
+    registry.register({ id, version, schema });
+  }
+  const result = registry.validate(CONTRACT_IDS.CONTEXT_PACKAGE, 1, fixtures.contextPackage());
+  assert.equal(result.ok, true);
+});
+
+test('public contract test kit passes', async () => {
+  const report = await runProjectIntelligenceContractTests();
+  assert.equal(report.ok, true);
+  assert.ok(report.results.length >= 10);
+  assert.ok(report.results.every(r => r.ok));
+});
+
+test('reason code messages are complete and free of host-path leakage', () => {
+  for (const [key, code] of Object.entries(REASON_CODES)) {
+    assert.equal(typeof projectIntelligence.REASON_CODE_MESSAGES[code], 'string', key);
+    const msg = projectIntelligence.REASON_CODE_MESSAGES[code];
+    assert.ok(!msg.includes('C:\\'), key);
+    assert.ok(!msg.includes('/Users/'), key);
+    assert.ok(!msg.includes('\\\\server'), key);
+    // Messages may mention the concept of secrets, but must not embed values.
+    assert.ok(!/=[A-Za-z0-9+/=]{16,}/.test(msg), key);
+  }
+});


### PR DESCRIPTION
## Summary

- Implements **ZPI-02 (Community Knowledge Contract Kit)** from the Zeus Project Intelligence plan.
- Adds versioned project-knowledge contracts (project, snapshot, source unit/span, symbol, relationship, analyzer run, evidence, summary, diagnostic, context package, operation result).
- Freezes closed derivation classes, symbol/relationship catalogs, and fail-closed `ZPI.*` reason codes with stable messages.
- Provides validators, synthetic fixtures, registry integration (`INITIAL_SCHEMAS`), API export, and public package export `zeus-rpg-promptkit/project-intelligence-contracts`.
- **Out of scope (intentional):** SQLite/Lucene/content stores, analyzers, CLI/MCP adapters, Commercial module — those are ZPI-03+.

## Architecture notes

- Knowledge remains contract-only; source evidence authority rules (ADR-011) are enforced: `VERIFIED` requires evidence; summaries/context packages must set `sourceOfTruth: false`.
- Package 09 stays closed; no live IBM i runtime behavior.

## Test plan

- [x] `node --test tests/project-intelligence-contracts.test.js`
- [x] `npm run test:contract`
- [x] `npm run test:unit`
- [x] `npm run test:smoke`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `npm run check:public-knowledge-claims`
- [x] `npm run docs:check`
- [x] `npm run check:repo-portability`
- [x] `npm run test:release-integrity`
- [x] `npm run package:smoke`

## Next package

ZPI-03 — Store SPI and SQLite provider (no Lucene yet).