### PR TITLE
feat: ZPI-05 community lexical search provider

### DIFF
--- a/docs/knowledgebase/README.md
+++ b/docs/knowledgebase/README.md
@@ -33,8 +33,10 @@ Current implementation status:
 - **ZPI-03 (store):** `src/projectIntelligence/store/` KnowledgeStore SPI + SQLite metadata provider
   (`node:sqlite`), writer locks, migrations, integrity checks
 - **ZPI-04 (content):** `src/projectIntelligence/content/` content-addressed object store (sha256),
-  trusted-root path controls, text canonicalization, atomic write/dedupe; GC is design-only —
-  still no Lucene, analyzer runtime, CLI, or MCP adapters
+  trusted-root path controls, text canonicalization, atomic write/dedupe; GC is design-only
+- **ZPI-05 (search):** `src/projectIntelligence/search/` Search SPI + Community pure-JS lexical
+  provider under the standard `lucene/` layout (Lucene-compatible document schema; Apache Lucene
+  Java binding still optional/future) — still no RPG analyzer runtime, CLI, or MCP adapters
 
 Local risk handling:
 

--- a/docs/knowledgebase/zpi-license-inventory.md
+++ b/docs/knowledgebase/zpi-license-inventory.md
@@ -64,11 +64,19 @@ ZPI implementation packages must preserve or establish:
 | Pure-JS sql.js      | Not selected for default                                         | Reserved as future fallback if engines must stay on Node 20 without `node:sqlite` |
 | Runtime requirement | Store operations require a Node build that exposes `node:sqlite` | Probe via `probeNodeSqlite()`; fail closed with `ZPI.STORE_UNAVAILABLE`           |
 
+## Resolved in ZPI-05 (search / lexical engine)
+
+| Decision                   | Choice                                                  | Notes                                                                                        |
+| -------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Search SPI                 | Community-owned under `src/projectIntelligence/search/` | Full-text, filters, ranking, rebuild, vector-ready schema                                    |
+| Default Community engine   | Pure-JS inverted index `zeus.community-lexical`         | No extra npm dependency; deterministic ranking; index under `lucene/` layout                 |
+| Apache Lucene Java binding | Deferred                                                | Architectural target remains Lucene (ADR-010); Node-safe binding is a later governance event |
+| Vector search              | Schema-ready only                                       | Optional `vector` field on documents; not used for ranking in v1                             |
+
 ## Unresolved decisions
 
-- exact Lucene runtime package, bridge, or hosting strategy
-- whether Lucene binding adds native compilation or bundled binaries
-- what Community `NOTICE` or third-party attribution process will be used once Lucene packages are
-  chosen
+- exact Apache Lucene runtime package, bridge, or hosting strategy for a future swap-in
+- whether a Lucene binding adds native compilation, JARs, or bundled binaries
+- what Community `NOTICE` attribution will be required once a Lucene package is chosen
 - whether future optional embedding or vector packages introduce new redistribution or model-license
   constraints

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -11,7 +11,8 @@ This directory is the home for versioned domain contract documentation.
 
 ZPI-03 adds the SQLite metadata store under `src/projectIntelligence/store/`.
 ZPI-04 adds the content-addressed blob store under `src/projectIntelligence/content/`.
