### PR TITLE
feat: ZPI-03 SQLite knowledge store SPI

### DIFF
--- a/docs/knowledgebase/README.md
+++ b/docs/knowledgebase/README.md
@@ -28,9 +28,11 @@ Current implementation status:
 - `src/knowledge/` now contains a skeleton with `raw/`, `sanitized/`, `final/`, and `privacy/` boundaries
 - no runtime extractor or persistence is implemented yet
 - the privacy gate is fail-closed and rejects malformed or suspicious final-catalog candidates
-- **ZPI-02 (contracts only):** `src/projectIntelligence/` provides versioned project-knowledge
-  contracts, closed reason codes, validators, fixtures, and a contract test kit — still no
-  store, search, analyzer runtime, CLI, or MCP adapters
+- **ZPI-02 (contracts):** `src/projectIntelligence/` versioned project-knowledge contracts, closed
+  reason codes, validators, fixtures, and a contract test kit
+- **ZPI-03 (store):** `src/projectIntelligence/store/` KnowledgeStore SPI + SQLite metadata provider
+  (`node:sqlite`), writer locks, migrations, integrity checks — still no content store, Lucene,
+  analyzer runtime, CLI, or MCP adapters
 
 Local risk handling:
 

--- a/docs/knowledgebase/zpi-license-inventory.md
+++ b/docs/knowledgebase/zpi-license-inventory.md
@@ -55,12 +55,20 @@ ZPI implementation packages must preserve or establish:
 - Commercial policy modules do not relicense the Community pin.
 - Raw user project data portability is separate from dependency attribution obligations.
 
+## Resolved in ZPI-03 (SQLite binding)
+
+| Decision            | Choice                                                           | Notes                                                                             |
+| ------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| SQLite runtime      | Node.js built-in `node:sqlite` (`DatabaseSync`)                  | No extra npm dependency; SQLite public-domain engine via Node                     |
+| Native npm binding  | Not selected                                                     | Avoids better-sqlite3 native compile / prebuild SBOM surface                      |
+| Pure-JS sql.js      | Not selected for default                                         | Reserved as future fallback if engines must stay on Node 20 without `node:sqlite` |
+| Runtime requirement | Store operations require a Node build that exposes `node:sqlite` | Probe via `probeNodeSqlite()`; fail closed with `ZPI.STORE_UNAVAILABLE`           |
+
 ## Unresolved decisions
 
-- exact SQLite runtime package or binding
 - exact Lucene runtime package, bridge, or hosting strategy
-- whether any selected binding adds native compilation or bundled binaries
-- what Community `NOTICE` or third-party attribution process will be used once concrete packages are
+- whether Lucene binding adds native compilation or bundled binaries
+- what Community `NOTICE` or third-party attribution process will be used once Lucene packages are
   chosen
 - whether future optional embedding or vector packages introduce new redistribution or model-license
   constraints

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -9,8 +9,8 @@ This directory is the home for versioned domain contract documentation.
 - Module descriptor contracts: `src/modules/`.
 - **Project Intelligence contracts (ZPI-02):** `src/projectIntelligence/`.
 
