### PR TITLE
feat: ZPI-04 content-addressed store

### DIFF
--- a/docs/knowledgebase/README.md
+++ b/docs/knowledgebase/README.md
@@ -31,8 +31,10 @@ Current implementation status:
 - **ZPI-02 (contracts):** `src/projectIntelligence/` versioned project-knowledge contracts, closed
   reason codes, validators, fixtures, and a contract test kit
 - **ZPI-03 (store):** `src/projectIntelligence/store/` KnowledgeStore SPI + SQLite metadata provider
-  (`node:sqlite`), writer locks, migrations, integrity checks — still no content store, Lucene,
-  analyzer runtime, CLI, or MCP adapters
+  (`node:sqlite`), writer locks, migrations, integrity checks
+- **ZPI-04 (content):** `src/projectIntelligence/content/` content-addressed object store (sha256),
+  trusted-root path controls, text canonicalization, atomic write/dedupe; GC is design-only —
+  still no Lucene, analyzer runtime, CLI, or MCP adapters
 
 Local risk handling:
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -9,8 +9,9 @@ This directory is the home for versioned domain contract documentation.
 - Module descriptor contracts: `src/modules/`.
 - **Project Intelligence contracts (ZPI-02):** `src/projectIntelligence/`.
 
-ZPI-03 adds the SQLite metadata store under `src/projectIntelligence/store/` (no Lucene/content
-store yet). Search and analyzer packages remain later.
+ZPI-03 adds the SQLite metadata store under `src/projectIntelligence/store/`.
+ZPI-04 adds the content-addressed blob store under `src/projectIntelligence/content/`.
+Search (Lucene) and analyzer packages remain later.
 
 ## Contract IDs (stable)
 

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -22,6 +22,7 @@ module.exports = {
       'tests/community-deployment.test.js',
       'tests/project-intelligence-contracts.test.js',
       'tests/project-intelligence-store.test.js',
+      'tests/project-intelligence-content.test.js',
     ],
     smoke: [
       'tests/reproducible-output.test.js',

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -862,8 +862,8 @@ const zeus = {
   // Generation Validation Foundation (Iteration 29): offline candidate validation.
   // Never mutates the analyzed source workspace. review-ready is not compile readiness.
   generationValidation,
-  // Project Intelligence (ZPI-02 contracts + ZPI-03 SQLite store SPI).
-  // No Lucene/content-store/analyzer/CLI/MCP adapters yet.
+  // Project Intelligence (ZPI-02..04: contracts, SQLite store, content store).
+  // No Lucene/analyzer/CLI/MCP adapters yet.
   projectIntelligence,
   // External module contracts (Iteration 30): trusted in-process registration only.
   // Core does not parse licenses or enforce commercial entitlement.

--- a/src/projectIntelligence/content/constants.js
+++ b/src/projectIntelligence/content/constants.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/** Content-addressed object algorithm for Community default. */
+const CONTENT_HASH_ALGORITHM = 'sha256';
+
+/** Layout under the project-knowledge `content/` directory. */
+const CONTENT_LAYOUT = Object.freeze({
+  OBJECTS_DIR: 'objects',
+  TMP_DIR: 'tmp',
+  MANIFEST: 'content-manifest.json',
+});
+
+/** Default max payload size (64 MiB) for a single put. */
+const DEFAULT_MAX_OBJECT_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Garbage collection is design-only in ZPI-04.
+ * Runtime GC execution is intentionally unavailable.
+ */
+const GC_STATUS = Object.freeze({
+  DESIGN_ONLY: 'design-only',
+  NOT_IMPLEMENTED: 'not-implemented',
+});
+
+module.exports = {
+  CONTENT_HASH_ALGORITHM,
+  CONTENT_LAYOUT,
+  DEFAULT_MAX_OBJECT_BYTES,
+  GC_STATUS,
+};

--- a/src/projectIntelligence/content/contentStore.js
+++ b/src/projectIntelligence/content/contentStore.js
@@ -1,0 +1,352 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { CONTENT_HASH_ALGORITHM, CONTENT_LAYOUT, DEFAULT_MAX_OBJECT_BYTES } = require('./constants');
+const { sha256Hex, requireContentHash, contentObjectRelativePath } = require('./hash');
+const { canonicalizeContent, canonicalizeRelativePath } = require('./normalize');
+const { createTrustedRootRegistry } = require('./trustedRoots');
+const { describeContentGarbageCollection, runContentGarbageCollection } = require('./gcDesign');
+const { fail, REASON_CODES, KnowledgeStoreError } = require('../store/errors');
+const { resolveKnowledgeRoot, knowledgePaths, ensureLayoutDirs } = require('../store/layout');
+
+function ensureContentLayout(contentRoot) {
+  const root = path.resolve(contentRoot);
+  const objectsDir = path.join(root, CONTENT_LAYOUT.OBJECTS_DIR);
+  const tmpDir = path.join(root, CONTENT_LAYOUT.TMP_DIR);
+  fs.mkdirSync(objectsDir, { recursive: true });
+  fs.mkdirSync(tmpDir, { recursive: true });
+  return { root, objectsDir, tmpDir, manifest: path.join(root, CONTENT_LAYOUT.MANIFEST) };
+}
+
+function objectAbsolutePath(objectsDir, contentHash) {
+  const rel = contentObjectRelativePath(contentHash);
+  return path.join(objectsDir, ...rel.split('/'));
+}
+
+function writeFileAtomic(targetPath, bytes) {
+  const dir = path.dirname(targetPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.tmp-${process.pid}-${crypto.randomBytes(8).toString('hex')}`);
+  try {
+    fs.writeFileSync(tmp, bytes);
+    // Best-effort durability
+    try {
+      const fd = fs.openSync(tmp, 'r+');
+      try {
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      // fsync may be unavailable on some FS; atomic rename still applies
+    }
+    fs.renameSync(tmp, targetPath);
+  } catch (err) {
+    try {
+      if (fs.existsSync(tmp)) fs.unlinkSync(tmp);
+    } catch {
+      // ignore
+    }
+    throw err;
+  }
+}
+
+/**
+ * Create or open a content-addressed store under a content directory.
+ *
+ * @param {object} options
+ * @param {string} [options.contentDir] absolute/relative content directory
+ * @param {string} [options.knowledgeRoot] project-knowledge root (uses layout.contentDir)
+ * @param {Array<{rootId:string,path:string}>} [options.trustedRoots]
+ * @param {boolean} [options.readOnly]
+ * @param {number} [options.maxObjectBytes]
+ */
+function createContentStore(options = {}) {
+  const readOnly = Boolean(options.readOnly);
+  const maxObjectBytes =
+    options.maxObjectBytes == null ? DEFAULT_MAX_OBJECT_BYTES : Number(options.maxObjectBytes);
+  if (!Number.isInteger(maxObjectBytes) || maxObjectBytes < 1) {
+    fail(REASON_CODES.SCHEMA_INVALID, 'maxObjectBytes must be a positive integer');
+  }
+
+  let contentRoot;
+  if (options.contentDir) {
+    contentRoot = path.resolve(options.contentDir);
+  } else if (options.knowledgeRoot) {
+    const paths = knowledgePaths(options.knowledgeRoot);
+    contentRoot = paths.contentDir;
+  } else {
+    fail(REASON_CODES.PATH_UNSAFE, 'contentDir or knowledgeRoot is required');
+  }
+
+  if (!readOnly) {
+    ensureContentLayout(contentRoot);
+  } else if (!fs.existsSync(contentRoot)) {
+    fail(REASON_CODES.CONTENT_NOT_FOUND, 'content store directory does not exist');
+  }
+
+  const layout = ensureContentLayout(contentRoot);
+  const trustedRoots = createTrustedRootRegistry(options.trustedRoots || []);
+
+  if (!readOnly) {
+    const manifest = {
+      schemaVersion: 1,
+      kind: 'project-knowledge-content-manifest',
+      hashAlgorithm: CONTENT_HASH_ALGORITHM,
+      layout: {
+        objects: CONTENT_LAYOUT.OBJECTS_DIR,
+        tmp: CONTENT_LAYOUT.TMP_DIR,
+      },
+      updatedAt: new Date().toISOString(),
+    };
+    writeFileAtomic(layout.manifest, Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`, 'utf8'));
+  }
+
+  function assertWritable() {
+    if (readOnly) {
+      fail(REASON_CODES.STORE_UNAVAILABLE, 'content store is read-only');
+    }
+  }
+
+  function has(contentHash) {
+    const hash = requireContentHash(contentHash);
+    return fs.existsSync(objectAbsolutePath(layout.objectsDir, hash));
+  }
+
+  function stat(contentHash) {
+    const hash = requireContentHash(contentHash);
+    const abs = objectAbsolutePath(layout.objectsDir, hash);
+    if (!fs.existsSync(abs)) {
+      fail(REASON_CODES.CONTENT_NOT_FOUND, 'content object was not found');
+    }
+    const st = fs.statSync(abs);
+    return {
+      contentHash: hash,
+      sizeBytes: st.size,
+      algorithm: CONTENT_HASH_ALGORITHM,
+      path: abs,
+    };
+  }
+
+  function getBytes(contentHash) {
+    const hash = requireContentHash(contentHash);
+    const abs = objectAbsolutePath(layout.objectsDir, hash);
+    if (!fs.existsSync(abs)) {
+      fail(REASON_CODES.CONTENT_NOT_FOUND, 'content object was not found');
+    }
+    const bytes = fs.readFileSync(abs);
+    const actual = sha256Hex(bytes);
+    if (actual !== hash) {
+      fail(REASON_CODES.CONTENT_HASH_MISMATCH, 'stored content hash does not match payload');
+    }
+    return bytes;
+  }
+
+  /**
+   * Verify object exists and hash matches bytes on disk.
+   */
+  function verify(contentHash) {
+    try {
+      const hash = requireContentHash(contentHash);
+      const abs = objectAbsolutePath(layout.objectsDir, hash);
+      if (!fs.existsSync(abs)) {
+        return { ok: false, reasonCode: REASON_CODES.CONTENT_NOT_FOUND };
+      }
+      const bytes = fs.readFileSync(abs);
+      const actual = sha256Hex(bytes);
+      if (actual !== hash) {
+        return { ok: false, reasonCode: REASON_CODES.CONTENT_HASH_MISMATCH };
+      }
+      return { ok: true, reasonCode: null, sizeBytes: bytes.length };
+    } catch (err) {
+      if (err instanceof KnowledgeStoreError) {
+        return { ok: false, reasonCode: err.reasonCode };
+      }
+      return { ok: false, reasonCode: REASON_CODES.CONTENT_CORRUPT };
+    }
+  }
+
+  /**
+   * Put raw bytes/string after optional canonicalization.
+   * Deduplicates by content hash (second put is a no-op write).
+   */
+  function put(input, putOptions = {}) {
+    assertWritable();
+    const mode = putOptions.mode === 'text' ? 'text' : 'binary';
+    const { bytes, normalized } = canonicalizeContent(input, {
+      mode,
+      strictUtf8: putOptions.strictUtf8,
+    });
+
+    if (bytes.length > maxObjectBytes) {
+      fail(REASON_CODES.SOURCE_TOO_LARGE, 'content object exceeds configured size limit', {
+        sizeBytes: bytes.length,
+        maxObjectBytes,
+      });
+    }
+
+    const contentHash = sha256Hex(bytes);
+    const target = objectAbsolutePath(layout.objectsDir, contentHash);
+
+    if (fs.existsSync(target)) {
+      // Deduplicate: verify existing object matches
+      const existing = fs.readFileSync(target);
+      const existingHash = sha256Hex(existing);
+      if (existingHash !== contentHash) {
+        fail(REASON_CODES.CONTENT_CORRUPT, 'existing content object failed hash verification');
+      }
+      return {
+        contentHash,
+        sizeBytes: existing.length,
+        deduplicated: true,
+        normalized,
+        mode,
+        algorithm: CONTENT_HASH_ALGORITHM,
+      };
+    }
+
+    try {
+      writeFileAtomic(target, bytes);
+    } catch (err) {
+      fail(REASON_CODES.CONTENT_CORRUPT, 'failed to write content object atomically', {
+        message: err && err.message ? String(err.message) : undefined,
+      });
+    }
+
+    // Post-write verify
+    const check = verify(contentHash);
+    if (!check.ok) {
+      fail(
+        check.reasonCode || REASON_CODES.CONTENT_HASH_MISMATCH,
+        'post-write content verification failed'
+      );
+    }
+
+    return {
+      contentHash,
+      sizeBytes: bytes.length,
+      deduplicated: false,
+      normalized,
+      mode,
+      algorithm: CONTENT_HASH_ALGORITHM,
+    };
+  }
+
+  /**
+   * Put a file under a trusted root (path-controlled ingestion).
+   */
+  function putFile(rootId, relativePath, putOptions = {}) {
+    assertWritable();
+    if (trustedRoots.size() === 0) {
+      fail(REASON_CODES.UNTRUSTED_ROOT, 'no trusted roots configured for path ingestion');
+    }
+    const resolved = trustedRoots.resolveUnderRoot(rootId, relativePath);
+    if (!fs.existsSync(resolved.realPath)) {
+      fail(REASON_CODES.CONTENT_NOT_FOUND, 'source file was not found under trusted root');
+    }
+    let st;
+    try {
+      st = fs.lstatSync(resolved.absolutePath);
+    } catch {
+      st = fs.lstatSync(resolved.realPath);
+    }
+    if (st.isSymbolicLink()) {
+      // Ensure real path still inside root (already checked); reject dangling weirdness
+      if (!fs.statSync(resolved.realPath).isFile()) {
+        fail(REASON_CODES.PATH_UNSAFE, 'source path must be a regular file');
+      }
+    } else if (!st.isFile()) {
+      fail(REASON_CODES.PATH_UNSAFE, 'source path must be a regular file');
+    }
+
+    const bytes = fs.readFileSync(resolved.realPath);
+    const mode =
+      putOptions.mode === 'text' ? 'text' : putOptions.mode === 'binary' ? 'binary' : 'text';
+    const result = put(bytes, { ...putOptions, mode });
+    return {
+      ...result,
+      rootId,
+      relativePath: resolved.relativePath,
+    };
+  }
+
+  /**
+   * Put from absolute path that must fall under trusted rootId.
+   */
+  function putAbsoluteFile(rootId, absolutePath, putOptions = {}) {
+    assertWritable();
+    if (trustedRoots.size() === 0) {
+      fail(REASON_CODES.UNTRUSTED_ROOT, 'no trusted roots configured for path ingestion');
+    }
+    const resolved = trustedRoots.resolveAbsolute(rootId, absolutePath);
+    if (!fs.existsSync(resolved.realPath) || !fs.statSync(resolved.realPath).isFile()) {
+      fail(REASON_CODES.CONTENT_NOT_FOUND, 'source file was not found under trusted root');
+    }
+    const bytes = fs.readFileSync(resolved.realPath);
+    const mode = putOptions.mode === 'binary' ? 'binary' : 'text';
+    const result = put(bytes, { ...putOptions, mode });
+    const rel =
+      !resolved.relativePath || resolved.relativePath === '.'
+        ? path.basename(resolved.realPath)
+        : resolved.relativePath;
+    return {
+      ...result,
+      rootId,
+      relativePath: canonicalizeRelativePath(rel),
+    };
+  }
+
+  function getStatus() {
+    return {
+      contentRoot: layout.root,
+      readOnly,
+      hashAlgorithm: CONTENT_HASH_ALGORITHM,
+      maxObjectBytes,
+      trustedRootCount: trustedRoots.size(),
+      garbageCollection: describeContentGarbageCollection(),
+    };
+  }
+
+  return {
+    getStatus,
+    has,
+    stat,
+    getBytes,
+    verify,
+    put,
+    putFile,
+    putAbsoluteFile,
+    trustedRoots,
+    // GC design only
+    describeGarbageCollection: describeContentGarbageCollection,
+    runGarbageCollection: runContentGarbageCollection,
+    // paths for tests
+    _layout: layout,
+  };
+}
+
+/**
+ * Open content store from a project-knowledge root using standard layout.
+ */
+function openContentStoreFromKnowledgeRoot(knowledgeRoot, options = {}) {
+  const root = resolveKnowledgeRoot(knowledgeRoot);
+  if (!options.readOnly) {
+    ensureLayoutDirs(root);
+  }
+  return createContentStore({
+    knowledgeRoot: root,
+    trustedRoots: options.trustedRoots,
+    readOnly: options.readOnly,
+    maxObjectBytes: options.maxObjectBytes,
+  });
+}
+
+module.exports = {
+  createContentStore,
+  openContentStoreFromKnowledgeRoot,
+  ensureContentLayout,
+  writeFileAtomic,
+  objectAbsolutePath,
+};