-Search (Lucene) and analyzer packages remain later.
+ZPI-05 adds the search SPI and Community lexical provider under `src/projectIntelligence/search/`.
+Analyzer runtime and CLI/MCP packages remain later.
 
 ## Contract IDs (stable)
 

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -23,6 +23,7 @@ module.exports = {
       'tests/project-intelligence-contracts.test.js',
       'tests/project-intelligence-store.test.js',
       'tests/project-intelligence-content.test.js',
+      'tests/project-intelligence-search.test.js',
     ],
     smoke: [
       'tests/reproducible-output.test.js',

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -862,8 +862,8 @@ const zeus = {
   // Generation Validation Foundation (Iteration 29): offline candidate validation.
   // Never mutates the analyzed source workspace. review-ready is not compile readiness.
   generationValidation,
-  // Project Intelligence (ZPI-02..04: contracts, SQLite store, content store).
-  // No Lucene/analyzer/CLI/MCP adapters yet.
+  // Project Intelligence (ZPI-02..05: contracts, store, content, search).
+  // No RPG analyzer runtime / CLI / MCP adapters yet.
   projectIntelligence,
   // External module contracts (Iteration 30): trusted in-process registration only.
   // Core does not parse licenses or enforce commercial entitlement.

--- a/src/projectIntelligence/index.js
+++ b/src/projectIntelligence/index.js
@@ -1,13 +1,14 @@
 'use strict';
 
 /**
- * Zeus Project Intelligence — Community contracts, store, and content (ZPI-02..04).
+ * Zeus Project Intelligence — Community contracts, store, content, search (ZPI-02..05).
  *
  * ZPI-02: contracts, reason codes, validators, fixtures, contract test kit.
  * ZPI-03: KnowledgeStore SPI + SQLite metadata provider, locks, migrations.
  * ZPI-04: content-addressed store, trusted roots, path controls (GC design-only).
+ * ZPI-05: Search SPI + Community lexical provider (Lucene layout/schema).
  *
- * Not included yet: Lucene, analyzers, CLI/MCP.
+ * Not included yet: RPG analyzer runtime, CLI/MCP.
  */
 
 const constants = require('./constants');
@@ -19,6 +20,7 @@ const validate = require('./validate');
 const { runProjectIntelligenceContractTests } = require('./contractTestKit');
 const store = require('./store');
 const content = require('./content');
+const search = require('./search');
 
 module.exports = {
   // Vocabulary
@@ -70,4 +72,9 @@ module.exports = {
   sha256Hex: content.sha256Hex,
   describeContentGarbageCollection: content.describeContentGarbageCollection,
   runContentGarbageCollection: content.runContentGarbageCollection,
+
+  // Search (ZPI-05)
+  search,
+  createSearchProvider: search.createSearchProvider,
+  openSearchProvider: search.openSearchProvider,
 };

--- a/src/projectIntelligence/search/analyzer.js
+++ b/src/projectIntelligence/search/analyzer.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { ANALYZER_ID, ANALYZER_VERSION } = require('./constants');
+
+/**
+ * Standard Community lexical analyzer.
+ * - lowercase
+ * - split on non-alphanumeric (unicode letters/digits kept)
+ * - drop empty tokens
+ * Deterministic; no stemming/stopword lists in v1 (stable ranking).
+ */
+function analyzeText(text) {
+  if (text == null) return [];
+  const raw = String(text).toLowerCase();
+  const tokens = raw.split(/[^\p{L}\p{N}_]+/u).filter(Boolean);
+  return tokens;
+}
+
+function analyzerIdentity() {
+  return {
+    analyzerId: ANALYZER_ID,
+    analyzerVersion: ANALYZER_VERSION,
+  };
+}
+
+/**
+ * Build searchable bag of tokens from a document body + selected fields.
+ */
+function tokenizeDocument(doc) {
+  const parts = [];
+  if (doc.title) parts.push(String(doc.title));
+  if (doc.body) parts.push(String(doc.body));
+  if (doc.fields && typeof doc.fields === 'object') {
+    for (const key of Object.keys(doc.fields).sort()) {
+      const value = doc.fields[key];
+      if (value == null) continue;
+      if (typeof value === 'string' || typeof value === 'number') {
+        parts.push(String(value));
+      }
+    }
+  }
+  return analyzeText(parts.join('\n'));
+}
+
+module.exports = {
+  analyzeText,
+  analyzerIdentity,
+  tokenizeDocument,
+};

--- a/src/projectIntelligence/search/constants.js
+++ b/src/projectIntelligence/search/constants.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * Community search foundation (ZPI-05).
+ *
+ * Architectural target (ADR-010): Apache Lucene for lexical retrieval.
+ * ZPI-05 ships a pure-JS Lucene-compatible inverted index under the standard
+ * `lucene/` layout so Community stays offline, dependency-light, and
+ * deterministic. A future Lucene binding can replace the engine without
+ * changing the Search SPI or document schema.
+ */
+
+/** Search index schema version (independent of store/content). */
+const SEARCH_SCHEMA_VERSION = 1;
+
+/** Engine identity for the Community pure-JS lexical provider. */
+const ENGINE_ID = 'zeus.community-lexical';
+const ENGINE_VERSION = '1.0.0';
+
+/** Analyzer identity used for tokenization and ranking contracts. */
+const ANALYZER_ID = 'zeus.community-lexical.standard';
+const ANALYZER_VERSION = '1.0.0';
+
+/** Document kinds indexed by default. */
+const DOC_KINDS = Object.freeze([
+  'source-unit',
+  'symbol',
+  'relationship',
+  'evidence',
+  'summary',
+  'diagnostic',
+]);
+
+/** Default result bounds. */
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 200;
+
+const SEARCH_LAYOUT = Object.freeze({
+  MANIFEST: 'search-manifest.json',
+  DOCS: 'docs.json',
+  POSTINGS: 'postings.json',
+  GENERATION: 'generation.json',
+  QUARANTINE_MARKER: 'CORRUPT',
+});
+
+module.exports = {
+  SEARCH_SCHEMA_VERSION,
+  ENGINE_ID,
+  ENGINE_VERSION,
+  ANALYZER_ID,
+  ANALYZER_VERSION,
+  DOC_KINDS,
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+  SEARCH_LAYOUT,
+};

--- a/src/projectIntelligence/search/documentSchema.js
+++ b/src/projectIntelligence/search/documentSchema.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const { DOC_KINDS } = require('./constants');
+const { fail, REASON_CODES } = require('../store/errors');
+const { isSha256Hex } = require('../helpers');
+
+/**
+ * Vector-ready optional embedding field.
+ * Not used for ranking in Community v1 lexical baseline.
+ * @typedef {{ dims: number, values?: number[], modelId?: string }} VectorField
+ */
+
+/**
+ * Normalize and validate a search document.
+ * Fail-closed on missing identity or unknown kinds.
+ */
+function normalizeSearchDocument(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    fail(REASON_CODES.SCHEMA_INVALID, 'search document must be an object');
+  }
+  if (typeof raw.docId !== 'string' || !raw.docId.trim()) {
+    fail(REASON_CODES.SCHEMA_INVALID, 'docId is required');
+  }
+  if (typeof raw.projectId !== 'string' || !raw.projectId.trim()) {
+    fail(REASON_CODES.SCHEMA_INVALID, 'projectId is required');
+  }
+  if (typeof raw.snapshotId !== 'string' || !raw.snapshotId.trim()) {
+    fail(REASON_CODES.SCHEMA_INVALID, 'snapshotId is required');
+  }
+  if (typeof raw.kind !== 'string' || !DOC_KINDS.includes(raw.kind)) {
+    fail(REASON_CODES.UNKNOWN_ENUM_VALUE, 'document kind is unknown or missing');
+  }
+  if (raw.body != null && typeof raw.body !== 'string') {
+    fail(REASON_CODES.SCHEMA_INVALID, 'body must be a string when present');
+  }
+  if (raw.title != null && typeof raw.title !== 'string') {
+    fail(REASON_CODES.SCHEMA_INVALID, 'title must be a string when present');
+  }
+
+  const fields = {};
+  if (raw.fields != null) {
+    if (typeof raw.fields !== 'object' || Array.isArray(raw.fields)) {
+      fail(REASON_CODES.SCHEMA_INVALID, 'fields must be an object when present');
+    }
+    for (const [k, v] of Object.entries(raw.fields)) {
+      if (v == null) continue;
+      if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+        fields[k] = v;
+      } else {
+        fail(REASON_CODES.SCHEMA_INVALID, `fields.${k} must be a scalar`);
+      }
+    }
+  }
+
+  let vector = null;
+  if (raw.vector != null) {
+    if (typeof raw.vector !== 'object' || Array.isArray(raw.vector)) {
+      fail(REASON_CODES.SCHEMA_INVALID, 'vector must be an object when present');
+    }
+    const dims = Number(raw.vector.dims);
+    if (!Number.isInteger(dims) || dims < 1) {
+      fail(REASON_CODES.SCHEMA_INVALID, 'vector.dims must be a positive integer');
+    }
+    if (raw.vector.values != null) {
+      if (!Array.isArray(raw.vector.values) || raw.vector.values.length !== dims) {
+        fail(REASON_CODES.SCHEMA_INVALID, 'vector.values length must equal dims');
+      }
+      for (const n of raw.vector.values) {
+        if (typeof n !== 'number' || !Number.isFinite(n)) {
+          fail(REASON_CODES.SCHEMA_INVALID, 'vector.values must be finite numbers');
+        }
+      }
+    }
+    vector = {
+      dims,
+      values: raw.vector.values ? raw.vector.values.map(Number) : undefined,
+      modelId: raw.vector.modelId ? String(raw.vector.modelId) : undefined,
+    };
+  }
+
+  if (raw.contentHash != null && !isSha256Hex(raw.contentHash)) {
+    fail(
+      REASON_CODES.CONTENT_HASH_MISMATCH,
+      'contentHash must be lowercase sha256 hex when present'
+    );
+  }
+
+  // Reject absolute host paths in indexed metadata (no path leakage in hits).
+  if (fields.relativePath != null) {
+    const p = String(fields.relativePath);
+    if (p.startsWith('/') || p.startsWith('\\') || /^[A-Za-z]:[\\/]/.test(p) || p.includes('..')) {
+      fail(REASON_CODES.PATH_UNSAFE, 'fields.relativePath must be a safe relative path');
+    }
+  }
+
+  return {
+    docId: raw.docId.trim(),
+    projectId: raw.projectId.trim(),
+    snapshotId: raw.snapshotId.trim(),
+    kind: raw.kind,
+    title: raw.title ? String(raw.title) : '',
+    body: raw.body ? String(raw.body) : '',
+    fields,
+    contentHash: raw.contentHash || null,
+    vector,
+  };
+}
+
+module.exports = {
+  normalizeSearchDocument,
+  DOC_KINDS,
+};

--- a/src/projectIntelligence/search/fileIndexStore.js
+++ b/src/projectIntelligence/search/fileIndexStore.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  SEARCH_SCHEMA_VERSION,
+  ENGINE_ID,
+  ENGINE_VERSION,
+  ANALYZER_ID,
+  ANALYZER_VERSION,
+  SEARCH_LAYOUT,
+} = require('./constants');
+const { fail, REASON_CODES } = require('../store/errors');
+const { knowledgePaths, resolveKnowledgeRoot } = require('../store/layout');
+
+function resolveIndexDir(options = {}) {
+  if (options.indexDir) {
+    return path.resolve(options.indexDir);
+  }
+  if (options.knowledgeRoot) {
+    const root = resolveKnowledgeRoot(options.knowledgeRoot);
+    return knowledgePaths(root).luceneDir;
+  }
+  fail(REASON_CODES.PATH_UNSAFE, 'indexDir or knowledgeRoot is required');
+}
+
+function indexPaths(indexDir) {
+  const root = path.resolve(indexDir);
+  return {
+    root,
+    manifest: path.join(root, SEARCH_LAYOUT.MANIFEST),
+    docs: path.join(root, SEARCH_LAYOUT.DOCS),
+    postings: path.join(root, SEARCH_LAYOUT.POSTINGS),
+    generation: path.join(root, SEARCH_LAYOUT.GENERATION),
+    corruptMarker: path.join(root, SEARCH_LAYOUT.QUARANTINE_MARKER),
+  };
+}
+
+function writeJsonAtomic(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, `${JSON.stringify(value)}\n`, 'utf8');
+  fs.renameSync(tmp, filePath);
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    fail(REASON_CODES.INDEX_CORRUPT, 'search index file is unreadable or invalid JSON');
+  }
+}
+
+function writeManifest(indexDir, { projectId, snapshotId, docCount, generation }) {
+  const paths = indexPaths(indexDir);
+  const manifest = {
+    schemaVersion: 1,
+    kind: 'project-knowledge-search-manifest',
+    searchSchemaVersion: SEARCH_SCHEMA_VERSION,
+    engineId: ENGINE_ID,
+    engineVersion: ENGINE_VERSION,
+    analyzerId: ANALYZER_ID,
+    analyzerVersion: ANALYZER_VERSION,
+    projectId: projectId || null,
+    snapshotId: snapshotId || null,
+    docCount: docCount || 0,
+    generation: generation || 1,
+    updatedAt: new Date().toISOString(),
+  };
+  writeJsonAtomic(paths.manifest, manifest);
+  return manifest;
+}
+
+function loadIndexFiles(indexDir) {
+  const paths = indexPaths(indexDir);
+  if (fs.existsSync(paths.corruptMarker)) {
+    fail(REASON_CODES.INDEX_CORRUPT, 'search index is marked corrupt; rebuild required');
+  }
+  if (
+    !fs.existsSync(paths.manifest) ||
+    !fs.existsSync(paths.docs) ||
+    !fs.existsSync(paths.postings)
+  ) {
+    fail(REASON_CODES.INDEX_UNAVAILABLE, 'search index files are missing');
+  }
+  const manifest = readJson(paths.manifest);
+  if (Number(manifest.searchSchemaVersion) !== SEARCH_SCHEMA_VERSION) {
+    if (Number(manifest.searchSchemaVersion) > SEARCH_SCHEMA_VERSION) {
+      fail(REASON_CODES.INDEX_SCHEMA_MISMATCH, 'unsupported future search schema version');
+    }
+    fail(REASON_CODES.INDEX_REBUILD_REQUIRED, 'search schema migration/rebuild required');
+  }
+  if (manifest.engineId && manifest.engineId !== ENGINE_ID) {
+    fail(REASON_CODES.INDEX_SCHEMA_MISMATCH, 'search engine identity mismatch');
+  }
+  const docs = readJson(paths.docs);
+  const postings = readJson(paths.postings);
+  if (!Array.isArray(docs)) {
+    fail(REASON_CODES.INDEX_CORRUPT, 'docs index payload must be an array');
+  }
+  if (!postings || typeof postings !== 'object' || Array.isArray(postings)) {
+    fail(REASON_CODES.INDEX_CORRUPT, 'postings index payload must be an object');
+  }
+  return { manifest, docs, postings, paths };
+}
+
+function persistIndex(indexDir, { docs, postings, projectId, snapshotId, generation }) {
+  const paths = indexPaths(indexDir);
+  fs.mkdirSync(paths.root, { recursive: true });
+  // Remove corrupt marker on successful rebuild/write
+  if (fs.existsSync(paths.corruptMarker)) {
+    try {
+      fs.unlinkSync(paths.corruptMarker);
+    } catch {
+      // ignore
+    }
+  }
+  writeJsonAtomic(paths.docs, docs);
+  writeJsonAtomic(paths.postings, postings);
+  writeJsonAtomic(paths.generation, {
+    generation: generation || 1,
+    updatedAt: new Date().toISOString(),
+  });
+  return writeManifest(indexDir, {
+    projectId,
+    snapshotId,
+    docCount: Array.isArray(docs) ? docs.length : 0,
+    generation,
+  });
+}
+
+function markCorrupt(indexDir, reason = 'integrity failure') {
+  const paths = indexPaths(indexDir);
+  fs.mkdirSync(paths.root, { recursive: true });
+  fs.writeFileSync(
+    paths.corruptMarker,
+    `${JSON.stringify({ reason, markedAt: new Date().toISOString() })}\n`,
+    'utf8'
+  );
+}
+
+function exists(indexDir) {
+  const paths = indexPaths(indexDir);
+  return fs.existsSync(paths.manifest);
+}
+
+module.exports = {
+  resolveIndexDir,
+  indexPaths,
+  writeJsonAtomic,
+  loadIndexFiles,
+  persistIndex,
+  markCorrupt,
+  exists,
+  writeManifest,
+};