-Full structural definitions and producers/consumers for later ZPI packages
-(store, search, analyzers) will land in subsequent work packages.
+ZPI-03 adds the SQLite metadata store under `src/projectIntelligence/store/` (no Lucene/content
+store yet). Search and analyzer packages remain later.
 
 ## Contract IDs (stable)
 

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -21,6 +21,7 @@ module.exports = {
       'tests/workflow-presets.test.js',
       'tests/community-deployment.test.js',
       'tests/project-intelligence-contracts.test.js',
+      'tests/project-intelligence-store.test.js',
     ],
     smoke: [
       'tests/reproducible-output.test.js',

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -862,8 +862,8 @@ const zeus = {
   // Generation Validation Foundation (Iteration 29): offline candidate validation.
   // Never mutates the analyzed source workspace. review-ready is not compile readiness.
   generationValidation,
-  // Project Intelligence contract kit (ZPI-02): validators and reason codes only.
-  // No store/search/analyzer runtime, CLI, or MCP adapters in this package.
+  // Project Intelligence (ZPI-02 contracts + ZPI-03 SQLite store SPI).
+  // No Lucene/content-store/analyzer/CLI/MCP adapters yet.
   projectIntelligence,
   // External module contracts (Iteration 30): trusted in-process registration only.
   // Core does not parse licenses or enforce commercial entitlement.

--- a/src/projectIntelligence/index.js
+++ b/src/projectIntelligence/index.js
@@ -1,10 +1,12 @@
 'use strict';
 
 /**
- * Zeus Project Intelligence — Community Knowledge Contract Kit (ZPI-02).
+ * Zeus Project Intelligence — Community contracts (ZPI-02) and store (ZPI-03).
  *
- * Contracts, closed enums, reason codes, validators, fixtures, and a contract
- * test kit. No persistence, search, analyzers, CLI, or MCP adapters.
+ * ZPI-02: contracts, reason codes, validators, fixtures, contract test kit.
+ * ZPI-03: KnowledgeStore SPI + SQLite metadata provider, locks, migrations.
+ *
+ * Not included yet: content store, Lucene, analyzers, CLI/MCP.
  */
 
 const constants = require('./constants');
@@ -14,6 +16,7 @@ const helpers = require('./helpers');
 const fixtures = require('./fixtures');
 const validate = require('./validate');
 const { runProjectIntelligenceContractTests } = require('./contractTestKit');
+const store = require('./store');
 
 module.exports = {
   // Vocabulary
@@ -49,4 +52,11 @@ module.exports = {
   // Fixtures + contract test kit
   fixtures,
   runProjectIntelligenceContractTests,
+
+  // Knowledge store (ZPI-03)
+  store,
+  createProjectKnowledgeStore: store.createProjectKnowledgeStore,
+  openProjectKnowledgeStore: store.openProjectKnowledgeStore,
+  KnowledgeStoreError: store.KnowledgeStoreError,
+  probeNodeSqlite: store.probeNodeSqlite,
 };

--- a/src/projectIntelligence/store/constants.js
+++ b/src/projectIntelligence/store/constants.js
@@ -1,0 +1,51 @@
+'use strict';
+
+/** Community SQLite metadata schema version (independent of search/content). */
+const STORE_SCHEMA_VERSION = 1;
+
+/** Relative layout under a project-knowledge root (ADR layout). */
+const LAYOUT = Object.freeze({
+  MANIFEST: 'manifest.json',
+  SQLITE: 'knowledge.sqlite',
+  LOCKS_DIR: 'locks',
+  WRITER_LOCK: 'locks/writer.lock',
+  CONTENT_DIR: 'content',
+  LUCENE_DIR: 'lucene',
+  SNAPSHOTS_DIR: 'snapshots',
+  REPORTS_DIR: 'reports',
+  QUARANTINE_DIR: 'quarantine',
+});
+
+const STORE_MODES = Object.freeze({
+  CREATE: 'create',
+  OPEN: 'open',
+  READ_ONLY: 'readOnly',
+});
+
+const STORE_STATES = Object.freeze({
+  CLOSED: 'closed',
+  OPEN: 'open',
+  SEALED: 'sealed',
+});
+
+/** Default stale writer-lock age (30 minutes). */
+const DEFAULT_STALE_LOCK_MS = 30 * 60 * 1000;
+
+const META_KEYS = Object.freeze({
+  STORE_SCHEMA_VERSION: 'storeSchemaVersion',
+  CREATED_AT: 'createdAt',
+  OPENED_AT: 'openedAt',
+  SEALED_AT: 'sealedAt',
+  PROJECT_ID: 'projectId',
+  DRIVER: 'driver',
+  INTEGRITY_EPOCH: 'integrityEpoch',
+});
+
+module.exports = {
+  STORE_SCHEMA_VERSION,
+  LAYOUT,
+  STORE_MODES,
+  STORE_STATES,
+  DEFAULT_STALE_LOCK_MS,
+  META_KEYS,
+};

--- a/src/projectIntelligence/store/createStore.js
+++ b/src/projectIntelligence/store/createStore.js
@@ -1,0 +1,233 @@
+'use strict';
+
+const fs = require('fs');
+const { STORE_SCHEMA_VERSION, STORE_MODES, META_KEYS } = require('./constants');
+const { ensureLayoutDirs, knowledgePaths, readManifest, writeManifestAtomic } = require('./layout');
+const { acquireWriterLock, inspectWriterLock } = require('./writerLock');
+const { createSqliteKnowledgeStore } = require('./sqliteKnowledgeStore');
+const { probeNodeSqlite, DRIVER_ID } = require('./sqliteDriver');
+const { fail, REASON_CODES, KnowledgeStoreError } = require('./errors');
+
+/**
+ * Create a new project-knowledge store on disk.
+ * Acquires the writer lock for the lifetime of the returned handle.
+ */
+function createProjectKnowledgeStore({ rootPath, projectId, displayName, trustedRoots } = {}) {
+  if (typeof projectId !== 'string' || !projectId.trim()) {
+    fail(REASON_CODES.PROJECT_ID_INVALID, 'projectId is required');
+  }
+  if (!probeNodeSqlite().available) {
+    fail(
+      REASON_CODES.STORE_UNAVAILABLE,
+      'SQLite driver unavailable (requires Node.js node:sqlite / DatabaseSync)'
+    );
+  }
+
+  const paths = ensureLayoutDirs(rootPath);
+  if (fs.existsSync(paths.sqlite) || fs.existsSync(paths.manifest)) {
+    fail(REASON_CODES.STORE_UNAVAILABLE, 'project knowledge store already exists at root');
+  }
+
+  const lock = acquireWriterLock(paths.writerLock, { owner: `create:${projectId}` });
+  let store;
+  try {
+    store = createSqliteKnowledgeStore({
+      dbPath: paths.sqlite,
+      projectId,
+      readOnly: false,
+    });
+
+    const project = {
+      schemaVersion: 1,
+      kind: 'project-knowledge-project',
+      contractId: 'zeus.project-knowledge-project',
+      projectId,
+      displayName: displayName || projectId,
+      trustedRoots: trustedRoots || [{ rootId: 'root-default', relativeLabel: 'src' }],
+      schemaBindings: {
+        storeSchemaVersion: STORE_SCHEMA_VERSION,
+        searchSchemaVersion: 1,
+        artifactSchemaVersion: 1,
+      },
+      safety: { level: 'S1', localOnly: true },
+    };
+    store.putProject(project);
+
+    writeManifestAtomic(paths.root, {
+      schemaVersion: 1,
+      kind: 'project-knowledge-manifest',
+      projectId,
+      storeSchemaVersion: STORE_SCHEMA_VERSION,
+      driver: DRIVER_ID,
+      createdAt: new Date().toISOString(),
+      layout: {
+        sqlite: 'knowledge.sqlite',
+        content: 'content/',
+        lucene: 'lucene/',
+        locks: 'locks/',
+      },
+    });
+  } catch (err) {
+    try {
+      lock.release();
+    } catch {
+      // ignore
+    }
+    if (store) {
+      try {
+        store.close();
+      } catch {
+        // ignore
+      }
+    }
+    if (err instanceof KnowledgeStoreError) throw err;
+    fail(REASON_CODES.STORE_UNAVAILABLE, 'failed to create project knowledge store', {
+      message: err && err.message ? String(err.message) : undefined,
+    });
+  }
+
+  return wrapHandle({ store, lock, paths, mode: STORE_MODES.CREATE, projectId });
+}
+
+/**
+ * Open an existing project-knowledge store.
+ */
+function openProjectKnowledgeStore({ rootPath, projectId, readOnly = false } = {}) {
+  const paths = knowledgePaths(rootPath);
+  if (!fs.existsSync(paths.sqlite)) {
+    fail(REASON_CODES.STORE_UNAVAILABLE, 'project knowledge sqlite file not found');
+  }
+
+  const manifest = readManifest(paths.root);
+  const resolvedProjectId = projectId || (manifest && manifest.projectId) || null;
+  if (!resolvedProjectId) {
+    fail(
+      REASON_CODES.PROJECT_ID_INVALID,
+      'projectId is required when manifest is missing projectId'
+    );
+  }
+  if (manifest && manifest.projectId && projectId && manifest.projectId !== projectId) {
+    fail(REASON_CODES.PROJECT_ID_INVALID, 'projectId does not match store manifest');
+  }
+  if (manifest && manifest.storeSchemaVersion != null) {
+    const v = Number(manifest.storeSchemaVersion);
+    if (Number.isInteger(v) && v > STORE_SCHEMA_VERSION) {
+      fail(
+        REASON_CODES.MIGRATION_UNSUPPORTED,
+        'manifest requires unsupported future store schema',
+        {
+          version: v,
+        }
+      );
+    }
+  }
+
+  if (!probeNodeSqlite().available) {
+    fail(
+      REASON_CODES.STORE_UNAVAILABLE,
+      'SQLite driver unavailable (requires Node.js node:sqlite / DatabaseSync)'
+    );
+  }
+
+  let lock = null;
+  if (!readOnly) {
+    lock = acquireWriterLock(paths.writerLock, { owner: `open:${resolvedProjectId}` });
+  }
+
+  let store;
+  try {
+    store = createSqliteKnowledgeStore({
+      dbPath: paths.sqlite,
+      projectId: resolvedProjectId,
+      readOnly,
+    });
+    // Touch project existence for writable opens.
+    if (!readOnly) {
+      store.getProject(resolvedProjectId);
+    }
+  } catch (err) {
+    if (lock) {
+      try {
+        lock.release();
+      } catch {
+        // ignore
+      }
+    }
+    if (store) {
+      try {
+        store.close();
+      } catch {
+        // ignore
+      }
+    }
+    if (err instanceof KnowledgeStoreError) throw err;
+    fail(REASON_CODES.STORE_UNAVAILABLE, 'failed to open project knowledge store', {
+      message: err && err.message ? String(err.message) : undefined,
+    });
+  }
+
+  return wrapHandle({
+    store,
+    lock,
+    paths,
+    mode: readOnly ? STORE_MODES.READ_ONLY : STORE_MODES.OPEN,
+    projectId: resolvedProjectId,
+  });
+}
+
+function wrapHandle({ store, lock, paths, mode, projectId }) {
+  let closed = false;
+
+  function close() {
+    if (closed) return;
+    closed = true;
+    try {
+      store.close();
+    } finally {
+      if (lock) {
+        try {
+          lock.release();
+        } catch {
+          // ignore release races in tests
+        }
+      }
+    }
+  }
+
+  return {
+    projectId,
+    mode,
+    paths,
+    lock: lock ? { token: lock.token, acquiredAt: lock.acquiredAt, path: lock.lockPath } : null,
+    getStatus: () => store.getStatus(),
+    checkIntegrity: () => store.checkIntegrity(),
+    withTransaction: fn => store.withTransaction(fn),
+    putProject: p => store.putProject(p),
+    getProject: id => store.getProject(id),
+    putSnapshot: s => store.putSnapshot(s),
+    getSnapshot: (pid, sid) => store.getSnapshot(pid, sid),
+    listSnapshots: pid => store.listSnapshots(pid),
+    publishSnapshot: (pid, sid, opts) => store.publishSnapshot(pid, sid, opts),
+    getCurrentSnapshot: pid => store.getCurrentSnapshot(pid),
+    putSourceUnit: u => store.putSourceUnit(u),
+    listSourceUnits: (pid, sid) => store.listSourceUnits(pid, sid),
+    putSymbol: s => store.putSymbol(s),
+    listSymbols: (pid, sid) => store.listSymbols(pid, sid),
+    putRelationship: r => store.putRelationship(r),
+    listRelationships: (pid, sid) => store.listRelationships(pid, sid),
+    putAnalyzerRun: r => store.putAnalyzerRun(r),
+    putEvidenceMeta: e => store.putEvidenceMeta(e),
+    seal: () => store.seal(),
+    close,
+    // test hooks
+    _store: store,
+    _inspectLock: () => inspectWriterLock(paths.writerLock),
+  };
+}
+
+module.exports = {
+  createProjectKnowledgeStore,
+  openProjectKnowledgeStore,
+  STORE_MODES,
+  META_KEYS,
+};

--- a/src/projectIntelligence/store/errors.js
+++ b/src/projectIntelligence/store/errors.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { REASON_CODES, REASON_CODE_MESSAGES } = require('../constants');
+
+class KnowledgeStoreError extends Error {
+  /**
+   * @param {string} reasonCode closed ZPI reason code
+   * @param {string} [message]
+   * @param {object} [details]
+   */
+  constructor(reasonCode, message, details = undefined) {
+    const code = REASON_CODES[reasonCode] ? REASON_CODES[reasonCode] : reasonCode;
+    const safeMessage =
+      typeof message === 'string' && message.trim()
+        ? message
+        : REASON_CODE_MESSAGES[code] || REASON_CODE_MESSAGES[REASON_CODES.STORE_UNAVAILABLE];
+    super(safeMessage);
+    this.name = 'KnowledgeStoreError';
+    this.reasonCode = code;
+    this.details = details && typeof details === 'object' ? details : undefined;
+  }
+}
+
+function fail(reasonCode, message, details) {
+  throw new KnowledgeStoreError(reasonCode, message, details);
+}
+
+module.exports = {
+  KnowledgeStoreError,
+  fail,
+  REASON_CODES,
+};

--- a/src/projectIntelligence/store/index.js
+++ b/src/projectIntelligence/store/index.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * Project Intelligence Knowledge Store (ZPI-03).
+ *
+ * Community SPI + SQLite metadata provider.
+ * No Lucene, no content-addressed blob store, no CLI/MCP.
+ */
+
+const constants = require('./constants');
+const errors = require('./errors');
+const layout = require('./layout');
+const writerLock = require('./writerLock');
+const migrations = require('./migrations');
+const sqliteDriver = require('./sqliteDriver');
+const { createSqliteKnowledgeStore } = require('./sqliteKnowledgeStore');
+const { createProjectKnowledgeStore, openProjectKnowledgeStore } = require('./createStore');
+
+module.exports = {
+  // lifecycle factory (preferred SPI entry)
+  createProjectKnowledgeStore,
+  openProjectKnowledgeStore,
+
+  // lower-level building blocks
+  createSqliteKnowledgeStore,
+  probeNodeSqlite: sqliteDriver.probeNodeSqlite,
+  DRIVER_ID: sqliteDriver.DRIVER_ID,
+
+  // layout / locks / migrations
+  ...constants,
+  knowledgePaths: layout.knowledgePaths,
+  resolveKnowledgeRoot: layout.resolveKnowledgeRoot,
+  ensureLayoutDirs: layout.ensureLayoutDirs,
+  acquireWriterLock: writerLock.acquireWriterLock,
+  inspectWriterLock: writerLock.inspectWriterLock,
+  isLockStale: writerLock.isLockStale,
+  MIGRATIONS: migrations.MIGRATIONS,
+  assertCompatibleSchemaVersion: migrations.assertCompatibleSchemaVersion,
+
+  // errors
+  KnowledgeStoreError: errors.KnowledgeStoreError,
+};

--- a/src/projectIntelligence/store/layout.js
+++ b/src/projectIntelligence/store/layout.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { LAYOUT } = require('./constants');
+const { fail, REASON_CODES } = require('./errors');
+
+/**
+ * Resolve and validate a project-knowledge root directory.
+ * Absolute path required after resolve; must not contain `..` segments after normalize.
+ */
+function resolveKnowledgeRoot(rootPath) {
+  if (typeof rootPath !== 'string' || !rootPath.trim()) {
+    fail(REASON_CODES.PATH_UNSAFE, 'knowledge root path is required');
+  }
+  const resolved = path.resolve(rootPath);
+  const normalized = path.normalize(resolved);
+  if (normalized.includes(`..${path.sep}`) || normalized.endsWith('..')) {
+    fail(REASON_CODES.PATH_TRAVERSAL, 'knowledge root path must not contain parent traversal');
+  }
+  return normalized;
+}
+
+function knowledgePaths(rootPath) {
+  const root = resolveKnowledgeRoot(rootPath);
+  return Object.freeze({
+    root,
+    manifest: path.join(root, LAYOUT.MANIFEST),
+    sqlite: path.join(root, LAYOUT.SQLITE),
+    locksDir: path.join(root, LAYOUT.LOCKS_DIR),
+    writerLock: path.join(root, LAYOUT.WRITER_LOCK),
+    contentDir: path.join(root, LAYOUT.CONTENT_DIR),
+    luceneDir: path.join(root, LAYOUT.LUCENE_DIR),
+    snapshotsDir: path.join(root, LAYOUT.SNAPSHOTS_DIR),
+    reportsDir: path.join(root, LAYOUT.REPORTS_DIR),
+    quarantineDir: path.join(root, LAYOUT.QUARANTINE_DIR),
+  });
+}
+
+function ensureLayoutDirs(rootPath, { createContent = true } = {}) {
+  const paths = knowledgePaths(rootPath);
+  fs.mkdirSync(paths.root, { recursive: true });
+  fs.mkdirSync(paths.locksDir, { recursive: true });
+  fs.mkdirSync(paths.snapshotsDir, { recursive: true });
+  fs.mkdirSync(paths.reportsDir, { recursive: true });
+  fs.mkdirSync(paths.quarantineDir, { recursive: true });
+  if (createContent) {
+    fs.mkdirSync(paths.contentDir, { recursive: true });
+    fs.mkdirSync(paths.luceneDir, { recursive: true });
+  }
+  return paths;
+}
+
+function readManifest(rootPath) {
+  const { manifest } = knowledgePaths(rootPath);
+  if (!fs.existsSync(manifest)) return null;
+  try {
+    const raw = fs.readFileSync(manifest, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    fail(REASON_CODES.STORE_CORRUPT, 'project knowledge manifest is unreadable');
+  }
+}
+
+function writeManifestAtomic(rootPath, manifest) {
+  const paths = knowledgePaths(rootPath);
+  fs.mkdirSync(paths.root, { recursive: true });
+  const tmp = `${paths.manifest}.tmp-${process.pid}`;
+  const body = `${JSON.stringify(manifest, null, 2)}\n`;
+  fs.writeFileSync(tmp, body, 'utf8');
+  fs.renameSync(tmp, paths.manifest);
+}
+
+module.exports = {
+  resolveKnowledgeRoot,
+  knowledgePaths,
+  ensureLayoutDirs,
+  readManifest,
+  writeManifestAtomic,
+};

--- a/src/projectIntelligence/store/migrations.js
+++ b/src/projectIntelligence/store/migrations.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const { STORE_SCHEMA_VERSION } = require('./constants');
+
+/**
+ * Ordered, deterministic SQLite migrations for Community project knowledge.
+ * Each migration is pure SQL. Applied once; unknown future versions fail closed.
+ */
+const MIGRATIONS = Object.freeze([
+  {
+    id: 1,
+    name: 'initial-store-v1',
+    sql: `
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY NOT NULL,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  id INTEGER PRIMARY KEY NOT NULL,
+  name TEXT NOT NULL,
+  applied_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS projects (
+  project_id TEXT PRIMARY KEY NOT NULL,
+  display_name TEXT,
+  trusted_roots_json TEXT NOT NULL,
+  schema_bindings_json TEXT,
+  safety_json TEXT,
+  payload_json TEXT NOT NULL,
+  created_at TEXT,
+  updated_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS snapshots (
+  project_id TEXT NOT NULL,
+  snapshot_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  source_inventory_hash TEXT NOT NULL,
+  store_schema_version INTEGER NOT NULL,
+  search_schema_version INTEGER NOT NULL,
+  artifact_schema_version INTEGER NOT NULL,
+  is_current INTEGER NOT NULL DEFAULT 0,
+  content_addressing_json TEXT,
+  analyzer_run_ids_json TEXT,
+  published_at TEXT,
+  payload_json TEXT NOT NULL,
+  created_at TEXT,
+  updated_at TEXT,
+  PRIMARY KEY (project_id, snapshot_id)
+);
+
+CREATE TABLE IF NOT EXISTS current_pointer (
+  project_id TEXT PRIMARY KEY NOT NULL,
+  snapshot_id TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (project_id, snapshot_id) REFERENCES snapshots(project_id, snapshot_id)
+);
+
+CREATE TABLE IF NOT EXISTS source_units (
+  project_id TEXT NOT NULL,
+  snapshot_id TEXT NOT NULL,
+  source_unit_id TEXT NOT NULL,
+  relative_path TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  trusted_root_id TEXT NOT NULL,
+  language TEXT,
+  media_type TEXT,
+  size_bytes INTEGER,
+  hash_algorithm TEXT,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (project_id, snapshot_id, source_unit_id)
+);
+
+CREATE TABLE IF NOT EXISTS analyzer_runs (
+  project_id TEXT NOT NULL,
+  snapshot_id TEXT NOT NULL,
+  analyzer_run_id TEXT NOT NULL,
+  analyzer_id TEXT NOT NULL,
+  analyzer_version TEXT NOT NULL,
+  input_inventory_hash TEXT NOT NULL,
+  status TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (project_id, snapshot_id, analyzer_run_id)
+);
+
+CREATE TABLE IF NOT EXISTS symbols (
+  project_id TEXT NOT NULL,
+  snapshot_id TEXT NOT NULL,
+  symbol_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  symbol_kind TEXT NOT NULL,
+  derivation_class TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (project_id, snapshot_id, symbol_id)
+);
+
+CREATE TABLE IF NOT EXISTS relationships (
+  project_id TEXT NOT NULL,
+  snapshot_id TEXT NOT NULL,
+  relationship_id TEXT NOT NULL,
+  relationship_type TEXT NOT NULL,
+  from_symbol_id TEXT NOT NULL,
+  to_symbol_id TEXT NOT NULL,
+  derivation_class TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (project_id, snapshot_id, relationship_id)
+);
+
+CREATE TABLE IF NOT EXISTS evidence_meta (
+  project_id TEXT NOT NULL,
+  snapshot_id TEXT NOT NULL,
+  evidence_id TEXT NOT NULL,
+  source_unit_id TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  evidence_class TEXT NOT NULL,
+  trusted_root_id TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY (project_id, snapshot_id, evidence_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshots_project_status
+  ON snapshots(project_id, status);
+CREATE INDEX IF NOT EXISTS idx_source_units_hash
+  ON source_units(project_id, snapshot_id, content_hash);
+CREATE INDEX IF NOT EXISTS idx_symbols_name
+  ON symbols(project_id, snapshot_id, name);
+CREATE INDEX IF NOT EXISTS idx_relationships_from
+  ON relationships(project_id, snapshot_id, from_symbol_id);
+CREATE INDEX IF NOT EXISTS idx_relationships_to
+  ON relationships(project_id, snapshot_id, to_symbol_id);
+`,
+  },
+]);
+
+function listMigrationIds() {
+  return MIGRATIONS.map(m => m.id);
+}
+
+function maxMigrationId() {
+  return MIGRATIONS.reduce((max, m) => Math.max(max, m.id), 0);
+}
+
+function assertCompatibleSchemaVersion(version) {
+  const v = Number(version);
+  if (!Number.isInteger(v) || v < 1) {
+    return { ok: false, reason: 'invalid' };
+  }
+  if (v > STORE_SCHEMA_VERSION) {
+    return { ok: false, reason: 'future' };
+  }
+  if (v < STORE_SCHEMA_VERSION) {
+    return { ok: false, reason: 'migration-required' };
+  }
+  return { ok: true };
+}
+
+module.exports = {
+  MIGRATIONS,
+  listMigrationIds,
+  maxMigrationId,
+  assertCompatibleSchemaVersion,
+  STORE_SCHEMA_VERSION,
+};

--- a/src/projectIntelligence/store/sqliteDriver.js
+++ b/src/projectIntelligence/store/sqliteDriver.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { fail, REASON_CODES } = require('./errors');
+
+const DRIVER_ID = 'node:sqlite';
+
+/**
+ * @returns {{ available: boolean, DatabaseSync?: Function, reason?: string }}
+ */
+function probeNodeSqlite() {
+  try {
+    const mod = require('node:sqlite');
+    if (!mod || typeof mod.DatabaseSync !== 'function') {
+      return { available: false, reason: 'DatabaseSync missing' };
+    }
+    return { available: true, DatabaseSync: mod.DatabaseSync };
+  } catch (err) {
+    return {
+      available: false,
+      reason: err && err.message ? String(err.message) : 'node:sqlite unavailable',
+    };
+  }
+}
+
+/**
+ * Thin sync SQLite driver over Node's experimental DatabaseSync.
+ * Fail-closed when the binding is unavailable.
+ */
+function openSqliteDatabase(dbPath, { readOnly = false } = {}) {
+  const probe = probeNodeSqlite();
+  if (!probe.available) {
+    fail(
+      REASON_CODES.STORE_UNAVAILABLE,
+      'SQLite driver unavailable (requires Node.js node:sqlite / DatabaseSync)',
+      { driver: DRIVER_ID, reason: probe.reason }
+    );
+  }
+
+  const resolved = path.resolve(dbPath);
+  if (!readOnly) {
+    fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  } else if (!fs.existsSync(resolved)) {
+    fail(REASON_CODES.STORE_UNAVAILABLE, 'SQLite database file does not exist');
+  }
+
+  let db;
+  try {
+    db = new probe.DatabaseSync(resolved, { readOnly });
+  } catch (err) {
+    fail(REASON_CODES.STORE_CORRUPT, 'failed to open SQLite database', {
+      code: err && err.code,
+      message: err && err.message ? String(err.message) : undefined,
+    });
+  }
+
+  if (!readOnly) {
+    try {
+      db.exec('PRAGMA foreign_keys = ON;');
+      db.exec('PRAGMA journal_mode = WAL;');
+      db.exec('PRAGMA synchronous = NORMAL;');
+      db.exec('PRAGMA busy_timeout = 3000;');
+    } catch {
+      // WAL may fail on some FS; continue with defaults.
+      try {
+        db.exec('PRAGMA foreign_keys = ON;');
+      } catch (err) {
+        fail(REASON_CODES.STORE_UNAVAILABLE, 'failed to configure SQLite pragmas', {
+          message: err && err.message ? String(err.message) : undefined,
+        });
+      }
+    }
+  } else {
+    try {
+      db.exec('PRAGMA foreign_keys = ON;');
+    } catch {
+      // ignore
+    }
+  }
+
+  function exec(sql) {
+    db.exec(sql);
+  }
+
+  function run(sql, params = {}) {
+    const stmt = db.prepare(sql);
+    return stmt.run(params);
+  }
+
+  function get(sql, params = {}) {
+    const stmt = db.prepare(sql);
+    return stmt.get(params) || null;
+  }
+
+  function all(sql, params = {}) {
+    const stmt = db.prepare(sql);
+    return stmt.all(params);
+  }
+
+  function begin() {
+    exec('BEGIN IMMEDIATE;');
+  }
+
+  function commit() {
+    exec('COMMIT;');
+  }
+
+  function rollback() {
+    try {
+      exec('ROLLBACK;');
+    } catch {
+      // no active transaction
+    }
+  }
+
+  function integrityCheck() {
+    const rows = all('PRAGMA integrity_check;');
+    const messages = rows.map(r => {
+      const keys = Object.keys(r);
+      return String(r[keys[0]]);
+    });
+    const ok = messages.length === 1 && messages[0] === 'ok';
+    return { ok, messages };
+  }
+
+  function close() {
+    try {
+      db.close();
+    } catch {
+      // already closed
+    }
+  }
+
+  return {
+    driverId: DRIVER_ID,
+    path: resolved,
+    readOnly,
+    exec,
+    run,
+    get,
+    all,
+    begin,
+    commit,
+    rollback,
+    integrityCheck,
+    close,
+    _db: db,
+  };
+}
+
+module.exports = {
+  DRIVER_ID,
+  probeNodeSqlite,
+  openSqliteDatabase,
+};

--- a/src/projectIntelligence/store/sqliteKnowledgeStore.js
+++ b/src/projectIntelligence/store/sqliteKnowledgeStore.js
@@ -1,0 +1,791 @@
+'use strict';
+
+const { STORE_SCHEMA_VERSION, STORE_STATES, META_KEYS } = require('./constants');
+const { MIGRATIONS, assertCompatibleSchemaVersion } = require('./migrations');
+const { openSqliteDatabase, DRIVER_ID } = require('./sqliteDriver');
+const { fail, REASON_CODES, KnowledgeStoreError } = require('./errors');
+const { SNAPSHOT_STATUSES } = require('../constants');
+const { validateProjectIntelligenceContract, CONTRACT_IDS } = require('../validate');
+
+function isoNow() {
+  return new Date().toISOString();
+}
+
+function jsonString(value) {
+  return JSON.stringify(value);
+}
+
+function jsonParse(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  try {
+    return JSON.parse(value);
+  } catch {
+    fail(REASON_CODES.STORE_CORRUPT, 'stored JSON payload is corrupt');
+  }
+}
+
+function requireOpen(store) {
+  if (store._state === STORE_STATES.CLOSED) {
+    fail(REASON_CODES.STORE_UNAVAILABLE, 'knowledge store is closed');
+  }
+  if (store._state === STORE_STATES.SEALED && store._writeBlocked) {
+    // reads still allowed when sealed
+  }
+}
+
+function requireWritable(store) {
+  requireOpen(store);
+  if (store._readOnly || store._state === STORE_STATES.SEALED) {
+    fail(REASON_CODES.SNAPSHOT_IMMUTABLE, 'knowledge store is not writable');
+  }
+}
+
+function validateOrThrow(contractId, value) {
+  const result = validateProjectIntelligenceContract(contractId, value);
+  if (!result.ok) {
+    fail(REASON_CODES.SCHEMA_INVALID, result.message, { errors: result.errors });
+  }
+  return result.value;
+}
+
+/**
+ * Community SQLite KnowledgeStore (ZPI-03).
+ * Metadata only — content blobs and Lucene indexes are later packages.
+ */
+function createSqliteKnowledgeStore({
+  dbPath,
+  projectId,
+  readOnly = false,
+  applyMigrations = true,
+} = {}) {
+  if (typeof projectId !== 'string' || !projectId.trim()) {
+    fail(REASON_CODES.PROJECT_ID_INVALID, 'projectId is required');
+  }
+
+  const db = openSqliteDatabase(dbPath, { readOnly });
+  const store = {
+    _db: db,
+    _projectId: projectId,
+    _readOnly: Boolean(readOnly),
+    _state: STORE_STATES.OPEN,
+    _writeBlocked: Boolean(readOnly),
+    _txDepth: 0,
+  };
+
+  function setMeta(key, value) {
+    db.run(
+      `INSERT INTO meta(key, value) VALUES (@key, @value)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      { key, value: String(value) }
+    );
+  }
+
+  function getMeta(key) {
+    const row = db.get('SELECT value FROM meta WHERE key = @key', { key });
+    return row ? row.value : null;
+  }
+
+  function applyAllMigrations() {
+    db.exec(MIGRATIONS[0].sql);
+    // Ensure migrations table exists before reading.
+    const applied = new Set(db.all('SELECT id FROM schema_migrations').map(r => Number(r.id)));
+    for (const migration of MIGRATIONS) {
+      if (applied.has(migration.id)) continue;
+      db.exec('BEGIN IMMEDIATE;');
+      try {
+        // Initial migration already executed above for table bootstrap;
+        // re-running CREATE IF NOT EXISTS is safe for id 1.
+        if (migration.id !== 1) {
+          db.exec(migration.sql);
+        }
+        db.run(
+          `INSERT INTO schema_migrations(id, name, applied_at)
+           VALUES (@id, @name, @applied_at)`,
+          { id: migration.id, name: migration.name, applied_at: isoNow() }
+        );
+        db.exec('COMMIT;');
+      } catch (err) {
+        db.rollback();
+        fail(REASON_CODES.MIGRATION_FAILED, 'store migration failed', {
+          migrationId: migration.id,
+          message: err && err.message ? String(err.message) : undefined,
+        });
+      }
+    }
+    setMeta(META_KEYS.STORE_SCHEMA_VERSION, String(STORE_SCHEMA_VERSION));
+    setMeta(META_KEYS.DRIVER, DRIVER_ID);
+    if (!getMeta(META_KEYS.CREATED_AT)) {
+      setMeta(META_KEYS.CREATED_AT, isoNow());
+    }
+    setMeta(META_KEYS.OPENED_AT, isoNow());
+    setMeta(META_KEYS.PROJECT_ID, projectId);
+  }
+
+  function ensureBootstrapped() {
+    if (readOnly) {
+      // Minimal meta table check
+      let version;
+      try {
+        version = getMeta(META_KEYS.STORE_SCHEMA_VERSION);
+      } catch {
+        fail(REASON_CODES.STORE_CORRUPT, 'store meta table missing or unreadable');
+      }
+      const compat = assertCompatibleSchemaVersion(version);
+      if (!compat.ok) {
+        if (compat.reason === 'future') {
+          fail(REASON_CODES.MIGRATION_UNSUPPORTED, 'unknown future store schema version', {
+            version,
+          });
+        }
+        fail(REASON_CODES.MIGRATION_REQUIRED, 'store schema migration required', { version });
+      }
+      return;
+    }
+
+    if (applyMigrations) {
+      applyAllMigrations();
+    }
+
+    const version = getMeta(META_KEYS.STORE_SCHEMA_VERSION);
+    const compat = assertCompatibleSchemaVersion(version);
+    if (!compat.ok) {
+      if (compat.reason === 'future') {
+        fail(REASON_CODES.MIGRATION_UNSUPPORTED, 'unknown future store schema version', {
+          version,
+        });
+      }
+      fail(REASON_CODES.MIGRATION_REQUIRED, 'store schema migration required', { version });
+    }
+  }
+
+  // Bootstrap immediately.
+  try {
+    if (!readOnly) {
+      // Create schema shell so getMeta works even on empty file.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS meta (
+          key TEXT PRIMARY KEY NOT NULL,
+          value TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+          id INTEGER PRIMARY KEY NOT NULL,
+          name TEXT NOT NULL,
+          applied_at TEXT NOT NULL
+        );
+      `);
+    }
+    ensureBootstrapped();
+  } catch (err) {
+    try {
+      db.close();
+    } catch {
+      // ignore
+    }
+    if (err instanceof KnowledgeStoreError) throw err;
+    fail(REASON_CODES.STORE_UNAVAILABLE, 'failed to bootstrap knowledge store', {
+      message: err && err.message ? String(err.message) : undefined,
+    });
+  }
+
+  function withTransaction(fn) {
+    requireWritable(store);
+    if (typeof fn !== 'function') {
+      fail(REASON_CODES.OPERATION_UNAVAILABLE, 'transaction callback is required');
+    }
+    if (store._txDepth === 0) {
+      db.begin();
+    }
+    store._txDepth += 1;
+    try {
+      const result = fn();
+      store._txDepth -= 1;
+      if (store._txDepth === 0) {
+        db.commit();
+      }
+      return result;
+    } catch (err) {
+      store._txDepth = 0;
+      db.rollback();
+      if (err instanceof KnowledgeStoreError) throw err;
+      fail(REASON_CODES.TRANSACTION_FAILED, 'knowledge store transaction failed', {
+        message: err && err.message ? String(err.message) : undefined,
+      });
+    }
+  }
+
+  function putProject(project) {
+    requireWritable(store);
+    const value = validateOrThrow(CONTRACT_IDS.PROJECT, project);
+    if (value.projectId !== store._projectId) {
+      fail(REASON_CODES.PROJECT_ID_INVALID, 'projectId does not match store project');
+    }
+    const now = isoNow();
+    db.run(
+      `INSERT INTO projects(
+         project_id, display_name, trusted_roots_json, schema_bindings_json,
+         safety_json, payload_json, created_at, updated_at
+       ) VALUES (
+         @project_id, @display_name, @trusted_roots_json, @schema_bindings_json,
+         @safety_json, @payload_json, @created_at, @updated_at
+       )
+       ON CONFLICT(project_id) DO UPDATE SET
+         display_name = excluded.display_name,
+         trusted_roots_json = excluded.trusted_roots_json,
+         schema_bindings_json = excluded.schema_bindings_json,
+         safety_json = excluded.safety_json,
+         payload_json = excluded.payload_json,
+         updated_at = excluded.updated_at`,
+      {
+        project_id: value.projectId,
+        display_name: value.displayName || null,
+        trusted_roots_json: jsonString(value.trustedRoots || []),
+        schema_bindings_json: value.schemaBindings ? jsonString(value.schemaBindings) : null,
+        safety_json: value.safety ? jsonString(value.safety) : null,
+        payload_json: jsonString(value),
+        created_at: now,
+        updated_at: now,
+      }
+    );
+    return value;
+  }
+
+  function getProject(projectId = store._projectId) {
+    requireOpen(store);
+    const row = db.get('SELECT payload_json FROM projects WHERE project_id = @project_id', {
+      project_id: projectId,
+    });
+    if (!row) {
+      fail(REASON_CODES.PROJECT_NOT_FOUND, 'project was not found');
+    }
+    return jsonParse(row.payload_json);
+  }
+
+  function putSnapshot(snapshot) {
+    requireWritable(store);
+    const value = validateOrThrow(CONTRACT_IDS.SNAPSHOT, snapshot);
+    if (value.projectId !== store._projectId) {
+      fail(REASON_CODES.PROJECT_ID_INVALID, 'snapshot projectId does not match store project');
+    }
+
+    // Published snapshots are immutable once stored as published.
+    const existing = db.get(
+      `SELECT status, payload_json FROM snapshots
+       WHERE project_id = @project_id AND snapshot_id = @snapshot_id`,
+      { project_id: value.projectId, snapshot_id: value.snapshotId }
+    );
+    if (existing && existing.status === SNAPSHOT_STATUSES.PUBLISHED) {
+      fail(REASON_CODES.SNAPSHOT_IMMUTABLE, 'published snapshots cannot be modified');
+    }
+
+    const now = isoNow();
+    db.run(
+      `INSERT INTO snapshots(
+         project_id, snapshot_id, status, source_inventory_hash,
+         store_schema_version, search_schema_version, artifact_schema_version,
+         is_current, content_addressing_json, analyzer_run_ids_json,
+         published_at, payload_json, created_at, updated_at
+       ) VALUES (
+         @project_id, @snapshot_id, @status, @source_inventory_hash,
+         @store_schema_version, @search_schema_version, @artifact_schema_version,
+         @is_current, @content_addressing_json, @analyzer_run_ids_json,
+         @published_at, @payload_json, @created_at, @updated_at
+       )
+       ON CONFLICT(project_id, snapshot_id) DO UPDATE SET
+         status = excluded.status,
+         source_inventory_hash = excluded.source_inventory_hash,
+         store_schema_version = excluded.store_schema_version,
+         search_schema_version = excluded.search_schema_version,
+         artifact_schema_version = excluded.artifact_schema_version,
+         is_current = excluded.is_current,
+         content_addressing_json = excluded.content_addressing_json,
+         analyzer_run_ids_json = excluded.analyzer_run_ids_json,
+         published_at = excluded.published_at,
+         payload_json = excluded.payload_json,
+         updated_at = excluded.updated_at`,
+      {
+        project_id: value.projectId,
+        snapshot_id: value.snapshotId,
+        status: value.status,
+        source_inventory_hash: value.sourceInventoryHash,
+        store_schema_version: value.storeSchemaVersion,
+        search_schema_version: value.searchSchemaVersion,
+        artifact_schema_version: value.artifactSchemaVersion,
+        is_current: value.isCurrent ? 1 : 0,
+        content_addressing_json: value.contentAddressing
+          ? jsonString(value.contentAddressing)
+          : null,
+        analyzer_run_ids_json: value.analyzerRunIds ? jsonString(value.analyzerRunIds) : null,
+        published_at: value.publishedAt || null,
+        payload_json: jsonString(value),
+        created_at: now,
+        updated_at: now,
+      }
+    );
+    return value;
+  }
+
+  function getSnapshot(projectId, snapshotId) {
+    requireOpen(store);
+    const row = db.get(
+      `SELECT payload_json FROM snapshots
+       WHERE project_id = @project_id AND snapshot_id = @snapshot_id`,
+      { project_id: projectId, snapshot_id: snapshotId }
+    );
+    if (!row) {
+      fail(REASON_CODES.SNAPSHOT_NOT_FOUND, 'snapshot was not found');
+    }
+    return jsonParse(row.payload_json);
+  }
+
+  function listSnapshots(projectId = store._projectId) {
+    requireOpen(store);
+    return db
+      .all(
+        `SELECT payload_json FROM snapshots
+         WHERE project_id = @project_id
+         ORDER BY snapshot_id ASC`,
+        { project_id: projectId }
+      )
+      .map(r => jsonParse(r.payload_json));
+  }
+
+  /**
+   * Atomically publish a snapshot and advance the current pointer.
+   * Only published snapshots may become current.
+   */
+  function publishSnapshot(projectId, snapshotId, { publishedAt } = {}) {
+    requireWritable(store);
+    return withTransaction(() => {
+      const snap = getSnapshot(projectId, snapshotId);
+      if (snap.status === SNAPSHOT_STATUSES.FAILED) {
+        fail(REASON_CODES.PUBLISH_INCOMPLETE, 'failed snapshots cannot be published');
+      }
+
+      const when = publishedAt || isoNow();
+      const next = {
+        ...snap,
+        status: SNAPSHOT_STATUSES.PUBLISHED,
+        isCurrent: true,
+        publishedAt: when,
+      };
+      validateOrThrow(CONTRACT_IDS.SNAPSHOT, next);
+
+      // Supersede any previously published / current snapshots (payload rewrite in JS).
+      const others = db.all(
+        `SELECT snapshot_id, payload_json, status FROM snapshots
+         WHERE project_id = @project_id AND snapshot_id != @snapshot_id`,
+        { project_id: projectId, snapshot_id: snapshotId }
+      );
+      for (const row of others) {
+        const payload = jsonParse(row.payload_json);
+        if (!payload.isCurrent && payload.status !== SNAPSHOT_STATUSES.PUBLISHED) {
+          continue;
+        }
+        payload.isCurrent = false;
+        if (payload.status === SNAPSHOT_STATUSES.PUBLISHED) {
+          payload.status = SNAPSHOT_STATUSES.SUPERSEDED;
+        }
+        db.run(
+          `UPDATE snapshots
+           SET status = @status, is_current = 0, payload_json = @payload_json, updated_at = @updated_at
+           WHERE project_id = @project_id AND snapshot_id = @snapshot_id`,
+          {
+            project_id: projectId,
+            snapshot_id: row.snapshot_id,
+            status: payload.status,
+            payload_json: jsonString(payload),
+            updated_at: when,
+          }
+        );
+      }
+
+      // Bypass putSnapshot immutability: direct update of the snapshot being published.
+      db.run(
+        `UPDATE snapshots
+         SET status = @status,
+             is_current = 1,
+             published_at = @published_at,
+             payload_json = @payload_json,
+             updated_at = @updated_at
+         WHERE project_id = @project_id AND snapshot_id = @snapshot_id`,
+        {
+          project_id: projectId,
+          snapshot_id: snapshotId,
+          status: SNAPSHOT_STATUSES.PUBLISHED,
+          published_at: when,
+          payload_json: jsonString(next),
+          updated_at: when,
+        }
+      );
+
+      db.run(
+        `INSERT INTO current_pointer(project_id, snapshot_id, updated_at)
+         VALUES (@project_id, @snapshot_id, @updated_at)
+         ON CONFLICT(project_id) DO UPDATE SET
+           snapshot_id = excluded.snapshot_id,
+           updated_at = excluded.updated_at`,
+        { project_id: projectId, snapshot_id: snapshotId, updated_at: when }
+      );
+
+      return next;
+    });
+  }
+
+  function getCurrentSnapshot(projectId = store._projectId) {
+    requireOpen(store);
+    const pointer = db.get(
+      `SELECT snapshot_id FROM current_pointer WHERE project_id = @project_id`,
+      { project_id: projectId }
+    );
+    if (!pointer) {
+      fail(REASON_CODES.SNAPSHOT_NOT_CURRENT, 'no current snapshot pointer');
+    }
+    const snap = getSnapshot(projectId, pointer.snapshot_id);
+    if (snap.status !== SNAPSHOT_STATUSES.PUBLISHED) {
+      fail(
+        REASON_CODES.CURRENT_POINTER_MISMATCH,
+        'current pointer does not reference a published snapshot'
+      );
+    }
+    return snap;
+  }
+
+  function putSourceUnit(unit) {
+    requireWritable(store);
+    const value = validateOrThrow(CONTRACT_IDS.SOURCE_UNIT, unit);
+    if (value.projectId !== store._projectId) {
+      fail(REASON_CODES.PROJECT_ID_INVALID);
+    }
+    db.run(
+      `INSERT INTO source_units(
+         project_id, snapshot_id, source_unit_id, relative_path, content_hash,
+         trusted_root_id, language, media_type, size_bytes, hash_algorithm, payload_json
+       ) VALUES (
+         @project_id, @snapshot_id, @source_unit_id, @relative_path, @content_hash,
+         @trusted_root_id, @language, @media_type, @size_bytes, @hash_algorithm, @payload_json
+       )
+       ON CONFLICT(project_id, snapshot_id, source_unit_id) DO UPDATE SET
+         relative_path = excluded.relative_path,
+         content_hash = excluded.content_hash,
+         trusted_root_id = excluded.trusted_root_id,
+         language = excluded.language,
+         media_type = excluded.media_type,
+         size_bytes = excluded.size_bytes,
+         hash_algorithm = excluded.hash_algorithm,
+         payload_json = excluded.payload_json`,
+      {
+        project_id: value.projectId,
+        snapshot_id: value.snapshotId,
+        source_unit_id: value.sourceUnitId,
+        relative_path: value.relativePath,
+        content_hash: value.contentHash,
+        trusted_root_id: value.trustedRootId,
+        language: value.language || null,
+        media_type: value.mediaType || null,
+        size_bytes: value.sizeBytes == null ? null : value.sizeBytes,
+        hash_algorithm: value.hashAlgorithm || null,
+        payload_json: jsonString(value),
+      }
+    );
+    return value;
+  }
+
+  function listSourceUnits(projectId, snapshotId) {
+    requireOpen(store);
+    return db
+      .all(
+        `SELECT payload_json FROM source_units
+         WHERE project_id = @project_id AND snapshot_id = @snapshot_id
+         ORDER BY source_unit_id ASC`,
+        { project_id: projectId, snapshot_id: snapshotId }
+      )
+      .map(r => jsonParse(r.payload_json));
+  }
+
+  function putSymbol(symbol) {
+    requireWritable(store);
+    const value = validateOrThrow(CONTRACT_IDS.SYMBOL, symbol);
+    if (value.projectId !== store._projectId) {
+      fail(REASON_CODES.PROJECT_ID_INVALID);
+    }
+    db.run(
+      `INSERT INTO symbols(
+         project_id, snapshot_id, symbol_id, name, symbol_kind, derivation_class, payload_json
+       ) VALUES (
+         @project_id, @snapshot_id, @symbol_id, @name, @symbol_kind, @derivation_class, @payload_json
+       )
+       ON CONFLICT(project_id, snapshot_id, symbol_id) DO UPDATE SET
+         name = excluded.name,
+         symbol_kind = excluded.symbol_kind,
+         derivation_class = excluded.derivation_class,
+         payload_json = excluded.payload_json`,
+      {
+        project_id: value.projectId,
+        snapshot_id: value.snapshotId,
+        symbol_id: value.symbolId,
+        name: value.name,
+        symbol_kind: value.symbolKind,
+        derivation_class: value.provenance.derivationClass,
+        payload_json: jsonString(value),
+      }
+    );
+    return value;
+  }
+
+  function listSymbols(projectId, snapshotId) {
+    requireOpen(store);
+    return db
+      .all(
+        `SELECT payload_json FROM symbols
+         WHERE project_id = @project_id AND snapshot_id = @snapshot_id
+         ORDER BY symbol_id ASC`,
+        { project_id: projectId, snapshot_id: snapshotId }
+      )
+      .map(r => jsonParse(r.payload_json));
+  }
+
+  function putRelationship(relationship) {
+    requireWritable(store);
+    const value = validateOrThrow(CONTRACT_IDS.RELATIONSHIP, relationship);
+    if (value.projectId !== store._projectId) {
+      fail(REASON_CODES.PROJECT_ID_INVALID);
+    }
+    db.run(
+      `INSERT INTO relationships(
+         project_id, snapshot_id, relationship_id, relationship_type,
+         from_symbol_id, to_symbol_id, derivation_class, payload_json
+       ) VALUES (
+         @project_id, @snapshot_id, @relationship_id, @relationship_type,
+         @from_symbol_id, @to_symbol_id, @derivation_class, @payload_json
+       )
+       ON CONFLICT(project_id, snapshot_id, relationship_id) DO UPDATE SET
+         relationship_type = excluded.relationship_type,
+         from_symbol_id = excluded.from_symbol_id,
+         to_symbol_id = excluded.to_symbol_id,
+         derivation_class = excluded.derivation_class,
+         payload_json = excluded.payload_json`,
+      {
+        project_id: value.projectId,
+        snapshot_id: value.snapshotId,
+        relationship_id: value.relationshipId,
+        relationship_type: value.relationshipType,
+        from_symbol_id: value.fromSymbolId,
+        to_symbol_id: value.toSymbolId,
+        derivation_class: value.provenance.derivationClass,
+        payload_json: jsonString(value),
+      }
+    );
+    return value;
+  }
+
+  function listRelationships(projectId, snapshotId) {
+    requireOpen(store);
+    return db
+      .all(
+        `SELECT payload_json FROM relationships
+         WHERE project_id = @project_id AND snapshot_id = @snapshot_id
+         ORDER BY relationship_id ASC`,
+        { project_id: projectId, snapshot_id: snapshotId }
+      )
+      .map(r => jsonParse(r.payload_json));
+  }
+
+  function putAnalyzerRun(run) {
+    requireWritable(store);
+    const value = validateOrThrow(CONTRACT_IDS.ANALYZER_RUN, run);
+    if (value.projectId !== store._projectId) {
+      fail(REASON_CODES.PROJECT_ID_INVALID);
+    }
+    db.run(
+      `INSERT INTO analyzer_runs(
+         project_id, snapshot_id, analyzer_run_id, analyzer_id, analyzer_version,
+         input_inventory_hash, status, payload_json
+       ) VALUES (
+         @project_id, @snapshot_id, @analyzer_run_id, @analyzer_id, @analyzer_version,
+         @input_inventory_hash, @status, @payload_json
+       )
+       ON CONFLICT(project_id, snapshot_id, analyzer_run_id) DO UPDATE SET
+         analyzer_id = excluded.analyzer_id,
+         analyzer_version = excluded.analyzer_version,
+         input_inventory_hash = excluded.input_inventory_hash,
+         status = excluded.status,
+         payload_json = excluded.payload_json`,
+      {
+        project_id: value.projectId,
+        snapshot_id: value.snapshotId,
+        analyzer_run_id: value.analyzerRunId,
+        analyzer_id: value.analyzerId,
+        analyzer_version: value.analyzerVersion,
+        input_inventory_hash: value.inputInventoryHash,
+        status: value.status,
+        payload_json: jsonString(value),
+      }
+    );
+    return value;
+  }
+
+  function putEvidenceMeta(evidence) {
+    requireWritable(store);
+    const value = validateOrThrow(CONTRACT_IDS.EVIDENCE, evidence);
+    if (value.projectId !== store._projectId) {
+      fail(REASON_CODES.PROJECT_ID_INVALID);
+    }
+    db.run(
+      `INSERT INTO evidence_meta(
+         project_id, snapshot_id, evidence_id, source_unit_id, content_hash,
+         evidence_class, trusted_root_id, payload_json
+       ) VALUES (
+         @project_id, @snapshot_id, @evidence_id, @source_unit_id, @content_hash,
+         @evidence_class, @trusted_root_id, @payload_json
+       )
+       ON CONFLICT(project_id, snapshot_id, evidence_id) DO UPDATE SET
+         source_unit_id = excluded.source_unit_id,
+         content_hash = excluded.content_hash,
+         evidence_class = excluded.evidence_class,
+         trusted_root_id = excluded.trusted_root_id,
+         payload_json = excluded.payload_json`,
+      {
+        project_id: value.projectId,
+        snapshot_id: value.snapshotId,
+        evidence_id: value.evidenceId,
+        source_unit_id: value.sourceUnitId,
+        content_hash: value.contentHash,
+        evidence_class: value.evidenceClass,
+        trusted_root_id: value.trustedRootId,
+        payload_json: jsonString(value),
+      }
+    );
+    return value;
+  }
+
+  function checkIntegrity() {
+    requireOpen(store);
+    const pragma = db.integrityCheck();
+    if (!pragma.ok) {
+      return {
+        ok: false,
+        reasonCode: REASON_CODES.STORE_CORRUPT,
+        messages: pragma.messages,
+      };
+    }
+
+    const version = getMeta(META_KEYS.STORE_SCHEMA_VERSION);
+    const compat = assertCompatibleSchemaVersion(version);
+    if (!compat.ok) {
+      return {
+        ok: false,
+        reasonCode:
+          compat.reason === 'future'
+            ? REASON_CODES.MIGRATION_UNSUPPORTED
+            : REASON_CODES.MIGRATION_REQUIRED,
+        messages: [`storeSchemaVersion=${version}`],
+      };
+    }
+
+    const requiredTables = [
+      'meta',
+      'schema_migrations',
+      'projects',
+      'snapshots',
+      'current_pointer',
+      'source_units',
+      'analyzer_runs',
+      'symbols',
+      'relationships',
+      'evidence_meta',
+    ];
+    for (const table of requiredTables) {
+      const row = db.get(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = @name`, {
+        name: table,
+      });
+      if (!row) {
+        return {
+          ok: false,
+          reasonCode: REASON_CODES.STORE_CORRUPT,
+          messages: [`missing table ${table}`],
+        };
+      }
+    }
+
+    // Current pointer consistency (if present).
+    const pointers = db.all('SELECT project_id, snapshot_id FROM current_pointer');
+    for (const p of pointers) {
+      const snap = db.get(
+        `SELECT status FROM snapshots
+         WHERE project_id = @project_id AND snapshot_id = @snapshot_id`,
+        { project_id: p.project_id, snapshot_id: p.snapshot_id }
+      );
+      if (!snap || snap.status !== SNAPSHOT_STATUSES.PUBLISHED) {
+        return {
+          ok: false,
+          reasonCode: REASON_CODES.CURRENT_POINTER_MISMATCH,
+          messages: [`pointer ${p.project_id} -> ${p.snapshot_id}`],
+        };
+      }
+    }
+
+    return { ok: true, reasonCode: null, messages: ['ok'] };
+  }
+
+  function seal() {
+    requireWritable(store);
+    setMeta(META_KEYS.SEALED_AT, isoNow());
+    store._state = STORE_STATES.SEALED;
+    store._writeBlocked = true;
+    return getStatus();
+  }
+
+  function close() {
+    if (store._state === STORE_STATES.CLOSED) return;
+    try {
+      db.close();
+    } finally {
+      store._state = STORE_STATES.CLOSED;
+    }
+  }
+
+  function getStatus() {
+    return {
+      state: store._state,
+      projectId: store._projectId,
+      readOnly: store._readOnly || store._state === STORE_STATES.SEALED,
+      driver: DRIVER_ID,
+      storeSchemaVersion: Number(getMeta(META_KEYS.STORE_SCHEMA_VERSION) || 0),
+      dbPath: db.path,
+    };
+  }
+
+  return {
+    // lifecycle
+    getStatus,
+    close,
+    seal,
+    checkIntegrity,
+    withTransaction,
+
+    // entities
+    putProject,
+    getProject,
+    putSnapshot,
+    getSnapshot,
+    listSnapshots,
+    publishSnapshot,
+    getCurrentSnapshot,
+    putSourceUnit,
+    listSourceUnits,
+    putSymbol,
+    listSymbols,
+    putRelationship,
+    listRelationships,
+    putAnalyzerRun,
+    putEvidenceMeta,
+
+    // internals for tests
+    _getMeta: getMeta,
+    _db: db,
+  };
+}
+
+module.exports = {
+  createSqliteKnowledgeStore,
+};

--- a/src/projectIntelligence/store/writerLock.js
+++ b/src/projectIntelligence/store/writerLock.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+const { DEFAULT_STALE_LOCK_MS } = require('./constants');
+const { fail, REASON_CODES } = require('./errors');
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function readLockFile(lockPath) {
+  try {
+    const raw = fs.readFileSync(lockPath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means the process exists but we cannot signal it.
+    return Boolean(err && err.code === 'EPERM');
+  }
+}
+
+function isLockStale(lock, { staleMs = DEFAULT_STALE_LOCK_MS, now = Date.now() } = {}) {
+  if (!lock || typeof lock !== 'object') return true;
+  const acquiredAt = Date.parse(String(lock.acquiredAt || ''));
+  if (!Number.isFinite(acquiredAt)) return true;
+  if (now - acquiredAt > staleMs) return true;
+  if (lock.pid != null && !isProcessAlive(Number(lock.pid))) return true;
+  return false;
+}
+
+/**
+ * Acquire an exclusive writer lock using O_EXCL create semantics (Windows-safe).
+ * @returns {{ token: string, lockPath: string, release: function }}
+ */
+function acquireWriterLock(lockPath, options = {}) {
+  const staleMs = options.staleMs == null ? DEFAULT_STALE_LOCK_MS : options.staleMs;
+  const now = options.now == null ? Date.now() : options.now;
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+
+  const token = crypto.randomBytes(16).toString('hex');
+  const payload = {
+    token,
+    pid: process.pid,
+    hostname: os.hostname(),
+    acquiredAt: new Date(now).toISOString(),
+    owner: options.owner || 'zeus-project-intelligence',
+  };
+
+  try {
+    const fd = fs.openSync(lockPath, 'wx');
+    try {
+      fs.writeFileSync(fd, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch (err) {
+    if (!err || err.code !== 'EEXIST') {
+      fail(REASON_CODES.STORE_LOCKED, 'failed to create writer lock', {
+        code: err && err.code,
+      });
+    }
+
+    const existing = readLockFile(lockPath);
+    if (!isLockStale(existing, { staleMs, now })) {
+      fail(REASON_CODES.WRITER_CONFLICT, 'another writer holds the project knowledge lock', {
+        pid: existing && existing.pid,
+      });
+    }
+
+    // Stale lock: remove and retry once.
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {
+      fail(REASON_CODES.STORE_LOCKED, 'stale writer lock could not be removed');
+    }
+
+    try {
+      const fd = fs.openSync(lockPath, 'wx');
+      try {
+        fs.writeFileSync(fd, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      fail(REASON_CODES.WRITER_CONFLICT, 'writer lock re-acquire failed after stale cleanup');
+    }
+  }
+
+  function release() {
+    const current = readLockFile(lockPath);
+    if (!current) return false;
+    if (current.token !== token) {
+      fail(REASON_CODES.STORE_LOCKED, 'writer lock token mismatch on release');
+    }
+    fs.unlinkSync(lockPath);
+    return true;
+  }
+
+  return {
+    token,
+    lockPath,
+    acquiredAt: payload.acquiredAt,
+    release,
+  };
+}
+
+function inspectWriterLock(lockPath, options = {}) {
+  if (!fs.existsSync(lockPath)) {
+    return { held: false, stale: false, lock: null };
+  }
+  const lock = readLockFile(lockPath);
+  const stale = isLockStale(lock, options);
+  return { held: true, stale, lock };
+}
+
+module.exports = {
+  acquireWriterLock,
+  inspectWriterLock,
+  isLockStale,
+  isProcessAlive,
+  readLockFile,
+  nowIso,
+};

--- a/tests/project-intelligence-store.test.js
+++ b/tests/project-intelligence-store.test.js
@@ -1,0 +1,333 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createProjectKnowledgeStore,
+  openProjectKnowledgeStore,
+  probeNodeSqlite,
+  KnowledgeStoreError,
+  REASON_CODES,
+  fixtures,
+  store,
+} = require('../src/projectIntelligence');
+
+const HAS_SQLITE = probeNodeSqlite().available;
+
+function tempRoot(label = 'zpi-store') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${label}-`));
+}
+
+function skipWithoutSqlite(t) {
+  if (!HAS_SQLITE) {
+    t.skip('node:sqlite DatabaseSync is unavailable on this Node runtime');
+    return true;
+  }
+  return false;
+}
+
+test('probeNodeSqlite reports availability shape', () => {
+  const probe = probeNodeSqlite();
+  assert.equal(typeof probe.available, 'boolean');
+  if (probe.available) {
+    assert.equal(typeof probe.DatabaseSync, 'function');
+  }
+});
+
+test('writer lock is exclusive and detects stale locks', () => {
+  const root = tempRoot('zpi-lock');
+  const lockPath = path.join(root, 'locks', 'writer.lock');
+  const first = store.acquireWriterLock(lockPath, { owner: 'a' });
+  assert.equal(typeof first.token, 'string');
+
+  assert.throws(
+    () => store.acquireWriterLock(lockPath, { owner: 'b' }),
+    err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.WRITER_CONFLICT
+  );
+
+  // Stale by age
+  const stalePath = path.join(root, 'locks', 'stale.lock');
+  fs.mkdirSync(path.dirname(stalePath), { recursive: true });
+  fs.writeFileSync(
+    stalePath,
+    JSON.stringify({
+      token: 'old',
+      pid: 99999999,
+      acquiredAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    }),
+    'utf8'
+  );
+  const recovered = store.acquireWriterLock(stalePath, { staleMs: 1000, owner: 'recover' });
+  assert.ok(recovered.token);
+  recovered.release();
+  first.release();
+});
+
+test('Windows-style absolute knowledge roots resolve safely', () => {
+  const root = tempRoot('zpi-winpath');
+  const resolved = store.resolveKnowledgeRoot(root);
+  assert.equal(path.isAbsolute(resolved), true);
+  // path with mixed separators should still resolve
+  const mixed = root.includes('\\') ? root.replace(/\\/g, '/') : root;
+  assert.equal(store.resolveKnowledgeRoot(mixed), path.resolve(mixed));
+});
+
+test(
+  'create/open store, put entities, publish snapshot, reopen current',
+  { skip: !HAS_SQLITE },
+  () => {
+    const root = tempRoot('zpi-crud');
+    const handle = createProjectKnowledgeStore({
+      rootPath: root,
+      projectId: 'proj-demo',
+      displayName: 'Demo',
+      trustedRoots: [{ rootId: 'root-src', relativeLabel: 'QRPGLESRC' }],
+    });
+
+    try {
+      const project = handle.getProject();
+      assert.equal(project.projectId, 'proj-demo');
+
+      const snap = fixtures.snapshot({
+        projectId: 'proj-demo',
+        snapshotId: 'snap-001',
+        status: 'building',
+        isCurrent: false,
+        publishedAt: undefined,
+      });
+      handle.putSnapshot(snap);
+      handle.putSourceUnit(fixtures.sourceUnit({ projectId: 'proj-demo', snapshotId: 'snap-001' }));
+      handle.putSymbol(fixtures.symbol({ projectId: 'proj-demo', snapshotId: 'snap-001' }));
+      handle.putRelationship(
+        fixtures.relationship({ projectId: 'proj-demo', snapshotId: 'snap-001' })
+      );
+      handle.putAnalyzerRun(
+        fixtures.analyzerRun({ projectId: 'proj-demo', snapshotId: 'snap-001' })
+      );
+      handle.putEvidenceMeta(fixtures.evidence({ projectId: 'proj-demo', snapshotId: 'snap-001' }));
+
+      const published = handle.publishSnapshot('proj-demo', 'snap-001');
+      assert.equal(published.status, 'published');
+      assert.equal(published.isCurrent, true);
+
+      const current = handle.getCurrentSnapshot();
+      assert.equal(current.snapshotId, 'snap-001');
+
+      const integrity = handle.checkIntegrity();
+      assert.equal(integrity.ok, true);
+
+      assert.equal(handle.listSourceUnits('proj-demo', 'snap-001').length, 1);
+      assert.equal(handle.listSymbols('proj-demo', 'snap-001').length, 1);
+      assert.equal(handle.listRelationships('proj-demo', 'snap-001').length, 1);
+    } finally {
+      handle.close();
+    }
+
+    // Reopen read-only and read current
+    const reopened = openProjectKnowledgeStore({
+      rootPath: root,
+      projectId: 'proj-demo',
+      readOnly: true,
+    });
+    try {
+      const current = reopened.getCurrentSnapshot();
+      assert.equal(current.snapshotId, 'snap-001');
+      assert.equal(reopened.checkIntegrity().ok, true);
+    } finally {
+      reopened.close();
+    }
+  }
+);
+
+test('parallel writer is rejected with WRITER_CONFLICT', { skip: !HAS_SQLITE }, () => {
+  const root = tempRoot('zpi-conflict');
+  const a = createProjectKnowledgeStore({ rootPath: root, projectId: 'proj-a' });
+  try {
+    assert.throws(
+      () => openProjectKnowledgeStore({ rootPath: root, projectId: 'proj-a', readOnly: false }),
+      err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.WRITER_CONFLICT
+    );
+  } finally {
+    a.close();
+  }
+});
+
+test('published snapshot is immutable', { skip: !HAS_SQLITE }, () => {
+  const root = tempRoot('zpi-immut');
+  const handle = createProjectKnowledgeStore({ rootPath: root, projectId: 'proj-demo' });
+  try {
+    handle.putSnapshot(
+      fixtures.snapshot({
+        projectId: 'proj-demo',
+        snapshotId: 'snap-001',
+        status: 'building',
+        isCurrent: false,
+        publishedAt: undefined,
+      })
+    );
+    handle.publishSnapshot('proj-demo', 'snap-001');
+    assert.throws(
+      () =>
+        handle.putSnapshot(
+          fixtures.snapshot({
+            projectId: 'proj-demo',
+            snapshotId: 'snap-001',
+            status: 'building',
+            isCurrent: false,
+          })
+        ),
+      err =>
+        err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.SNAPSHOT_IMMUTABLE
+    );
+  } finally {
+    handle.close();
+  }
+});
+
+test('transaction rollback leaves no partial snapshot pointer', { skip: !HAS_SQLITE }, () => {
+  const root = tempRoot('zpi-tx');
+  const handle = createProjectKnowledgeStore({ rootPath: root, projectId: 'proj-demo' });
+  try {
+    handle.putSnapshot(
+      fixtures.snapshot({
+        projectId: 'proj-demo',
+        snapshotId: 'snap-ok',
+        status: 'building',
+        isCurrent: false,
+        publishedAt: undefined,
+      })
+    );
+    handle.publishSnapshot('proj-demo', 'snap-ok');
+
+    assert.throws(() => {
+      handle.withTransaction(() => {
+        handle.putSnapshot(
+          fixtures.snapshot({
+            projectId: 'proj-demo',
+            snapshotId: 'snap-bad',
+            status: 'building',
+            isCurrent: false,
+            publishedAt: undefined,
+          })
+        );
+        throw new Error('simulated crash');
+      });
+    }, /simulated crash|transaction failed/i);
+
+    // Current pointer still the first published snapshot
+    assert.equal(handle.getCurrentSnapshot().snapshotId, 'snap-ok');
+    // Rolled-back insert should not be visible
+    assert.throws(
+      () => handle.getSnapshot('proj-demo', 'snap-bad'),
+      err =>
+        err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.SNAPSHOT_NOT_FOUND
+    );
+  } finally {
+    handle.close();
+  }
+});
+
+test('building snapshot is not served as current', { skip: !HAS_SQLITE }, () => {
+  const root = tempRoot('zpi-building');
+  const handle = createProjectKnowledgeStore({ rootPath: root, projectId: 'proj-demo' });
+  try {
+    handle.putSnapshot(
+      fixtures.snapshot({
+        projectId: 'proj-demo',
+        snapshotId: 'snap-building',
+        status: 'building',
+        isCurrent: false,
+        publishedAt: undefined,
+      })
+    );
+    assert.throws(
+      () => handle.getCurrentSnapshot(),
+      err =>
+        err instanceof KnowledgeStoreError &&
+        (err.reasonCode === REASON_CODES.SNAPSHOT_NOT_CURRENT ||
+          err.reasonCode === REASON_CODES.CURRENT_POINTER_MISMATCH)
+    );
+  } finally {
+    handle.close();
+  }
+});
+
+test('corrupt sqlite file fails closed on open', { skip: !HAS_SQLITE }, () => {
+  const root = tempRoot('zpi-corrupt');
+  // Create valid store first
+  const handle = createProjectKnowledgeStore({ rootPath: root, projectId: 'proj-demo' });
+  handle.close();
+
+  // Overwrite sqlite with garbage
+  const sqlitePath = path.join(root, 'knowledge.sqlite');
+  fs.writeFileSync(sqlitePath, 'this is not a database', 'utf8');
+
+  assert.throws(
+    () => openProjectKnowledgeStore({ rootPath: root, projectId: 'proj-demo', readOnly: true }),
+    err =>
+      err instanceof KnowledgeStoreError &&
+      (err.reasonCode === REASON_CODES.STORE_CORRUPT ||
+        err.reasonCode === REASON_CODES.STORE_UNAVAILABLE)
+  );
+});
+
+test('invalid contract payload is rejected by store', { skip: !HAS_SQLITE }, () => {
+  const root = tempRoot('zpi-schema');
+  const handle = createProjectKnowledgeStore({ rootPath: root, projectId: 'proj-demo' });
+  try {
+    assert.throws(
+      () =>
+        handle.putSnapshot({
+          schemaVersion: 1,
+          projectId: 'proj-demo',
+          snapshotId: 'x',
+          // missing required fields
+        }),
+      err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.SCHEMA_INVALID
+    );
+  } finally {
+    handle.close();
+  }
+});
+
+test('second publish supersedes previous current', { skip: !HAS_SQLITE }, () => {
+  const root = tempRoot('zpi-supersede');
+  const handle = createProjectKnowledgeStore({ rootPath: root, projectId: 'proj-demo' });
+  try {
+    handle.putSnapshot(
+      fixtures.snapshot({
+        projectId: 'proj-demo',
+        snapshotId: 'snap-1',
+        status: 'building',
+        isCurrent: false,
+        publishedAt: undefined,
+      })
+    );
+    handle.publishSnapshot('proj-demo', 'snap-1');
+
+    handle.putSnapshot(
+      fixtures.snapshot({
+        projectId: 'proj-demo',
+        snapshotId: 'snap-2',
+        status: 'building',
+        isCurrent: false,
+        publishedAt: undefined,
+      })
+    );
+    handle.publishSnapshot('proj-demo', 'snap-2');
+
+    assert.equal(handle.getCurrentSnapshot().snapshotId, 'snap-2');
+    const first = handle.getSnapshot('proj-demo', 'snap-1');
+    assert.equal(first.isCurrent, false);
+    assert.equal(first.status, 'superseded');
+  } finally {
+    handle.close();
+  }
+});
+
+// Silence unused when skipped
+void skipWithoutSqlite;


### PR DESCRIPTION
## Summary

- Implements **ZPI-03 — Store SPI and SQLite Provider**.
- Adds project-knowledge layout, exclusive writer locks (Windows-safe `O_EXCL`), schema migrations, transactions, and integrity checks.
- SQLite driver: Node built-in `node:sqlite` (`DatabaseSync`) — no extra npm native binding.
- Supports create/open, project/snapshot/source-unit/symbol/relationship/analyzer/evidence metadata, atomic `publishSnapshot` + current pointer.
- Fail-closed reason codes for lock conflicts, corrupt DB, immutable published snapshots, missing current pointer.
- **Out of scope:** content store (ZPI-04), Lucene (ZPI-05), analyzers, CLI/MCP.

## Test plan

- [x] `node --test tests/project-intelligence-store.test.js`
- [x] `npm run test:contract`
- [x] `npm run lint` / `format:check` / `typecheck`
- [x] `npm run check:public-knowledge-claims` / `docs:check`
- [x] `npm run check:repo-portability` / `package:smoke`

## Notes

- Store tests skip only if `node:sqlite` is unavailable (Node 20 without the module).
- CI Node 22/current LTS exercises the full SQLite path.