--- a/src/projectIntelligence/content/gcDesign.js
+++ b/src/projectIntelligence/content/gcDesign.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * Garbage collection design for the Community content store (ZPI-04).
+ *
+ * Runtime GC is intentionally NOT implemented in this package.
+ * This module freezes the design contract so later packages can implement
+ * collection without changing content-address identity rules.
+ *
+ * Design summary:
+ * 1. Content objects are immutable and content-addressed (sha256).
+ * 2. Live set = union of content hashes referenced by:
+ *    - published snapshots' source units / evidence meta
+ *    - optional building snapshot still under writer lock
+ * 3. Unreferenced objects become GC candidates only after:
+ *    - no current or building snapshot references them
+ *    - optional grace period (not configured in v1)
+ * 4. GC must never delete an object that is being written (tmp/ staging)
+ *    or that fails hash verification (quarantine instead).
+ * 5. GC execution requires an exclusive writer lock on the knowledge root.
+ * 6. Quarantine path: move corrupt objects to `quarantine/` rather than silent delete.
+ *
+ * @module projectIntelligence/content/gcDesign
+ */
+
+const { GC_STATUS } = require('./constants');
+const { fail, REASON_CODES } = require('../store/errors');
+
+/**
+ * Describe the GC design (no side effects).
+ */
+function describeContentGarbageCollection() {
+  return {
+    status: GC_STATUS.DESIGN_ONLY,
+    algorithm: 'mark-and-sweep-by-hash-reference',
+    hashAlgorithm: 'sha256',
+    liveReferenceSources: [
+      'snapshots.source_units.content_hash',
+      'snapshots.evidence_meta.content_hash',
+      'optional in-progress building snapshot under writer lock',
+    ],
+    deletionPolicy: 'unreferenced-after-grace',
+    quarantinePolicy: 'hash-mismatch-or-corrupt-to-quarantine',
+    requiresWriterLock: true,
+    implemented: false,
+  };
+}
+
+/**
+ * Runtime GC entry point — fail closed until a later approved package.
+ */
+function runContentGarbageCollection() {
+  fail(
+    REASON_CODES.OPERATION_UNAVAILABLE,
+    'content garbage collection is design-only in ZPI-04 and is not implemented'
+  );
+}
+
+module.exports = {
+  describeContentGarbageCollection,
+  runContentGarbageCollection,
+  GC_STATUS,
+};