--- a/src/projectIntelligence/search/index.js
+++ b/src/projectIntelligence/search/index.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * Project Intelligence Search (ZPI-05).
+ *
+ * Search SPI + Community pure-JS lexical provider (Lucene layout/schema).
+ */
+
+const constants = require('./constants');
+const analyzer = require('./analyzer');
+const documentSchema = require('./documentSchema');
+const ranking = require('./ranking');
+const invertedIndex = require('./invertedIndex');
+const fileIndexStore = require('./fileIndexStore');
+const searchProvider = require('./searchProvider');
+
+module.exports = {
+  ...constants,
+  analyzeText: analyzer.analyzeText,
+  analyzerIdentity: analyzer.analyzerIdentity,
+  tokenizeDocument: analyzer.tokenizeDocument,
+  normalizeSearchDocument: documentSchema.normalizeSearchDocument,
+  scoreDocument: ranking.scoreDocument,
+  compareHits: ranking.compareHits,
+  createInvertedIndex: invertedIndex.createInvertedIndex,
+  resolveIndexDir: fileIndexStore.resolveIndexDir,
+  createSearchProvider: searchProvider.createSearchProvider,
+  openSearchProvider: searchProvider.openSearchProvider,
+};

--- a/src/projectIntelligence/search/invertedIndex.js
+++ b/src/projectIntelligence/search/invertedIndex.js
@@ -1,0 +1,299 @@
+'use strict';
+
+const { analyzeText, tokenizeDocument } = require('./analyzer');
+const { scoreDocument, compareHits } = require('./ranking');
+const { normalizeSearchDocument } = require('./documentSchema');
+const { DEFAULT_LIMIT, MAX_LIMIT } = require('./constants');
+const { fail, REASON_CODES } = require('../store/errors');
+
+/**
+ * In-memory inverted index (serializable).
+ */
+function createInvertedIndex() {
+  /** @type {Map<string, object>} */
+  const docs = new Map();
+  /** @type {Map<string, Map<string, number>>} term -> docId -> tf */
+  const postings = new Map();
+
+  function clear() {
+    docs.clear();
+    postings.clear();
+  }
+
+  function addDocument(rawDoc) {
+    const doc = normalizeSearchDocument(rawDoc);
+    // Replace existing
+    if (docs.has(doc.docId)) {
+      removeDocument(doc.docId);
+    }
+    const tokens = tokenizeDocument(doc);
+    const titleTokens = new Set(analyzeText(doc.title || ''));
+    const termFreqs = new Map();
+    for (const t of tokens) {
+      termFreqs.set(t, (termFreqs.get(t) || 0) + 1);
+    }
+    docs.set(doc.docId, {
+      ...doc,
+      termFreqs: Object.fromEntries(termFreqs),
+      titleTokens: Array.from(titleTokens).sort(),
+      tokenCount: tokens.length,
+    });
+    for (const [term, tf] of termFreqs) {
+      if (!postings.has(term)) postings.set(term, new Map());
+      postings.get(term).set(doc.docId, tf);
+    }
+    return doc.docId;
+  }
+
+  function removeDocument(docId) {
+    const existing = docs.get(docId);
+    if (!existing) return false;
+    const terms = Object.keys(existing.termFreqs || {});
+    for (const term of terms) {
+      const map = postings.get(term);
+      if (!map) continue;
+      map.delete(docId);
+      if (map.size === 0) postings.delete(term);
+    }
+    docs.delete(docId);
+    return true;
+  }
+
+  function addDocuments(rawDocs) {
+    if (!Array.isArray(rawDocs)) {
+      fail(REASON_CODES.SCHEMA_INVALID, 'documents must be an array');
+    }
+    const ids = [];
+    for (const d of rawDocs) {
+      ids.push(addDocument(d));
+    }
+    return ids;
+  }
+
+  function matchesFilters(doc, filters = {}) {
+    if (!filters || typeof filters !== 'object') return true;
+    if (filters.projectId != null && doc.projectId !== filters.projectId) return false;
+    if (filters.snapshotId != null && doc.snapshotId !== filters.snapshotId) return false;
+    if (filters.kind != null) {
+      const kinds = Array.isArray(filters.kind) ? filters.kind : [filters.kind];
+      if (!kinds.includes(doc.kind)) return false;
+    }
+    if (filters.fields && typeof filters.fields === 'object') {
+      for (const [k, v] of Object.entries(filters.fields)) {
+        if (doc.fields[k] !== v) return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Lexical search with filters, bounds, and deterministic ordering.
+   */
+  function search({ query, filters = {}, limit, offset } = {}) {
+    if (typeof query !== 'string' || !query.trim()) {
+      fail(REASON_CODES.SCHEMA_INVALID, 'query string is required');
+    }
+    const queryTokens = analyzeText(query);
+    if (queryTokens.length === 0) {
+      return {
+        hits: [],
+        totalMatched: 0,
+        limit: normalizeLimit(limit),
+        offset: normalizeOffset(offset),
+        omitted: false,
+        queryTokens: [],
+      };
+    }
+
+    const lim = normalizeLimit(limit);
+    const off = normalizeOffset(offset);
+    const docCount = docs.size;
+
+    // Candidate set: intersection of postings for AND semantics
+    let candidateIds = null;
+    const docFreqs = new Map();
+    for (const term of queryTokens) {
+      const map = postings.get(term);
+      docFreqs.set(term, map ? map.size : 0);
+      const ids = map ? new Set(map.keys()) : new Set();
+      if (candidateIds == null) {
+        candidateIds = ids;
+      } else {
+        const next = new Set();
+        for (const id of candidateIds) {
+          if (ids.has(id)) next.add(id);
+        }
+        candidateIds = next;
+      }
+    }
+    if (!candidateIds || candidateIds.size === 0) {
+      return {
+        hits: [],
+        totalMatched: 0,
+        limit: lim,
+        offset: off,
+        omitted: false,
+        queryTokens,
+      };
+    }
+
+    const hits = [];
+    for (const docId of candidateIds) {
+      const doc = docs.get(docId);
+      if (!doc || !matchesFilters(doc, filters)) continue;
+      const termFreqs = new Map(Object.entries(doc.termFreqs || {}));
+      const titleTokenSet = new Set(doc.titleTokens || []);
+      const score = scoreDocument({
+        queryTokens,
+        termFreqs,
+        docFreqs,
+        docCount,
+        titleTokenSet,
+      });
+      if (score <= 0) continue;
+      hits.push({
+        docId: doc.docId,
+        projectId: doc.projectId,
+        snapshotId: doc.snapshotId,
+        kind: doc.kind,
+        score,
+        title: doc.title || '',
+        // Snippets are redacted of absolute paths — only relative field when present
+        fields: sanitizeHitFields(doc.fields),
+        contentHash: doc.contentHash,
+      });
+    }
+
+    hits.sort(compareHits);
+    const totalMatched = hits.length;
+    const page = hits.slice(off, off + lim);
+    return {
+      hits: page,
+      totalMatched,
+      limit: lim,
+      offset: off,
+      omitted: off + lim < totalMatched,
+      queryTokens,
+    };
+  }
+
+  function serialize() {
+    const docList = Array.from(docs.values()).map(d => ({
+      docId: d.docId,
+      projectId: d.projectId,
+      snapshotId: d.snapshotId,
+      kind: d.kind,
+      title: d.title,
+      body: d.body,
+      fields: d.fields,
+      contentHash: d.contentHash,
+      vector: d.vector,
+      termFreqs: d.termFreqs,
+      titleTokens: d.titleTokens,
+      tokenCount: d.tokenCount,
+    }));
+    docList.sort((a, b) => a.docId.localeCompare(b.docId));
+
+    const postingsObj = {};
+    const terms = Array.from(postings.keys()).sort();
+    for (const term of terms) {
+      const map = postings.get(term);
+      const entries = Array.from(map.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+      postingsObj[term] = Object.fromEntries(entries);
+    }
+    return { docs: docList, postings: postingsObj };
+  }
+
+  function load(serialized) {
+    clear();
+    if (!serialized || typeof serialized !== 'object') {
+      fail(REASON_CODES.INDEX_CORRUPT, 'serialized index is invalid');
+    }
+    const docList = Array.isArray(serialized.docs) ? serialized.docs : [];
+    for (const d of docList) {
+      docs.set(d.docId, {
+        docId: d.docId,
+        projectId: d.projectId,
+        snapshotId: d.snapshotId,
+        kind: d.kind,
+        title: d.title || '',
+        body: d.body || '',
+        fields: d.fields || {},
+        contentHash: d.contentHash || null,
+        vector: d.vector || null,
+        termFreqs: d.termFreqs || {},
+        titleTokens: d.titleTokens || [],
+        tokenCount: d.tokenCount || 0,
+      });
+    }
+    const postingsObj =
+      serialized.postings && typeof serialized.postings === 'object' ? serialized.postings : {};
+    for (const [term, mapObj] of Object.entries(postingsObj)) {
+      const map = new Map();
+      for (const [docId, tf] of Object.entries(mapObj || {})) {
+        map.set(docId, Number(tf) || 0);
+      }
+      postings.set(term, map);
+    }
+  }
+
+  function size() {
+    return docs.size;
+  }
+
+  function getDoc(docId) {
+    return docs.get(docId) || null;
+  }
+
+  return {
+    clear,
+    addDocument,
+    addDocuments,
+    removeDocument,
+    search,
+    serialize,
+    load,
+    size,
+    getDoc,
+  };
+}
+
+function normalizeLimit(limit) {
+  if (limit == null) return DEFAULT_LIMIT;
+  const n = Number(limit);
+  if (!Number.isInteger(n) || n < 1) {
+    fail(REASON_CODES.SCHEMA_INVALID, 'limit must be a positive integer');
+  }
+  if (n > MAX_LIMIT) {
+    fail(REASON_CODES.RESULT_LIMIT_EXCEEDED, `limit exceeds max ${MAX_LIMIT}`);
+  }
+  return n;
+}
+
+function normalizeOffset(offset) {
+  if (offset == null) return 0;
+  const n = Number(offset);
+  if (!Number.isInteger(n) || n < 0) {
+    fail(REASON_CODES.SCHEMA_INVALID, 'offset must be a non-negative integer');
+  }
+  return n;
+}
+
+function sanitizeHitFields(fields) {
+  if (!fields || typeof fields !== 'object') return {};
+  const out = {};
+  for (const [k, v] of Object.entries(fields)) {
+    if (typeof v === 'string') {
+      // Never surface absolute-looking paths
+      if (v.startsWith('/') || /^[A-Za-z]:[\\/]/.test(v) || v.startsWith('\\\\')) continue;
+      out[k] = v;
+    } else if (typeof v === 'number' || typeof v === 'boolean') {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+module.exports = {
+  createInvertedIndex,
+};

--- a/src/projectIntelligence/search/ranking.js
+++ b/src/projectIntelligence/search/ranking.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/**
+ * Deterministic lexical ranking for Community v1.
+ *
+ * score = sum over query terms of:
+ *   tf component: 1 + ln(tf)
+ *   idf component: ln(1 + N / df)
+ *   field boost: title match * 2.0 (if term appears in title tokens)
+ *
+ * Tie-break (stable): higher score, then docId ascending, then kind ascending.
+ * Scores are advisory; ordered docIds are the contract.
+ */
+
+function ln(n) {
+  return Math.log(n);
+}
+
+/**
+ * @param {object} params
+ * @param {string[]} params.queryTokens
+ * @param {Map<string, number>} params.termFreqs term -> tf in doc
+ * @param {Map<string, number>} params.docFreqs term -> df
+ * @param {number} params.docCount
+ * @param {Set<string>} params.titleTokenSet
+ */
+function scoreDocument({ queryTokens, termFreqs, docFreqs, docCount, titleTokenSet }) {
+  let score = 0;
+  const N = Math.max(1, docCount);
+  for (const term of queryTokens) {
+    const tf = termFreqs.get(term) || 0;
+    if (tf <= 0) continue;
+    const df = Math.max(1, docFreqs.get(term) || 1);
+    const tfWeight = 1 + ln(tf);
+    const idf = ln(1 + N / df);
+    let termScore = tfWeight * idf;
+    if (titleTokenSet && titleTokenSet.has(term)) {
+      termScore *= 2.0;
+    }
+    score += termScore;
+  }
+  // Round to stable precision for cross-platform float noise
+  return Math.round(score * 1e6) / 1e6;
+}
+
+function compareHits(a, b) {
+  if (b.score !== a.score) return b.score - a.score;
+  if (a.docId < b.docId) return -1;
+  if (a.docId > b.docId) return 1;
+  if (a.kind < b.kind) return -1;
+  if (a.kind > b.kind) return 1;
+  return 0;
+}
+
+module.exports = {
+  scoreDocument,
+  compareHits,
+};

--- a/src/projectIntelligence/search/searchProvider.js
+++ b/src/projectIntelligence/search/searchProvider.js
@@ -1,0 +1,262 @@
+'use strict';
+
+const {
+  SEARCH_SCHEMA_VERSION,
+  ENGINE_ID,
+  ENGINE_VERSION,
+  ANALYZER_ID,
+  ANALYZER_VERSION,
+} = require('./constants');
+const { analyzerIdentity } = require('./analyzer');
+const { createInvertedIndex } = require('./invertedIndex');
+const {
+  resolveIndexDir,
+  loadIndexFiles,
+  persistIndex,
+  markCorrupt,
+  exists,
+  indexPaths,
+} = require('./fileIndexStore');
+const { fail, REASON_CODES, KnowledgeStoreError } = require('../store/errors');
+
+/**
+ * Create a Community lexical search provider (ZPI-05).
+ *
+ * Lucene-compatible SPI surface under the project `lucene/` layout.
+ * Engine is pure-JS inverted index with deterministic ranking.
+ */
+function createSearchProvider(options = {}) {
+  const readOnly = Boolean(options.readOnly);
+  const indexDir = resolveIndexDir(options);
+  const projectId = options.projectId || null;
+  let snapshotId = options.snapshotId || null;
+  let generation = 1;
+  let closed = false;
+
+  const index = createInvertedIndex();
+
+  // Load existing if present
+  if (exists(indexDir)) {
+    try {
+      const loaded = loadIndexFiles(indexDir);
+      index.load({ docs: loaded.docs, postings: loaded.postings });
+      snapshotId = loaded.manifest.snapshotId || snapshotId;
+      generation = Number(loaded.manifest.generation) || 1;
+    } catch (err) {
+      if (options.openMode === 'rebuild-on-corrupt') {
+        index.clear();
+        generation = 1;
+      } else if (err instanceof KnowledgeStoreError) {
+        throw err;
+      } else {
+        fail(REASON_CODES.INDEX_CORRUPT, 'failed to open search index');
+      }
+    }
+  } else if (readOnly) {
+    fail(REASON_CODES.INDEX_UNAVAILABLE, 'search index does not exist');
+  }
+
+  function assertOpen() {
+    if (closed) fail(REASON_CODES.STORE_UNAVAILABLE, 'search provider is closed');
+  }
+
+  function assertWritable() {
+    assertOpen();
+    if (readOnly) fail(REASON_CODES.STORE_UNAVAILABLE, 'search index is read-only');
+  }
+
+  function indexDocuments(docs) {
+    assertWritable();
+    return index.addDocuments(docs);
+  }
+
+  function commit({ snapshotId: snap } = {}) {
+    assertWritable();
+    if (snap) snapshotId = snap;
+    generation += 1;
+    const serialized = index.serialize();
+    const manifest = persistIndex(indexDir, {
+      docs: serialized.docs,
+      postings: serialized.postings,
+      projectId,
+      snapshotId,
+      generation,
+    });
+    return {
+      ok: true,
+      generation,
+      docCount: index.size(),
+      manifest,
+    };
+  }
+
+  /**
+   * Full rebuild: replace index contents atomically via rewrite + commit.
+   */
+  function rebuild(docs, rebuildOptions = {}) {
+    assertWritable();
+    if (!Array.isArray(docs)) {
+      fail(REASON_CODES.SCHEMA_INVALID, 'rebuild requires a documents array');
+    }
+    index.clear();
+    index.addDocuments(docs);
+    if (rebuildOptions.snapshotId) snapshotId = rebuildOptions.snapshotId;
+    generation += 1;
+    const serialized = index.serialize();
+    const manifest = persistIndex(indexDir, {
+      docs: serialized.docs,
+      postings: serialized.postings,
+      projectId,
+      snapshotId,
+      generation,
+    });
+    return {
+      ok: true,
+      rebuilt: true,
+      generation,
+      docCount: index.size(),
+      manifest,
+    };
+  }
+
+  function search(request = {}) {
+    assertOpen();
+    try {
+      const result = index.search(request);
+      return {
+        schemaVersion: 1,
+        kind: 'project-knowledge-search-result',
+        engineId: ENGINE_ID,
+        engineVersion: ENGINE_VERSION,
+        analyzerId: ANALYZER_ID,
+        analyzerVersion: ANALYZER_VERSION,
+        searchSchemaVersion: SEARCH_SCHEMA_VERSION,
+        projectId,
+        snapshotId,
+        query: request.query,
+        filters: request.filters || {},
+        hits: result.hits,
+        totalMatched: result.totalMatched,
+        limit: result.limit,
+        offset: result.offset,
+        omitted: result.omitted,
+        queryTokens: result.queryTokens,
+        // Rankings are derived aids, not source evidence
+        sourceOfTruth: false,
+        advisory: true,
+      };
+    } catch (err) {
+      if (err instanceof KnowledgeStoreError) throw err;
+      fail(REASON_CODES.RETRIEVAL_FAILED, 'search operation failed');
+    }
+  }
+
+  function checkIntegrity() {
+    assertOpen();
+    try {
+      if (!exists(indexDir)) {
+        return { ok: false, reasonCode: REASON_CODES.INDEX_UNAVAILABLE, messages: ['missing'] };
+      }
+      const loaded = loadIndexFiles(indexDir);
+      // Re-verify in-memory vs disk doc counts
+      if (loaded.docs.length !== index.size()) {
+        return {
+          ok: false,
+          reasonCode: REASON_CODES.INDEX_CORRUPT,
+          messages: ['doc count mismatch between memory and disk'],
+        };
+      }
+      // Spot-check: every doc has docId
+      for (const d of loaded.docs) {
+        if (!d.docId) {
+          return {
+            ok: false,
+            reasonCode: REASON_CODES.INDEX_CORRUPT,
+            messages: ['doc missing docId'],
+          };
+        }
+      }
+      return {
+        ok: true,
+        reasonCode: null,
+        messages: ['ok'],
+        docCount: index.size(),
+        generation,
+      };
+    } catch (err) {
+      if (err instanceof KnowledgeStoreError) {
+        return { ok: false, reasonCode: err.reasonCode, messages: [err.message] };
+      }
+      return {
+        ok: false,
+        reasonCode: REASON_CODES.INDEX_CORRUPT,
+        messages: ['integrity check failed'],
+      };
+    }
+  }
+
+  /**
+   * Mark index corrupt and clear memory. Call rebuild() to recover.
+   */
+  function markCorruptAndRequireRebuild(reason) {
+    assertWritable();
+    markCorrupt(indexDir, reason || 'manual corrupt mark');
+    index.clear();
+    return { ok: true, reasonCode: REASON_CODES.INDEX_REBUILD_REQUIRED };
+  }
+
+  /**
+   * Recover from corrupt index by rebuild with provided documents.
+   */
+  function recoverFromCorrupt(docs, recoverOptions = {}) {
+    assertWritable();
+    return rebuild(docs, recoverOptions);
+  }
+
+  function getStatus() {
+    return {
+      indexDir,
+      readOnly,
+      projectId,
+      snapshotId,
+      generation,
+      docCount: index.size(),
+      engineId: ENGINE_ID,
+      engineVersion: ENGINE_VERSION,
+      analyzer: analyzerIdentity(),
+      searchSchemaVersion: SEARCH_SCHEMA_VERSION,
+      closed,
+    };
+  }
+
+  function close() {
+    closed = true;
+  }
+
+  return {
+    // SPI
+    indexDocuments,
+    commit,
+    rebuild,
+    search,
+    checkIntegrity,
+    markCorruptAndRequireRebuild,
+    recoverFromCorrupt,
+    getStatus,
+    close,
+    // identity helpers
+    ENGINE_ID,
+    SEARCH_SCHEMA_VERSION,
+    _index: index,
+    _paths: indexPaths(indexDir),
+  };
+}
+
+function openSearchProvider(options = {}) {
+  return createSearchProvider({ ...options, openMode: options.openMode || 'strict' });
+}
+
+module.exports = {
+  createSearchProvider,
+  openSearchProvider,
+};

--- a/tests/project-intelligence-search.test.js
+++ b/tests/project-intelligence-search.test.js
@@ -1,0 +1,303 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createSearchProvider,
+  openSearchProvider,
+  KnowledgeStoreError,
+  REASON_CODES,
+  search,
+} = require('../src/projectIntelligence');
+
+function tempDir(label = 'zpi-search') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${label}-`));
+}
+
+function corpusDocs(projectId = 'proj-demo', snapshotId = 'snap-001') {
+  return [
+    {
+      docId: 'su-order',
+      projectId,
+      snapshotId,
+      kind: 'source-unit',
+      title: 'ORDERPGM',
+      body: 'ORDERPGM calls CUSTINQ and updates ORDER table status',
+      fields: { language: 'rpgle', relativePath: 'QRPGLESRC/ORDERPGM.rpgle' },
+    },
+    {
+      docId: 'su-cust',
+      projectId,
+      snapshotId,
+      kind: 'source-unit',
+      title: 'CUSTINQ',
+      body: 'CUSTINQ reads customer master by customer id',
+      fields: { language: 'rpgle', relativePath: 'QRPGLESRC/CUSTINQ.rpgle' },
+    },
+    {
+      docId: 'sym-order',
+      projectId,
+      snapshotId,
+      kind: 'symbol',
+      title: 'ORDERPGM',
+      body: 'program ORDERPGM',
+      fields: { symbolKind: 'PROGRAM' },
+    },
+    {
+      docId: 'sym-cust',
+      projectId,
+      snapshotId,
+      kind: 'symbol',
+      title: 'CUSTINQ',
+      body: 'program CUSTINQ',
+      fields: { symbolKind: 'PROGRAM' },
+    },
+    {
+      docId: 'ev-1',
+      projectId,
+      snapshotId,
+      kind: 'evidence',
+      title: 'call site',
+      body: 'callp CUSTINQ for customer inquiry',
+      fields: { relativePath: 'QRPGLESRC/ORDERPGM.rpgle' },
+    },
+  ];
+}
+
+test('index, search ranking corpus, deterministic ordering', () => {
+  const root = tempDir();
+  const provider = createSearchProvider({
+    indexDir: path.join(root, 'lucene'),
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+  });
+
+  provider.rebuild(corpusDocs());
+  const a = provider.search({ query: 'ORDERPGM CUSTINQ', limit: 10 });
+  const b = provider.search({ query: 'ORDERPGM CUSTINQ', limit: 10 });
+
+  assert.equal(a.sourceOfTruth, false);
+  assert.equal(a.advisory, true);
+  assert.ok(a.hits.length >= 1);
+  assert.deepEqual(
+    a.hits.map(h => h.docId),
+    b.hits.map(h => h.docId)
+  );
+  assert.deepEqual(
+    a.hits.map(h => h.score),
+    b.hits.map(h => h.score)
+  );
+
+  // Title boost: ORDERPGM title docs should rank ahead of body-only mentions when equal terms
+  const orderHits = provider.search({ query: 'ORDERPGM', limit: 10 });
+  assert.ok(orderHits.hits.length >= 2);
+  assert.equal(orderHits.hits[0].score >= orderHits.hits[1].score, true);
+
+  provider.close();
+});
+
+test('filters and bounded results with omission', () => {
+  const root = tempDir();
+  const provider = createSearchProvider({
+    indexDir: path.join(root, 'lucene'),
+    projectId: 'proj-demo',
+  });
+  provider.rebuild(corpusDocs());
+
+  const filtered = provider.search({
+    query: 'program',
+    filters: { kind: 'symbol' },
+    limit: 10,
+  });
+  assert.ok(filtered.hits.every(h => h.kind === 'symbol'));
+
+  const bounded = provider.search({ query: 'program OR customer OR order', limit: 2, offset: 0 });
+  // OR is not special — tokens are AND. Use single broad token
+  const broad = provider.search({ query: 'program', limit: 2 });
+  assert.ok(broad.hits.length <= 2);
+  if (broad.totalMatched > 2) {
+    assert.equal(broad.omitted, true);
+  }
+
+  assert.throws(
+    () => provider.search({ query: 'x', limit: 9999 }),
+    err =>
+      err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.RESULT_LIMIT_EXCEEDED
+  );
+  provider.close();
+  void bounded;
+});
+
+test('field filter and snapshot isolation', () => {
+  const root = tempDir();
+  const provider = createSearchProvider({ indexDir: path.join(root, 'lucene') });
+  const docs = [
+    ...corpusDocs('proj-demo', 'snap-001'),
+    {
+      docId: 'su-other',
+      projectId: 'proj-demo',
+      snapshotId: 'snap-002',
+      kind: 'source-unit',
+      title: 'OTHER',
+      body: 'ORDERPGM in another snapshot',
+      fields: { language: 'sqlrpgle', relativePath: 'OTHER.rpgle' },
+    },
+  ];
+  provider.rebuild(docs);
+
+  const onlySnap1 = provider.search({
+    query: 'ORDERPGM',
+    filters: { snapshotId: 'snap-001' },
+    limit: 20,
+  });
+  assert.ok(onlySnap1.hits.every(h => h.snapshotId === 'snap-001'));
+  assert.ok(!onlySnap1.hits.some(h => h.docId === 'su-other'));
+
+  const rpgle = provider.search({
+    query: 'CUSTINQ',
+    filters: { fields: { language: 'rpgle' } },
+    limit: 20,
+  });
+  assert.ok(rpgle.hits.every(h => h.fields.language === 'rpgle'));
+  provider.close();
+});
+
+test('vector-ready schema accepts optional vector without affecting lexical rank', () => {
+  const root = tempDir();
+  const provider = createSearchProvider({ indexDir: path.join(root, 'lucene') });
+  provider.rebuild([
+    {
+      docId: 'v1',
+      projectId: 'p',
+      snapshotId: 's',
+      kind: 'symbol',
+      title: 'ALPHA',
+      body: 'alpha program',
+      vector: { dims: 3, values: [0.1, 0.2, 0.3], modelId: 'test-embed' },
+    },
+    {
+      docId: 'v2',
+      projectId: 'p',
+      snapshotId: 's',
+      kind: 'symbol',
+      title: 'BETA',
+      body: 'beta program',
+    },
+  ]);
+  const res = provider.search({ query: 'program', limit: 10 });
+  assert.equal(res.hits.length, 2);
+  // Deterministic by score then docId
+  assert.deepEqual(res.hits.map(h => h.docId).sort(), ['v1', 'v2']);
+  provider.close();
+});
+
+test('persist, reopen, deterministic output', () => {
+  const indexDir = path.join(tempDir(), 'lucene');
+  const writer = createSearchProvider({
+    indexDir,
+    projectId: 'proj-demo',
+    snapshotId: 'snap-001',
+  });
+  writer.rebuild(corpusDocs());
+  const first = writer.search({ query: 'CUSTINQ', limit: 5 });
+  writer.close();
+
+  const reader = openSearchProvider({ indexDir, readOnly: true });
+  const second = reader.search({ query: 'CUSTINQ', limit: 5 });
+  assert.deepEqual(
+    first.hits.map(h => ({ id: h.docId, score: h.score })),
+    second.hits.map(h => ({ id: h.docId, score: h.score }))
+  );
+  assert.equal(reader.checkIntegrity().ok, true);
+  reader.close();
+});
+
+test('corrupt index fails closed and recovers via rebuild', () => {
+  const indexDir = path.join(tempDir(), 'lucene');
+  const provider = createSearchProvider({ indexDir, projectId: 'proj-demo' });
+  provider.rebuild(corpusDocs());
+  provider.close();
+
+  // Corrupt postings file
+  fs.writeFileSync(path.join(indexDir, 'postings.json'), '{not-json', 'utf8');
+
+  assert.throws(
+    () => openSearchProvider({ indexDir, readOnly: true }),
+    err =>
+      err instanceof KnowledgeStoreError &&
+      (err.reasonCode === REASON_CODES.INDEX_CORRUPT ||
+        err.reasonCode === REASON_CODES.INDEX_UNAVAILABLE)
+  );
+
+  // Recover with rebuild-on-corrupt open then rebuild
+  const recovery = createSearchProvider({
+    indexDir,
+    projectId: 'proj-demo',
+    openMode: 'rebuild-on-corrupt',
+  });
+  // After open with empty memory, rebuild
+  recovery.recoverFromCorrupt(corpusDocs(), { snapshotId: 'snap-001' });
+  const res = recovery.search({ query: 'ORDERPGM', limit: 5 });
+  assert.ok(res.hits.length >= 1);
+  assert.equal(recovery.checkIntegrity().ok, true);
+  recovery.close();
+});
+
+test('mark corrupt requires rebuild and search on empty is empty', () => {
+  const indexDir = path.join(tempDir(), 'lucene');
+  const provider = createSearchProvider({ indexDir });
+  provider.rebuild(corpusDocs());
+  provider.markCorruptAndRequireRebuild('test');
+  assert.equal(provider.getStatus().docCount, 0);
+  assert.throws(
+    () => openSearchProvider({ indexDir, readOnly: true }),
+    err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.INDEX_CORRUPT
+  );
+  provider.recoverFromCorrupt(corpusDocs());
+  assert.ok(provider.search({ query: 'customer', limit: 5 }).hits.length >= 1);
+  provider.close();
+});
+
+test('absolute path in relativePath field is rejected', () => {
+  const provider = createSearchProvider({ indexDir: path.join(tempDir(), 'lucene') });
+  assert.throws(
+    () =>
+      provider.indexDocuments([
+        {
+          docId: 'bad',
+          projectId: 'p',
+          snapshotId: 's',
+          kind: 'source-unit',
+          body: 'x',
+          fields: { relativePath: 'C:\\Windows\\x.rpgle' },
+        },
+      ]),
+    err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.PATH_UNSAFE
+  );
+  provider.close();
+});
+
+test('hits never include absolute path-like field values', () => {
+  const provider = createSearchProvider({ indexDir: path.join(tempDir(), 'lucene') });
+  provider.rebuild(corpusDocs());
+  const res = provider.search({ query: 'ORDERPGM', limit: 20 });
+  for (const hit of res.hits) {
+    for (const v of Object.values(hit.fields || {})) {
+      if (typeof v === 'string') {
+        assert.equal(/^[A-Za-z]:[\\/]/.test(v), false);
+        assert.equal(v.startsWith('/'), false);
+      }
+    }
+  }
+  provider.close();
+});
+
+test('search module exports engine identity constants', () => {
+  assert.equal(search.ENGINE_ID, 'zeus.community-lexical');
+  assert.equal(search.SEARCH_SCHEMA_VERSION, 1);
+  assert.equal(typeof search.analyzeText, 'function');
+});


### PR DESCRIPTION
## Summary

- Implements **ZPI-05 — Search SPI and Lucene Provider**.
- Community pure-JS lexical engine (`zeus.community-lexical`) under standard `lucene/` layout.
- Full-text AND search, metadata filters, deterministic ranking + tie-break, bounded results.
- Vector-ready optional document field (not used for ranking in v1).
- Rebuild, integrity checks, corrupt fail-closed + recovery path.
- Apache Lucene Java binding remains architectural target (documented); no extra npm dependency.

## Test plan

- [x] search contract tests
- [x] format/lint/typecheck/test:contract
- [x] public-claims, portability, package:smoke