--- a/src/projectIntelligence/content/hash.js
+++ b/src/projectIntelligence/content/hash.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const crypto = require('crypto');
+const { CONTENT_HASH_ALGORITHM } = require('./constants');
+const { isSha256Hex } = require('../helpers');
+const { fail, REASON_CODES } = require('../store/errors');
+
+function sha256Hex(buffer) {
+  const buf = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
+  return crypto.createHash(CONTENT_HASH_ALGORITHM).update(buf).digest('hex');
+}
+
+function requireContentHash(contentHash) {
+  if (!isSha256Hex(contentHash)) {
+    fail(
+      REASON_CODES.CONTENT_HASH_MISMATCH,
+      'content hash must be lowercase sha256 hex (64 chars)'
+    );
+  }
+  return contentHash;
+}
+
+/**
+ * Object path segments for sha256: objects/ab/abcd...64
+ * Prevents flat directories with millions of files.
+ */
+function contentObjectRelativePath(contentHash) {
+  const hash = requireContentHash(contentHash);
+  const prefix = hash.slice(0, 2);
+  return `${prefix}/${hash}`;
+}
+
+module.exports = {
+  CONTENT_HASH_ALGORITHM,
+  sha256Hex,
+  requireContentHash,
+  contentObjectRelativePath,
+  isSha256Hex,
+};

--- a/src/projectIntelligence/content/index.js
+++ b/src/projectIntelligence/content/index.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * Project Intelligence Content Store (ZPI-04).
+ *
+ * Content-addressed local storage with trusted-root path controls.
+ * Garbage collection is design-only (not executed).
+ */
+
+const constants = require('./constants');
+const hash = require('./hash');
+const normalize = require('./normalize');
+const trustedRoots = require('./trustedRoots');
+const gcDesign = require('./gcDesign');
+const contentStore = require('./contentStore');
+
+module.exports = {
+  ...constants,
+  sha256Hex: hash.sha256Hex,
+  requireContentHash: hash.requireContentHash,
+  contentObjectRelativePath: hash.contentObjectRelativePath,
+  canonicalizeContent: normalize.canonicalizeContent,
+  canonicalizeRelativePath: normalize.canonicalizeRelativePath,
+  createTrustedRootRegistry: trustedRoots.createTrustedRootRegistry,
+  realpathSafe: trustedRoots.realpathSafe,
+  isInsideRoot: trustedRoots.isInsideRoot,
+  describeContentGarbageCollection: gcDesign.describeContentGarbageCollection,
+  runContentGarbageCollection: gcDesign.runContentGarbageCollection,
+  createContentStore: contentStore.createContentStore,
+  openContentStoreFromKnowledgeRoot: contentStore.openContentStoreFromKnowledgeRoot,
+  ensureContentLayout: contentStore.ensureContentLayout,
+  writeFileAtomic: contentStore.writeFileAtomic,
+};

--- a/src/projectIntelligence/content/normalize.js
+++ b/src/projectIntelligence/content/normalize.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * Canonical source normalization for content-addressed storage.
+ *
+ * Rules (Community v1):
+ * - Binary mode: bytes stored as-is (no transformation)
+ * - Text mode: UTF-8 decode (fail closed on invalid sequences when strict),
+ *   normalize newlines to LF, strip UTF-8 BOM
+ *
+ * Normalization is applied *before* hashing so identical logical source
+ * yields identical content hashes across platforms.
+ */
+
+const { fail, REASON_CODES } = require('../store/errors');
+const { isSafeRelativePath } = require('../helpers');
+
+/**
+ * @param {Buffer|string} input
+ * @param {{ mode?: 'binary'|'text', strictUtf8?: boolean }} [options]
+ * @returns {{ bytes: Buffer, mode: string, normalized: boolean }}
+ */
+function canonicalizeContent(input, options = {}) {
+  const mode = options.mode === 'text' ? 'text' : 'binary';
+  const strictUtf8 = options.strictUtf8 !== false;
+
+  if (mode === 'binary') {
+    const bytes = Buffer.isBuffer(input) ? Buffer.from(input) : Buffer.from(String(input), 'utf8');
+    return { bytes, mode, normalized: false };
+  }
+
+  let text;
+  if (typeof input === 'string') {
+    text = input;
+  } else if (Buffer.isBuffer(input)) {
+    if (strictUtf8) {
+      try {
+        const decoder = new TextDecoder('utf-8', { fatal: true });
+        text = decoder.decode(input);
+      } catch {
+        fail(REASON_CODES.CONTENT_CORRUPT, 'source content is not valid UTF-8');
+      }
+    } else {
+      text = input.toString('utf8');
+    }
+  } else {
+    fail(REASON_CODES.SCHEMA_INVALID, 'content input must be a Buffer or string');
+  }
+
+  const before = text;
+  // Strip UTF-8 BOM
+  if (text.charCodeAt(0) === 0xfeff) {
+    text = text.slice(1);
+  }
+  // CRLF / CR -> LF
+  text = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  return {
+    bytes: Buffer.from(text, 'utf8'),
+    mode: 'text',
+    normalized: text !== before,
+  };
+}
+
+/**
+ * Normalize relative source paths for inventory identity (posix, no traversal).
+ */
+function canonicalizeRelativePath(relativePath) {
+  if (typeof relativePath !== 'string' || !relativePath.trim()) {
+    fail(REASON_CODES.PATH_UNSAFE, 'relative path is required');
+  }
+  const posix = relativePath
+    .replace(/\\/g, '/')
+    .replace(/^\.\/+/, '')
+    .replace(/\/+/g, '/');
+  if (!isSafeRelativePath(posix)) {
+    fail(
+      REASON_CODES.PATH_TRAVERSAL,
+      'relative path must be safe (no absolute, drive, UNC, or traversal)'
+    );
+  }
+  return posix;
+}
+
+module.exports = {
+  canonicalizeContent,
+  canonicalizeRelativePath,
+};

--- a/src/projectIntelligence/content/trustedRoots.js
+++ b/src/projectIntelligence/content/trustedRoots.js
@@ -1,0 +1,222 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { fail, REASON_CODES } = require('../store/errors');
+const { canonicalizeRelativePath } = require('./normalize');
+
+function realpathSafe(target) {
+  try {
+    return fs.realpathSync.native
+      ? fs.realpathSync.native(path.resolve(target))
+      : fs.realpathSync(path.resolve(target));
+  } catch (err) {
+    if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) {
+      // Fall back to resolved path when the leaf does not exist yet.
+      const resolved = path.resolve(target);
+      const parent = path.dirname(resolved);
+      try {
+        const realParent = fs.realpathSync.native
+          ? fs.realpathSync.native(parent)
+          : fs.realpathSync(parent);
+        return path.join(realParent, path.basename(resolved));
+      } catch {
+        return resolved;
+      }
+    }
+    fail(REASON_CODES.PATH_UNSAFE, 'failed to resolve path', {
+      code: err && err.code,
+    });
+  }
+}
+
+function isInsideRoot(rootReal, candidateReal) {
+  const relative = path.relative(rootReal, candidateReal);
+  if (!relative) return true; // exact root
+  if (path.isAbsolute(relative)) return false;
+  if (relative === '..' || relative.startsWith(`..${path.sep}`)) return false;
+  return true;
+}
+
+/**
+ * Create a trusted-root registry for content ingestion path checks.
+ * @param {Array<{ rootId: string, path: string }>} roots
+ */
+function createTrustedRootRegistry(roots = []) {
+  if (!Array.isArray(roots)) {
+    fail(REASON_CODES.UNTRUSTED_ROOT, 'trustedRoots must be an array');
+  }
+
+  const byId = new Map();
+  for (const entry of roots) {
+    if (!entry || typeof entry.rootId !== 'string' || !entry.rootId.trim()) {
+      fail(REASON_CODES.UNTRUSTED_ROOT, 'trusted rootId is required');
+    }
+    if (typeof entry.path !== 'string' || !entry.path.trim()) {
+      fail(REASON_CODES.UNTRUSTED_ROOT, 'trusted root path is required');
+    }
+    if (byId.has(entry.rootId)) {
+      fail(REASON_CODES.UNTRUSTED_ROOT, 'duplicate trusted rootId');
+    }
+    const abs = path.resolve(entry.path);
+    if (!fs.existsSync(abs)) {
+      fail(REASON_CODES.UNTRUSTED_ROOT, 'trusted root path does not exist');
+    }
+    let stat;
+    try {
+      stat = fs.lstatSync(abs);
+    } catch {
+      fail(REASON_CODES.UNTRUSTED_ROOT, 'trusted root path is not accessible');
+    }
+    if (stat.isSymbolicLink()) {
+      // Allow root itself to be a symlink only if realpath stays a directory;
+      // still record the real path as the trust boundary.
+    }
+    const real = realpathSafe(abs);
+    const realStat = fs.statSync(real);
+    if (!realStat.isDirectory()) {
+      fail(REASON_CODES.UNTRUSTED_ROOT, 'trusted root must be a directory');
+    }
+    byId.set(entry.rootId, {
+      rootId: entry.rootId,
+      configuredPath: abs,
+      realPath: real,
+    });
+  }
+
+  function get(rootId) {
+    const root = byId.get(rootId);
+    if (!root) {
+      fail(REASON_CODES.UNTRUSTED_ROOT, 'unknown trusted rootId');
+    }
+    return root;
+  }
+
+  /**
+   * Resolve a path that must remain inside a trusted root after realpath.
+   * Rejects traversal, absolute escape, and symlink escape.
+   *
+   * @param {string} rootId
+   * @param {string} relativePath relative to the trusted root
+   * @returns {{ rootId, relativePath, absolutePath, realPath }}
+   */
+  function resolveUnderRoot(rootId, relativePath) {
+    const root = get(rootId);
+    const rel = canonicalizeRelativePath(relativePath);
+    const candidate = path.resolve(root.realPath, ...rel.split('/'));
+
+    // Structural containment before realpath
+    if (!isInsideRoot(root.realPath, candidate)) {
+      fail(REASON_CODES.PATH_ESCAPE, 'path escapes trusted root');
+    }
+
+    // If path exists, realpath must still be inside root (symlink escape).
+    let realCandidate;
+    try {
+      if (fs.existsSync(candidate)) {
+        realCandidate = realpathSafe(candidate);
+      } else {
+        // Resolve existing parent chain
+        realCandidate = realpathSafe(candidate);
+      }
+    } catch (err) {
+      if (err && err.reasonCode) throw err;
+      fail(REASON_CODES.PATH_UNSAFE, 'failed to resolve candidate path');
+    }
+
+    if (!isInsideRoot(root.realPath, realCandidate)) {
+      // Distinguish symlink escape when the logical path looked inside.
+      let symlinkEscape = false;
+      try {
+        const parts = rel.split('/');
+        let walk = root.realPath;
+        for (const part of parts) {
+          walk = path.join(walk, part);
+          if (fs.existsSync(walk) && fs.lstatSync(walk).isSymbolicLink()) {
+            symlinkEscape = true;
+            break;
+          }
+        }
+      } catch {
+        // ignore
+      }
+      fail(
+        symlinkEscape ? REASON_CODES.SYMLINK_ESCAPE : REASON_CODES.PATH_ESCAPE,
+        symlinkEscape ? 'symlink or junction escapes trusted root' : 'path escapes trusted root'
+      );
+    }
+
+    return {
+      rootId,
+      relativePath: rel,
+      absolutePath: candidate,
+      realPath: realCandidate,
+    };
+  }
+
+  /**
+   * Validate an absolute path is under a registered trusted root.
+   */
+  function resolveAbsolute(rootId, absolutePath) {
+    const root = get(rootId);
+    if (typeof absolutePath !== 'string' || !absolutePath.trim()) {
+      fail(REASON_CODES.PATH_UNSAFE, 'absolute path is required');
+    }
+    const abs = path.resolve(absolutePath);
+    const real = realpathSafe(abs);
+    if (!isInsideRoot(root.realPath, real)) {
+      // Check symlink on the path
+      let symlinkEscape = false;
+      try {
+        let walk = abs;
+        while (walk && walk !== path.dirname(walk)) {
+          if (fs.existsSync(walk) && fs.lstatSync(walk).isSymbolicLink()) {
+            const realWalk = realpathSafe(walk);
+            if (!isInsideRoot(root.realPath, realWalk)) {
+              symlinkEscape = true;
+              break;
+            }
+          }
+          const parent = path.dirname(walk);
+          if (parent === walk) break;
+          walk = parent;
+          if (walk === root.realPath || walk === root.configuredPath) break;
+        }
+      } catch {
+        // ignore
+      }
+      fail(
+        symlinkEscape ? REASON_CODES.SYMLINK_ESCAPE : REASON_CODES.UNTRUSTED_ROOT,
+        symlinkEscape ? 'symlink or junction escapes trusted root' : 'path is outside trusted root'
+      );
+    }
+    const relative = path.relative(root.realPath, real).split(path.sep).join('/');
+    return {
+      rootId,
+      relativePath: relative || '.',
+      absolutePath: abs,
+      realPath: real,
+    };
+  }
+
+  function list() {
+    return Array.from(byId.values()).map(r => ({
+      rootId: r.rootId,
+      path: r.configuredPath,
+    }));
+  }
+
+  return {
+    get,
+    list,
+    resolveUnderRoot,
+    resolveAbsolute,
+    size: () => byId.size,
+  };
+}
+
+module.exports = {
+  createTrustedRootRegistry,
+  realpathSafe,
+  isInsideRoot,
+};

--- a/src/projectIntelligence/index.js
+++ b/src/projectIntelligence/index.js
@@ -1,12 +1,13 @@
 'use strict';
 
 /**
- * Zeus Project Intelligence — Community contracts (ZPI-02) and store (ZPI-03).
+ * Zeus Project Intelligence — Community contracts, store, and content (ZPI-02..04).
  *
  * ZPI-02: contracts, reason codes, validators, fixtures, contract test kit.
  * ZPI-03: KnowledgeStore SPI + SQLite metadata provider, locks, migrations.
+ * ZPI-04: content-addressed store, trusted roots, path controls (GC design-only).
  *
- * Not included yet: content store, Lucene, analyzers, CLI/MCP.
+ * Not included yet: Lucene, analyzers, CLI/MCP.
  */
 
 const constants = require('./constants');
@@ -17,6 +18,7 @@ const fixtures = require('./fixtures');
 const validate = require('./validate');
 const { runProjectIntelligenceContractTests } = require('./contractTestKit');
 const store = require('./store');
+const content = require('./content');
 
 module.exports = {
   // Vocabulary
@@ -59,4 +61,13 @@ module.exports = {
   openProjectKnowledgeStore: store.openProjectKnowledgeStore,
   KnowledgeStoreError: store.KnowledgeStoreError,
   probeNodeSqlite: store.probeNodeSqlite,
+
+  // Content store (ZPI-04)
+  content,
+  createContentStore: content.createContentStore,
+  openContentStoreFromKnowledgeRoot: content.openContentStoreFromKnowledgeRoot,
+  canonicalizeContent: content.canonicalizeContent,
+  sha256Hex: content.sha256Hex,
+  describeContentGarbageCollection: content.describeContentGarbageCollection,
+  runContentGarbageCollection: content.runContentGarbageCollection,
 };

--- a/src/projectIntelligence/store/index.js
+++ b/src/projectIntelligence/store/index.js
@@ -4,7 +4,7 @@
  * Project Intelligence Knowledge Store (ZPI-03).
  *
  * Community SPI + SQLite metadata provider.
- * No Lucene, no content-addressed blob store, no CLI/MCP.
+ * Content blobs live in ../content (ZPI-04). No Lucene/CLI/MCP.
  */
 
 const constants = require('./constants');

--- a/tests/project-intelligence-content.test.js
+++ b/tests/project-intelligence-content.test.js
@@ -1,0 +1,245 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createContentStore,
+  openContentStoreFromKnowledgeRoot,
+  canonicalizeContent,
+  sha256Hex,
+  describeContentGarbageCollection,
+  runContentGarbageCollection,
+  KnowledgeStoreError,
+  REASON_CODES,
+  content,
+} = require('../src/projectIntelligence');
+
+function tempDir(label = 'zpi-content') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${label}-`));
+}
+
+test('text canonicalization normalizes CRLF and strips BOM before hash', () => {
+  const a = canonicalizeContent('\uFEFFhello\r\nworld\r\n', { mode: 'text' });
+  const b = canonicalizeContent('hello\nworld\n', { mode: 'text' });
+  assert.equal(sha256Hex(a.bytes), sha256Hex(b.bytes));
+  assert.equal(a.normalized, true);
+});
+
+test('put/get/dedupe and atomic content-addressed layout', () => {
+  const root = tempDir();
+  const store = createContentStore({ contentDir: path.join(root, 'content') });
+
+  const first = store.put('**free\ndcl-s x int(10);\n', { mode: 'text' });
+  assert.equal(first.deduplicated, false);
+  assert.equal(first.contentHash.length, 64);
+  assert.equal(store.has(first.contentHash), true);
+
+  const second = store.put('**free\r\ndcl-s x int(10);\r\n', { mode: 'text' });
+  assert.equal(second.deduplicated, true);
+  assert.equal(second.contentHash, first.contentHash);
+
+  const bytes = store.getBytes(first.contentHash);
+  assert.equal(bytes.toString('utf8'), '**free\ndcl-s x int(10);\n');
+  assert.equal(store.verify(first.contentHash).ok, true);
+
+  // Object path uses two-char prefix
+  const objectPath = path.join(
+    store._layout.objectsDir,
+    first.contentHash.slice(0, 2),
+    first.contentHash
+  );
+  assert.equal(fs.existsSync(objectPath), true);
+});
+
+test('hash mismatch on corrupted object fails closed', () => {
+  const root = tempDir();
+  const store = createContentStore({ contentDir: path.join(root, 'content') });
+  const put = store.put(Buffer.from('original-payload'), { mode: 'binary' });
+  const objectPath = path.join(
+    store._layout.objectsDir,
+    put.contentHash.slice(0, 2),
+    put.contentHash
+  );
+  fs.writeFileSync(objectPath, Buffer.from('tampered-payload'));
+
+  assert.throws(
+    () => store.getBytes(put.contentHash),
+    err =>
+      err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.CONTENT_HASH_MISMATCH
+  );
+  assert.equal(store.verify(put.contentHash).ok, false);
+  assert.equal(store.verify(put.contentHash).reasonCode, REASON_CODES.CONTENT_HASH_MISMATCH);
+});
+
+test('path traversal under trusted root is rejected', () => {
+  const root = tempDir();
+  const trusted = path.join(root, 'src');
+  fs.mkdirSync(trusted, { recursive: true });
+  fs.writeFileSync(path.join(trusted, 'ok.rpgle'), 'x\n', 'utf8');
+
+  const store = createContentStore({
+    contentDir: path.join(root, 'content'),
+    trustedRoots: [{ rootId: 'r1', path: trusted }],
+  });
+
+  assert.throws(
+    () => store.putFile('r1', '../escape.rpgle'),
+    err =>
+      err instanceof KnowledgeStoreError &&
+      (err.reasonCode === REASON_CODES.PATH_TRAVERSAL ||
+        err.reasonCode === REASON_CODES.PATH_ESCAPE)
+  );
+  assert.throws(
+    () => store.putFile('r1', 'C:\\Windows\\a.rpgle'),
+    err => err instanceof KnowledgeStoreError
+  );
+
+  const ok = store.putFile('r1', 'ok.rpgle', { mode: 'text' });
+  assert.equal(ok.relativePath, 'ok.rpgle');
+  assert.equal(store.has(ok.contentHash), true);
+});
+
+test('untrusted root and unknown rootId fail closed', () => {
+  const root = tempDir();
+  const trusted = path.join(root, 'src');
+  fs.mkdirSync(trusted, { recursive: true });
+  const store = createContentStore({
+    contentDir: path.join(root, 'content'),
+    trustedRoots: [{ rootId: 'r1', path: trusted }],
+  });
+
+  assert.throws(
+    () => store.putFile('nope', 'a.rpgle'),
+    err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.UNTRUSTED_ROOT
+  );
+
+  const bare = createContentStore({ contentDir: path.join(root, 'content2') });
+  assert.throws(
+    () => bare.putFile('r1', 'a.rpgle'),
+    err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.UNTRUSTED_ROOT
+  );
+});
+
+test('symlink escape is rejected when platform allows symlink creation', t => {
+  const root = tempDir('zpi-symlink');
+  const trusted = path.join(root, 'trusted');
+  const outside = path.join(root, 'outside');
+  fs.mkdirSync(trusted, { recursive: true });
+  fs.mkdirSync(outside, { recursive: true });
+  const secret = path.join(outside, 'secret.rpgle');
+  fs.writeFileSync(secret, 'secret\n', 'utf8');
+
+  const linkPath = path.join(trusted, 'escape.rpgle');
+  try {
+    fs.symlinkSync(secret, linkPath);
+  } catch (err) {
+    if (err && (err.code === 'EPERM' || err.code === 'ENOTSUP' || err.code === 'EACCES')) {
+      t.skip('symlink creation not permitted on this platform/user');
+      return;
+    }
+    throw err;
+  }
+
+  const store = createContentStore({
+    contentDir: path.join(root, 'content'),
+    trustedRoots: [{ rootId: 'r1', path: trusted }],
+  });
+
+  assert.throws(
+    () => store.putFile('r1', 'escape.rpgle'),
+    err =>
+      err instanceof KnowledgeStoreError &&
+      (err.reasonCode === REASON_CODES.SYMLINK_ESCAPE ||
+        err.reasonCode === REASON_CODES.PATH_ESCAPE ||
+        err.reasonCode === REASON_CODES.UNTRUSTED_ROOT)
+  );
+});
+
+test('atomic write leaves no partial object on failure mid-rename simulation', () => {
+  // Successful atomic put should not leave tmp files behind
+  const root = tempDir();
+  const contentDir = path.join(root, 'content');
+  const store = createContentStore({ contentDir });
+  store.put(Buffer.from('payload-a'), { mode: 'binary' });
+  const tmpDir = path.join(contentDir, 'tmp');
+  // object dir may have .tmp-* only transiently; after put, tmp dir should be empty or absent of leftovers in objects
+  if (fs.existsSync(tmpDir)) {
+    const leftovers = fs.readdirSync(tmpDir);
+    assert.equal(leftovers.length, 0);
+  }
+  // No .tmp-* in object prefix dirs
+  const objects = path.join(contentDir, 'objects');
+  function walk(dir) {
+    const names = fs.readdirSync(dir);
+    for (const name of names) {
+      assert.equal(name.startsWith('.tmp-'), false, `leftover tmp ${name}`);
+      const p = path.join(dir, name);
+      if (fs.statSync(p).isDirectory()) walk(p);
+    }
+  }
+  walk(objects);
+});
+
+test('duplicate content from different relative paths shares one object', () => {
+  const root = tempDir();
+  const trusted = path.join(root, 'src');
+  fs.mkdirSync(path.join(trusted, 'a'), { recursive: true });
+  fs.mkdirSync(path.join(trusted, 'b'), { recursive: true });
+  fs.writeFileSync(path.join(trusted, 'a', 'same.rpgle'), 'same-body\n', 'utf8');
+  fs.writeFileSync(path.join(trusted, 'b', 'same.rpgle'), 'same-body\n', 'utf8');
+
+  const store = createContentStore({
+    contentDir: path.join(root, 'content'),
+    trustedRoots: [{ rootId: 'r1', path: trusted }],
+  });
+  const one = store.putFile('r1', 'a/same.rpgle');
+  const two = store.putFile('r1', 'b/same.rpgle');
+  assert.equal(one.contentHash, two.contentHash);
+  assert.equal(two.deduplicated, true);
+});
+
+test('openContentStoreFromKnowledgeRoot uses standard layout', () => {
+  const knowledgeRoot = tempDir('zpi-kroot');
+  const store = openContentStoreFromKnowledgeRoot(knowledgeRoot, {
+    trustedRoots: [],
+  });
+  const put = store.put('x', { mode: 'text' });
+  assert.equal(
+    fs.existsSync(
+      path.join(knowledgeRoot, 'content', 'objects', put.contentHash.slice(0, 2), put.contentHash)
+    ),
+    true
+  );
+});
+
+test('garbage collection is design-only and fails closed on run', () => {
+  const design = describeContentGarbageCollection();
+  assert.equal(design.implemented, false);
+  assert.equal(design.status, 'design-only');
+  assert.throws(
+    () => runContentGarbageCollection(),
+    err =>
+      err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.OPERATION_UNAVAILABLE
+  );
+});
+
+test('oversized content is rejected', () => {
+  const root = tempDir();
+  const store = createContentStore({
+    contentDir: path.join(root, 'content'),
+    maxObjectBytes: 16,
+  });
+  assert.throws(
+    () => store.put(Buffer.alloc(32, 1), { mode: 'binary' }),
+    err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.SOURCE_TOO_LARGE
+  );
+});
+
+test('content module exports are available via projectIntelligence.content', () => {
+  assert.equal(typeof content.createContentStore, 'function');
+  assert.equal(typeof content.sha256Hex, 'function');
+});


### PR DESCRIPTION
## Summary

- Implements **ZPI-04 — Content Store**.
- Content-addressed `sha256` objects under `content/objects/ab/<hash>`.
- Trusted-root path controls with traversal/symlink escape refusal.
- Text canonicalization (BOM strip, CRLF→LF) before hash; binary mode as-is.
- Atomic write + deduplication; hash verification on read.
- Garbage collection: design-only (runtime fails closed).

## Test plan

- [x] content contract tests (dedupe, hash mismatch, traversal, GC design-only)
- [x] format/lint/typecheck
- [x] test:contract, public-claims, portability, package:smoke

## Next

ZPI-05 — Search SPI and Lucene provider.