### PR TITLE
feat: ZPI-06 snapshot and incremental update engine

### DIFF
--- a/docs/knowledgebase/README.md
+++ b/docs/knowledgebase/README.md
@@ -35,8 +35,10 @@ Current implementation status:
 - **ZPI-04 (content):** `src/projectIntelligence/content/` content-addressed object store (sha256),
   trusted-root path controls, text canonicalization, atomic write/dedupe; GC is design-only
 - **ZPI-05 (search):** `src/projectIntelligence/search/` Search SPI + Community pure-JS lexical
-  provider under the standard `lucene/` layout (Lucene-compatible document schema; Apache Lucene
-  Java binding still optional/future) — still no RPG analyzer runtime, CLI, or MCP adapters
+  provider under the standard `lucene/` layout
+- **ZPI-06 (snapshots):** `src/projectIntelligence/engine/` inventory, diff planner, invalidation,
+  baseline analyzer, atomic publish + current pointer / incremental update — still no full RPG
+  extractors (ZPI-07), CLI, or MCP adapters
 
 Local risk handling:
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -12,7 +12,8 @@ This directory is the home for versioned domain contract documentation.
 ZPI-03 adds the SQLite metadata store under `src/projectIntelligence/store/`.
 ZPI-04 adds the content-addressed blob store under `src/projectIntelligence/content/`.
 ZPI-05 adds the search SPI and Community lexical provider under `src/projectIntelligence/search/`.
-Analyzer runtime and CLI/MCP packages remain later.
+ZPI-06 adds the snapshot/incremental engine under `src/projectIntelligence/engine/`.
+Full RPG analyzer extractors and CLI/MCP packages remain later.
 
 ## Contract IDs (stable)
 

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -24,6 +24,7 @@ module.exports = {
       'tests/project-intelligence-store.test.js',
       'tests/project-intelligence-content.test.js',
       'tests/project-intelligence-search.test.js',
+      'tests/project-intelligence-engine.test.js',
     ],
     smoke: [
       'tests/reproducible-output.test.js',

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -862,8 +862,8 @@ const zeus = {
   // Generation Validation Foundation (Iteration 29): offline candidate validation.
   // Never mutates the analyzed source workspace. review-ready is not compile readiness.
   generationValidation,
-  // Project Intelligence (ZPI-02..05: contracts, store, content, search).
-  // No RPG analyzer runtime / CLI / MCP adapters yet.
+  // Project Intelligence (ZPI-02..06: contracts, store, content, search, snapshots).
+  // Full RPG extractors (ZPI-07) and CLI/MCP adapters remain later.
   projectIntelligence,
   // External module contracts (Iteration 30): trusted in-process registration only.
   // Core does not parse licenses or enforce commercial entitlement.

--- a/src/projectIntelligence/engine/baselineAnalyzer.js
+++ b/src/projectIntelligence/engine/baselineAnalyzer.js
@@ -1,0 +1,153 @@
+'use strict';
+
+const path = require('path');
+const { DERIVATION_CLASSES, ANALYZER_RUN_STATUSES, EVIDENCE_CLASSES } = require('../constants');
+const CONTRACT_IDS = require('../contractIds');
+
+const ANALYZER_ID = 'zeus.baseline-inventory-analyzer';
+const ANALYZER_VERSION = '1.0.0';
+
+/**
+ * Deterministic Community baseline analyzer (placeholder until ZPI-07 RPG extractors).
+ *
+ * For each source unit:
+ * - one PROGRAM/symbol derived from basename
+ * - one evidence meta row
+ * - optional CALL relationship if body text contains another unit basename (case-insensitive)
+ *
+ * Output is fully determined by unit paths, hashes, and canonical body text.
+ */
+function createBaselineAnalyzer(options = {}) {
+  const analyzerId = options.analyzerId || ANALYZER_ID;
+  const analyzerVersion = options.analyzerVersion || ANALYZER_VERSION;
+
+  function analyze({ projectId, snapshotId, units, bodiesByHash = {} }) {
+    const symbols = [];
+    const relationships = [];
+    const evidence = [];
+    const basenameToSymbolId = new Map();
+
+    const sorted = [...units].sort((a, b) => a.sourceUnitId.localeCompare(b.sourceUnitId));
+
+    for (const unit of sorted) {
+      const base = path.basename(unit.relativePath, path.extname(unit.relativePath));
+      const symbolId = `sym:${unit.sourceUnitId}`;
+      basenameToSymbolId.set(base.toUpperCase(), symbolId);
+
+      const provenance = {
+        projectId,
+        snapshotId,
+        sourceHash: unit.contentHash,
+        analyzerId,
+        analyzerVersion,
+        derivationClass: DERIVATION_CLASSES.VERIFIED,
+        sourceUnitId: unit.sourceUnitId,
+      };
+
+      symbols.push({
+        schemaVersion: 1,
+        kind: 'project-knowledge-symbol',
+        contractId: CONTRACT_IDS.SYMBOL,
+        projectId,
+        snapshotId,
+        symbolId,
+        name: base.toUpperCase(),
+        symbolKind: 'PROGRAM',
+        provenance,
+        evidenceReferences: [{ id: `ev:${unit.sourceUnitId}`, kind: 'source' }],
+        sourceSpanIds: [],
+        confidence: 'high',
+        _sourceUnitId: unit.sourceUnitId,
+      });
+
+      evidence.push({
+        schemaVersion: 1,
+        kind: 'project-knowledge-evidence',
+        contractId: CONTRACT_IDS.EVIDENCE,
+        projectId,
+        snapshotId,
+        evidenceId: `ev:${unit.sourceUnitId}`,
+        sourceUnitId: unit.sourceUnitId,
+        contentHash: unit.contentHash,
+        evidenceClass: EVIDENCE_CLASSES.SOURCE,
+        trustedRootId: unit.trustedRootId,
+        relativePath: unit.relativePath,
+        sourceSpanIds: [],
+      });
+    }
+
+    // Relationships: if body mentions another program basename as whole word
+    for (const unit of sorted) {
+      const body = bodiesByHash[unit.contentHash] || '';
+      const fromId = `sym:${unit.sourceUnitId}`;
+      const upper = String(body).toUpperCase();
+      for (const [base, toId] of basenameToSymbolId) {
+        if (toId === fromId) continue;
+        // Simple deterministic mention check
+        if (upper.includes(base)) {
+          relationships.push({
+            schemaVersion: 1,
+            kind: 'project-knowledge-relationship',
+            contractId: CONTRACT_IDS.RELATIONSHIP,
+            projectId,
+            snapshotId,
+            relationshipId: `rel:${fromId}->${toId}`,
+            relationshipType: 'PROGRAM_CALL',
+            fromSymbolId: fromId,
+            toSymbolId: toId,
+            provenance: {
+              projectId,
+              snapshotId,
+              sourceHash: unit.contentHash,
+              analyzerId,
+              analyzerVersion,
+              derivationClass: DERIVATION_CLASSES.INFERRED,
+              sourceUnitId: unit.sourceUnitId,
+            },
+            evidenceReferences: [{ id: `ev:${unit.sourceUnitId}`, kind: 'source' }],
+            confidence: 'medium',
+            _sourceUnitId: unit.sourceUnitId,
+          });
+        }
+      }
+    }
+
+    relationships.sort((a, b) => a.relationshipId.localeCompare(b.relationshipId));
+    symbols.sort((a, b) => a.symbolId.localeCompare(b.symbolId));
+    evidence.sort((a, b) => a.evidenceId.localeCompare(b.evidenceId));
+
+    const analyzerRun = {
+      schemaVersion: 1,
+      kind: 'project-knowledge-analyzer-run',
+      contractId: CONTRACT_IDS.ANALYZER_RUN,
+      projectId,
+      snapshotId,
+      analyzerRunId: `run:${analyzerId}:${snapshotId}`,
+      analyzerId,
+      analyzerVersion,
+      inputInventoryHash: '', // filled by engine
+      status: ANALYZER_RUN_STATUSES.SUCCEEDED,
+    };
+
+    return {
+      analyzerRun,
+      symbols,
+      relationships,
+      evidence,
+      analyzerId,
+      analyzerVersion,
+    };
+  }
+
+  return {
+    analyzerId,
+    analyzerVersion,
+    analyze,
+  };
+}
+
+module.exports = {
+  ANALYZER_ID,
+  ANALYZER_VERSION,
+  createBaselineAnalyzer,
+};

--- a/src/projectIntelligence/engine/diffPlanner.js
+++ b/src/projectIntelligence/engine/diffPlanner.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const { inventoryUnitKey, hashInventory } = require('./inventory');
+
+/**
+ * Classify source units as added / changed / deleted / unchanged.
+ * Identity key: trustedRootId + relativePath.
+ * Change detection: contentHash inequality.
+ *
+ * @param {Array<object>} previousUnits from last published snapshot (no _canonicalBytes needed)
+ * @param {Array<object>} nextUnits from current inventory scan
+ */
+function planInventoryDiff(previousUnits = [], nextUnits = []) {
+  const prevMap = new Map();
+  for (const u of previousUnits) {
+    prevMap.set(inventoryUnitKey(u), u);
+  }
+  const nextMap = new Map();
+  for (const u of nextUnits) {
+    nextMap.set(inventoryUnitKey(u), u);
+  }
+
+  const added = [];
+  const changed = [];
+  const unchanged = [];
+  const deleted = [];
+
+  for (const [key, next] of nextMap) {
+    const prev = prevMap.get(key);
+    if (!prev) {
+      added.push(next);
+    } else if (prev.contentHash !== next.contentHash) {
+      changed.push({ previous: prev, next });
+    } else {
+      unchanged.push({ previous: prev, next });
+    }
+  }
+  for (const [key, prev] of prevMap) {
+    if (!nextMap.has(key)) {
+      deleted.push(prev);
+    }
+  }
+
+  // Deterministic ordering
+  const byPath = (a, b) => {
+    const ua = a.next || a.previous || a;
+    const ub = b.next || b.previous || b;
+    return inventoryUnitKey(ua).localeCompare(inventoryUnitKey(ub));
+  };
+  added.sort((a, b) => inventoryUnitKey(a).localeCompare(inventoryUnitKey(b)));
+  changed.sort(byPath);
+  unchanged.sort(byPath);
+  deleted.sort((a, b) => inventoryUnitKey(a).localeCompare(inventoryUnitKey(b)));
+
+  return {
+    added,
+    changed,
+    deleted,
+    unchanged,
+    counts: {
+      added: added.length,
+      changed: changed.length,
+      deleted: deleted.length,
+      unchanged: unchanged.length,
+      previous: previousUnits.length,
+      next: nextUnits.length,
+    },
+    previousInventoryHash: hashInventory(previousUnits),
+    nextInventoryHash: hashInventory(nextUnits),
+    isNoOp:
+      added.length === 0 &&
+      changed.length === 0 &&
+      deleted.length === 0 &&
+      previousUnits.length === nextUnits.length,
+  };
+}
+
+module.exports = {
+  planInventoryDiff,
+};

--- a/src/projectIntelligence/engine/index.js
+++ b/src/projectIntelligence/engine/index.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/**
+ * Snapshot and incremental update engine (ZPI-06).
+ */
+
+const inventory = require('./inventory');
+const diffPlanner = require('./diffPlanner');
+const invalidation = require('./invalidation');
+const baselineAnalyzer = require('./baselineAnalyzer');
+const snapshotEngine = require('./snapshotEngine');
+
+module.exports = {
+  buildSourceInventory: inventory.buildSourceInventory,
+  hashInventory: inventory.hashInventory,
+  planInventoryDiff: diffPlanner.planInventoryDiff,
+  planInvalidation: invalidation.planInvalidation,
+  createBaselineAnalyzer: baselineAnalyzer.createBaselineAnalyzer,
+  ANALYZER_ID: baselineAnalyzer.ANALYZER_ID,
+  ANALYZER_VERSION: baselineAnalyzer.ANALYZER_VERSION,
+  createSnapshotEngine: snapshotEngine.createSnapshotEngine,
+  openSnapshotEngine: snapshotEngine.openSnapshotEngine,
+};

--- a/src/projectIntelligence/engine/invalidation.js
+++ b/src/projectIntelligence/engine/invalidation.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/**
+ * Invalidation planner for incremental snapshot builds.
+ *
+ * Community baseline (ZPI-06):
+ * - Source units that are deleted or changed invalidate all derived facts
+ *   whose primary sourceHash / sourceUnitId matches.
+ * - Unchanged source units keep their derived symbols, relationships, evidence.
+ * - Relationships are kept only if both endpoints remain in the kept symbol set
+ *   (conservative transitive invalidation).
+ */
+
+/**
+ * @param {object} diff from planInventoryDiff
+ * @param {object} previousFacts
+ * @param {Array} previousFacts.symbols
+ * @param {Array} previousFacts.relationships
+ * @param {Array} previousFacts.evidence
+ */
+function planInvalidation(diff, previousFacts = {}) {
+  const invalidatedSourceUnitIds = new Set();
+  for (const u of diff.deleted || []) {
+    invalidatedSourceUnitIds.add(u.sourceUnitId);
+  }
+  for (const entry of diff.changed || []) {
+    invalidatedSourceUnitIds.add(entry.previous.sourceUnitId);
+    // next id may differ only if path identity scheme changed; still invalidate previous
+    if (entry.next && entry.next.sourceUnitId !== entry.previous.sourceUnitId) {
+      invalidatedSourceUnitIds.add(entry.next.sourceUnitId);
+    }
+  }
+
+  const keptSourceUnitIds = new Set();
+  for (const entry of diff.unchanged || []) {
+    keptSourceUnitIds.add(entry.previous.sourceUnitId);
+  }
+
+  const prevSymbols = Array.isArray(previousFacts.symbols) ? previousFacts.symbols : [];
+  const prevRelationships = Array.isArray(previousFacts.relationships)
+    ? previousFacts.relationships
+    : [];
+  const prevEvidence = Array.isArray(previousFacts.evidence) ? previousFacts.evidence : [];
+
+  const keptSymbols = [];
+  const invalidatedSymbols = [];
+  for (const sym of prevSymbols) {
+    const srcIds = extractSourceUnitIds(sym);
+    if (srcIds.some(id => invalidatedSourceUnitIds.has(id))) {
+      invalidatedSymbols.push(sym);
+    } else if (srcIds.length === 0 || srcIds.every(id => keptSourceUnitIds.has(id))) {
+      keptSymbols.push(sym);
+    } else {
+      invalidatedSymbols.push(sym);
+    }
+  }
+
+  const keptSymbolIds = new Set(keptSymbols.map(s => s.symbolId));
+
+  const keptRelationships = [];
+  const invalidatedRelationships = [];
+  for (const rel of prevRelationships) {
+    const endpointsOk = keptSymbolIds.has(rel.fromSymbolId) && keptSymbolIds.has(rel.toSymbolId);
+    const srcIds = extractSourceUnitIds(rel);
+    const sourceOk =
+      srcIds.length === 0 ||
+      (srcIds.every(id => !invalidatedSourceUnitIds.has(id)) &&
+        srcIds.every(id => keptSourceUnitIds.has(id)));
+    if (endpointsOk && sourceOk) {
+      keptRelationships.push(rel);
+    } else {
+      invalidatedRelationships.push(rel);
+    }
+  }
+
+  const keptEvidence = [];
+  const invalidatedEvidence = [];
+  for (const ev of prevEvidence) {
+    if (invalidatedSourceUnitIds.has(ev.sourceUnitId)) {
+      invalidatedEvidence.push(ev);
+    } else if (keptSourceUnitIds.has(ev.sourceUnitId)) {
+      keptEvidence.push(ev);
+    } else {
+      invalidatedEvidence.push(ev);
+    }
+  }
+
+  return {
+    invalidatedSourceUnitIds: Array.from(invalidatedSourceUnitIds).sort(),
+    keptSourceUnitIds: Array.from(keptSourceUnitIds).sort(),
+    kept: {
+      symbols: keptSymbols,
+      relationships: keptRelationships,
+      evidence: keptEvidence,
+    },
+    invalidated: {
+      symbols: invalidatedSymbols,
+      relationships: invalidatedRelationships,
+      evidence: invalidatedEvidence,
+    },
+  };
+}
+
+function extractSourceUnitIds(entity) {
+  const ids = new Set();
+  if (entity && entity.sourceUnitId) ids.add(entity.sourceUnitId);
+  if (entity && Array.isArray(entity.sourceSpanIds)) {
+    // no reverse map in baseline; ignore spans
+  }
+  if (entity && Array.isArray(entity.evidenceReferences)) {
+    // evidence refs are ids not source units
+  }
+  // Convention: symbolId/relationship provenance may embed path in fields
+  if (entity && entity.fields && entity.fields.sourceUnitId) {
+    ids.add(entity.fields.sourceUnitId);
+  }
+  // Baseline analyzer tags sourceUnitId on symbols
+  if (entity && entity._sourceUnitId) ids.add(entity._sourceUnitId);
+  if (entity && entity.provenance && entity.provenance.sourceUnitId) {
+    ids.add(entity.provenance.sourceUnitId);
+  }
+  // Derive from evidenceReferences kind source-unit
+  if (entity && Array.isArray(entity.evidenceReferences)) {
+    for (const ref of entity.evidenceReferences) {
+      if (ref && ref.kind === 'source-unit' && ref.id) ids.add(ref.id);
+    }
+  }
+  return Array.from(ids);
+}
+
+module.exports = {
+  planInvalidation,
+  extractSourceUnitIds,
+};

--- a/src/projectIntelligence/engine/inventory.js
+++ b/src/projectIntelligence/engine/inventory.js
@@ -1,0 +1,190 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { sha256Hex } = require('../content/hash');
+const { canonicalizeContent, canonicalizeRelativePath } = require('../content/normalize');
+const { createTrustedRootRegistry, realpathSafe } = require('../content/trustedRoots');
+const { fail, REASON_CODES } = require('../store/errors');
+
+const DEFAULT_EXTENSIONS = Object.freeze([
+  '.rpgle',
+  '.sqlrpgle',
+  '.rpg',
+  '.clle',
+  '.clp',
+  '.sql',
+  '.pf',
+  '.lf',
+  '.dspf',
+  '.prtf',
+  '.bnd',
+  '.txt',
+  '.md',
+]);
+
+function guessLanguage(relativePath) {
+  const ext = path.extname(relativePath).toLowerCase();
+  if (ext === '.sqlrpgle') return 'sqlrpgle';
+  if (ext === '.rpgle' || ext === '.rpg') return 'rpgle';
+  if (ext === '.clle' || ext === '.clp') return 'clle';
+  if (ext === '.sql') return 'sql';
+  if (ext === '.md') return 'markdown';
+  return ext ? ext.slice(1) : 'unknown';
+}
+
+function shouldInclude(relativePath, extensions) {
+  const ext = path.extname(relativePath).toLowerCase();
+  return extensions.includes(ext);
+}
+
+function walkFiles(rootReal, baseRel, extensions, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(rootReal, { withFileTypes: true });
+  } catch {
+    fail(REASON_CODES.UNTRUSTED_ROOT, 'failed to read trusted root');
+  }
+  // Deterministic order
+  entries.sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    if (entry.name === '.' || entry.name === '..') continue;
+    if (entry.name.startsWith('.')) continue;
+    const abs = path.join(rootReal, entry.name);
+    const rel = baseRel ? `${baseRel}/${entry.name}` : entry.name;
+    let stat;
+    try {
+      stat = fs.lstatSync(abs);
+    } catch {
+      continue;
+    }
+    if (stat.isSymbolicLink()) {
+      // Resolve and ensure still under root
+      let real;
+      try {
+        real = realpathSafe(abs);
+      } catch {
+        fail(REASON_CODES.SYMLINK_ESCAPE, 'symlink under trusted root could not be resolved');
+      }
+      // Parent walk already constrained; re-check containment by prefix of realpath of root
+      // Defer to caller registry for put; here skip non-file symlink targets that escape via fail later
+      try {
+        const st = fs.statSync(real);
+        if (st.isDirectory()) {
+          walkFiles(real, rel.replace(/\\/g, '/'), extensions, out);
+        } else if (st.isFile()) {
+          const posix = canonicalizeRelativePath(rel.replace(/\\/g, '/'));
+          if (shouldInclude(posix, extensions)) {
+            out.push({ absolutePath: real, relativePath: posix });
+          }
+        }
+      } catch {
+        fail(REASON_CODES.SYMLINK_ESCAPE, 'symlink target is not accessible under trusted root');
+      }
+      continue;
+    }
+    if (stat.isDirectory()) {
+      walkFiles(abs, rel.replace(/\\/g, '/'), extensions, out);
+    } else if (stat.isFile()) {
+      const posix = canonicalizeRelativePath(rel.replace(/\\/g, '/'));
+      if (shouldInclude(posix, extensions)) {
+        out.push({ absolutePath: abs, relativePath: posix });
+      }
+    }
+  }
+}
+
+/**
+ * Build a deterministic source inventory from trusted roots.
+ * Content is hashed after text canonicalization (BOM/CRLF) for source-like files.
+ *
+ * @returns {{
+ *   units: Array<object>,
+ *   inventoryHash: string,
+ *   unitCount: number
+ * }}
+ */
+function buildSourceInventory({
+  trustedRoots,
+  extensions = DEFAULT_EXTENSIONS,
+  hashMode = 'text',
+} = {}) {
+  if (!Array.isArray(trustedRoots) || trustedRoots.length === 0) {
+    fail(REASON_CODES.UNTRUSTED_ROOT, 'at least one trusted root is required');
+  }
+  // Validate roots exist
+  createTrustedRootRegistry(trustedRoots);
+
+  const units = [];
+  for (const root of trustedRoots) {
+    const rootReal = realpathSafe(root.path);
+    const files = [];
+    walkFiles(rootReal, '', extensions, files);
+    for (const file of files) {
+      // Symlink escape: ensure real path stays under rootReal
+      const realFile = realpathSafe(file.absolutePath);
+      const relCheck = path.relative(rootReal, realFile);
+      if (
+        relCheck.startsWith('..') ||
+        path.isAbsolute(relCheck) ||
+        relCheck.includes(`..${path.sep}`)
+      ) {
+        fail(REASON_CODES.SYMLINK_ESCAPE, 'source path escapes trusted root');
+      }
+      const raw = fs.readFileSync(realFile);
+      const { bytes } = canonicalizeContent(raw, {
+        mode: hashMode === 'binary' ? 'binary' : 'text',
+      });
+      const contentHash = sha256Hex(bytes);
+      const relativePath = file.relativePath;
+      const sourceUnitId = `su:${root.rootId}:${relativePath}`;
+      units.push({
+        sourceUnitId,
+        trustedRootId: root.rootId,
+        relativePath,
+        contentHash,
+        sizeBytes: bytes.length,
+        language: guessLanguage(relativePath),
+        hashAlgorithm: 'sha256',
+        // raw bytes for content store put (canonical)
+        _canonicalBytes: bytes,
+      });
+    }
+  }
+
+  units.sort((a, b) => {
+    if (a.trustedRootId !== b.trustedRootId) {
+      return a.trustedRootId.localeCompare(b.trustedRootId);
+    }
+    return a.relativePath.localeCompare(b.relativePath);
+  });
+
+  const inventoryHash = hashInventory(units);
+  return {
+    units,
+    inventoryHash,
+    unitCount: units.length,
+  };
+}
+
+/**
+ * Stable inventory identity hash.
+ */
+function hashInventory(units) {
+  const lines = units.map(
+    u => `${u.trustedRootId}\0${u.relativePath}\0${u.contentHash}\0${u.sizeBytes}`
+  );
+  return sha256Hex(Buffer.from(`${lines.join('\n')}\n`, 'utf8'));
+}
+
+function inventoryUnitKey(unit) {
+  return `${unit.trustedRootId}\0${unit.relativePath}`;
+}
+
+module.exports = {
+  DEFAULT_EXTENSIONS,
+  buildSourceInventory,
+  hashInventory,
+  inventoryUnitKey,
+  guessLanguage,
+};

--- a/src/projectIntelligence/engine/snapshotEngine.js
+++ b/src/projectIntelligence/engine/snapshotEngine.js
@@ -1,0 +1,575 @@
+'use strict';
+
+const crypto = require('crypto');
+const { createProjectKnowledgeStore, openProjectKnowledgeStore } = require('../store/createStore');
+const { openContentStoreFromKnowledgeRoot } = require('../content/contentStore');
+const { createSearchProvider } = require('../search/searchProvider');
+const { STORE_SCHEMA_VERSION } = require('../store/constants');
+const { SEARCH_SCHEMA_VERSION } = require('../search/constants');
+const { SNAPSHOT_STATUSES } = require('../constants');
+const CONTRACT_IDS = require('../contractIds');
+const { fail, REASON_CODES, KnowledgeStoreError } = require('../store/errors');
+const { probeNodeSqlite } = require('../store/sqliteDriver');
+const { buildSourceInventory } = require('./inventory');
+const { planInventoryDiff } = require('./diffPlanner');
+const { planInvalidation } = require('./invalidation');
+const { createBaselineAnalyzer } = require('./baselineAnalyzer');
+
+const ARTIFACT_SCHEMA_VERSION = 1;
+
+function isoNow() {
+  return new Date().toISOString();
+}
+
+function stripInternal(entity) {
+  if (!entity || typeof entity !== 'object') return entity;
+  const copy = { ...entity };
+  delete copy._canonicalBytes;
+  delete copy._sourceUnitId;
+  if (copy.provenance && copy.provenance.sourceUnitId) {
+    // keep sourceUnitId in provenance for invalidation round-trips (allowed extra field)
+  }
+  return copy;
+}
+
+function rewriteSnapshotIds(entities, projectId, snapshotId, mapFn) {
+  return entities.map(e => {
+    const next = mapFn ? mapFn({ ...e }) : { ...e };
+    next.projectId = projectId;
+    next.snapshotId = snapshotId;
+    if (next.provenance) {
+      next.provenance = { ...next.provenance, projectId, snapshotId };
+    }
+    return stripInternal(next);
+  });
+}
+
+/**
+ * Create a new project knowledge workspace + snapshot engine.
+ */
+function createSnapshotEngine(options = {}) {
+  if (!probeNodeSqlite().available) {
+    fail(
+      REASON_CODES.STORE_UNAVAILABLE,
+      'SQLite driver unavailable (requires Node.js node:sqlite / DatabaseSync)'
+    );
+  }
+  const { knowledgeRoot, projectId, displayName, trustedRoots, analyzer } = options;
+  if (!knowledgeRoot || !projectId) {
+    fail(REASON_CODES.PROJECT_ID_INVALID, 'knowledgeRoot and projectId are required');
+  }
+  if (!Array.isArray(trustedRoots) || trustedRoots.length === 0) {
+    fail(REASON_CODES.UNTRUSTED_ROOT, 'trustedRoots are required');
+  }
+
+  const store = createProjectKnowledgeStore({
+    rootPath: knowledgeRoot,
+    projectId,
+    displayName,
+    trustedRoots: trustedRoots.map(r => ({
+      rootId: r.rootId,
+      relativeLabel: r.relativeLabel || r.rootId,
+      // store contract allows relativeLabel; absolute path is engine-only
+    })),
+  });
+
+  return wrapEngine({
+    store,
+    knowledgeRoot,
+    projectId,
+    trustedRoots,
+    analyzer: analyzer || createBaselineAnalyzer(),
+    readOnly: false,
+  });
+}
+
+/**
+ * Open existing workspace.
+ */
+function openSnapshotEngine(options = {}) {
+  if (!probeNodeSqlite().available) {
+    fail(
+      REASON_CODES.STORE_UNAVAILABLE,
+      'SQLite driver unavailable (requires Node.js node:sqlite / DatabaseSync)'
+    );
+  }
+  const { knowledgeRoot, projectId, trustedRoots, analyzer, readOnly = false } = options;
+  if (!knowledgeRoot) {
+    fail(REASON_CODES.PATH_UNSAFE, 'knowledgeRoot is required');
+  }
+  const store = openProjectKnowledgeStore({
+    rootPath: knowledgeRoot,
+    projectId,
+    readOnly,
+  });
+  const project = store.getProject();
+  return wrapEngine({
+    store,
+    knowledgeRoot,
+    projectId: project.projectId,
+    trustedRoots: trustedRoots || [],
+    analyzer: analyzer || createBaselineAnalyzer(),
+    readOnly,
+  });
+}
+
+function wrapEngine({ store, knowledgeRoot, projectId, trustedRoots, analyzer, readOnly }) {
+  let closed = false;
+
+  function assertOpen() {
+    if (closed) fail(REASON_CODES.STORE_UNAVAILABLE, 'snapshot engine is closed');
+  }
+
+  function assertWritable() {
+    assertOpen();
+    if (readOnly) fail(REASON_CODES.STORE_UNAVAILABLE, 'snapshot engine is read-only');
+  }
+
+  function openContent(ro = readOnly) {
+    return openContentStoreFromKnowledgeRoot(knowledgeRoot, {
+      trustedRoots: trustedRoots.map(r => ({ rootId: r.rootId, path: r.path })),
+      readOnly: ro,
+    });
+  }
+
+  function openSearch(ro = readOnly) {
+    return createSearchProvider({
+      knowledgeRoot,
+      projectId,
+      readOnly: ro,
+      openMode: 'rebuild-on-corrupt',
+    });
+  }
+
+  /**
+   * Read current published snapshot or fail closed.
+   */
+  function getCurrentSnapshot() {
+    assertOpen();
+    return store.getCurrentSnapshot(projectId);
+  }
+
+  /**
+   * Refuse serving when live inventory no longer matches published inventory hash.
+   */
+  function assertCurrentNotStale() {
+    assertOpen();
+    const current = store.getCurrentSnapshot(projectId);
+    if (!trustedRoots.length) {
+      return { ok: true, current };
+    }
+    const live = buildSourceInventory({ trustedRoots });
+    if (live.inventoryHash !== current.sourceInventoryHash) {
+      fail(
+        REASON_CODES.SNAPSHOT_STALE,
+        'published snapshot inventory is stale relative to sources'
+      );
+    }
+    return { ok: true, current, inventoryHash: live.inventoryHash };
+  }
+
+  function loadPreviousFacts(snapshotId) {
+    return {
+      units: store.listSourceUnits(projectId, snapshotId),
+      symbols: store.listSymbols(projectId, snapshotId),
+      relationships: store.listRelationships(projectId, snapshotId),
+      // evidence listing via private query - use list if available
+      evidence: listEvidence(store, projectId, snapshotId),
+    };
+  }
+
+  function listEvidence(storeHandle, pid, sid) {
+    // Store API may not expose listEvidence — use internal db if present
+    if (storeHandle._store && storeHandle._store._db) {
+      const rows = storeHandle._store._db.all(
+        `SELECT payload_json FROM evidence_meta
+         WHERE project_id = @project_id AND snapshot_id = @snapshot_id
+         ORDER BY evidence_id ASC`,
+        { project_id: pid, snapshot_id: sid }
+      );
+      return rows.map(r => JSON.parse(r.payload_json));
+    }
+    return [];
+  }
+
+  /**
+   * Full rebuild from trusted roots.
+   */
+  function fullRebuild(rebuildOptions = {}) {
+    assertWritable();
+    const inv = buildSourceInventory({
+      trustedRoots,
+      extensions: rebuildOptions.extensions,
+    });
+    return publishFromPlan({
+      mode: 'full',
+      inventory: inv,
+      unitsToAnalyze: inv.units,
+      keptFacts: { symbols: [], relationships: [], evidence: [] },
+      diff: planInventoryDiff([], inv.units),
+    });
+  }
+
+  /**
+   * Incremental update: reuse facts for unchanged units, re-analyze added/changed.
+   * Falls back to full rebuild when no current snapshot exists.
+   */
+  function incrementalUpdate(updateOptions = {}) {
+    assertWritable();
+    const inv = buildSourceInventory({
+      trustedRoots,
+      extensions: updateOptions.extensions,
+    });
+
+    let previousUnits = [];
+    let previousFacts = { symbols: [], relationships: [], evidence: [] };
+    let hasCurrent = false;
+    try {
+      const current = store.getCurrentSnapshot(projectId);
+      hasCurrent = true;
+      previousFacts = loadPreviousFacts(current.snapshotId);
+      previousUnits = previousFacts.units;
+    } catch (err) {
+      const noCurrent =
+        err instanceof KnowledgeStoreError &&
+        (err.reasonCode === REASON_CODES.SNAPSHOT_NOT_CURRENT ||
+          err.reasonCode === REASON_CODES.CURRENT_POINTER_MISMATCH ||
+          err.reasonCode === REASON_CODES.SNAPSHOT_NOT_FOUND);
+      if (!noCurrent) throw err;
+      return publishFromPlan({
+        mode: 'full',
+        inventory: inv,
+        unitsToAnalyze: inv.units,
+        keptFacts: { symbols: [], relationships: [], evidence: [] },
+        diff: planInventoryDiff([], inv.units),
+      });
+    }
+
+    const diff = planInventoryDiff(previousUnits, inv.units);
+    if (diff.isNoOp && hasCurrent) {
+      const current = store.getCurrentSnapshot(projectId);
+      return {
+        ok: true,
+        mode: 'incremental-noop',
+        snapshot: current,
+        diff,
+        published: false,
+      };
+    }
+
+    const invalidation = planInvalidation(diff, previousFacts);
+    const unitsToAnalyze = [...diff.added, ...diff.changed.map(c => c.next)].sort((a, b) =>
+      a.sourceUnitId.localeCompare(b.sourceUnitId)
+    );
+
+    return publishFromPlan({
+      mode: 'incremental',
+      inventory: inv,
+      unitsToAnalyze,
+      keptFacts: invalidation.kept,
+      diff,
+      invalidation,
+    });
+  }
+
+  /**
+   * Core atomic publish path for full and incremental.
+   */
+  function publishFromPlan({ mode, inventory, unitsToAnalyze, keptFacts, diff, invalidation }) {
+    const snapshotId = `snap-${inventory.inventoryHash.slice(0, 16)}`;
+    const analyzerRunId = `run:${analyzer.analyzerId}:${snapshotId}`;
+    const content = openContent();
+    const search = openSearch(false);
+
+    // Idempotent: if this inventory already published as current, no-op
+    try {
+      const current = store.getCurrentSnapshot(projectId);
+      if (
+        current.snapshotId === snapshotId &&
+        current.sourceInventoryHash === inventory.inventoryHash
+      ) {
+        content; // silence
+        search.close();
+        return {
+          ok: true,
+          mode: `${mode}-noop`,
+          snapshot: current,
+          diff,
+          published: false,
+        };
+      }
+    } catch {
+      // no current
+    }
+
+    const bodiesByHash = {};
+    try {
+      // 1) Content store: put canonical bytes for units that need analysis + all next units
+      for (const unit of inventory.units) {
+        if (unit._canonicalBytes) {
+          content.put(unit._canonicalBytes, { mode: 'binary' });
+          bodiesByHash[unit.contentHash] = unit._canonicalBytes.toString('utf8');
+        }
+      }
+
+      // 2) Analyze changed/added units
+      const analysis = analyzer.analyze({
+        projectId,
+        snapshotId,
+        units: unitsToAnalyze.map(u => stripInternal({ ...u })),
+        bodiesByHash,
+      });
+      analysis.analyzerRun.analyzerRunId = analyzerRunId;
+      analysis.analyzerRun.inputInventoryHash = inventory.inventoryHash;
+      analysis.analyzerRun.snapshotId = snapshotId;
+      analysis.analyzerRun.projectId = projectId;
+
+      // 3) Merge kept + new derived facts; rewrite snapshot ids on kept
+      const newSymbols = analysis.symbols;
+      const newRelationships = analysis.relationships;
+      const newEvidence = analysis.evidence;
+
+      const symbols = [
+        ...rewriteSnapshotIds(keptFacts.symbols || [], projectId, snapshotId),
+        ...newSymbols.map(stripInternal),
+      ].sort((a, b) => a.symbolId.localeCompare(b.symbolId));
+
+      const relationships = [
+        ...rewriteSnapshotIds(keptFacts.relationships || [], projectId, snapshotId),
+        ...newRelationships.map(stripInternal),
+      ].sort((a, b) => a.relationshipId.localeCompare(b.relationshipId));
+
+      const evidence = [
+        ...rewriteSnapshotIds(keptFacts.evidence || [], projectId, snapshotId),
+        ...newEvidence.map(stripInternal),
+      ].sort((a, b) => a.evidenceId.localeCompare(b.evidenceId));
+
+      // Dedupe by id (prefer new)
+      const dedupeBy = (arr, key) => {
+        const map = new Map();
+        for (const item of arr) map.set(item[key], item);
+        return Array.from(map.values()).sort((a, b) =>
+          String(a[key]).localeCompare(String(b[key]))
+        );
+      };
+      const finalSymbols = dedupeBy(symbols, 'symbolId');
+      const finalRelationships = dedupeBy(relationships, 'relationshipId');
+      const finalEvidence = dedupeBy(evidence, 'evidenceId');
+
+      // 4) Building snapshot metadata
+      const building = {
+        schemaVersion: 1,
+        kind: 'project-knowledge-snapshot',
+        contractId: CONTRACT_IDS.SNAPSHOT,
+        projectId,
+        snapshotId,
+        status: SNAPSHOT_STATUSES.BUILDING,
+        isCurrent: false,
+        sourceInventoryHash: inventory.inventoryHash,
+        storeSchemaVersion: STORE_SCHEMA_VERSION,
+        searchSchemaVersion: SEARCH_SCHEMA_VERSION,
+        artifactSchemaVersion: ARTIFACT_SCHEMA_VERSION,
+        contentAddressing: { algorithm: 'sha256' },
+        analyzerRunIds: [analyzerRunId],
+      };
+
+      // Atomic store transaction for metadata writes + publish pointer.
+      // Search index is rebuilt only after pointer advances so a failed publish
+      // cannot leave search ahead of the current snapshot.
+      store.withTransaction(() => {
+        store.putSnapshot(building);
+
+        for (const unit of inventory.units) {
+          store.putSourceUnit({
+            schemaVersion: 1,
+            kind: 'project-knowledge-source-unit',
+            contractId: CONTRACT_IDS.SOURCE_UNIT,
+            projectId,
+            snapshotId,
+            sourceUnitId: unit.sourceUnitId,
+            relativePath: unit.relativePath,
+            contentHash: unit.contentHash,
+            trustedRootId: unit.trustedRootId,
+            language: unit.language,
+            sizeBytes: unit.sizeBytes,
+            hashAlgorithm: 'sha256',
+          });
+        }
+
+        store.putAnalyzerRun(analysis.analyzerRun);
+
+        for (const s of finalSymbols) store.putSymbol(s);
+        for (const r of finalRelationships) store.putRelationship(r);
+        for (const e of finalEvidence) store.putEvidenceMeta(e);
+
+        // Atomic pointer advance (last store step)
+        store.publishSnapshot(projectId, snapshotId, { publishedAt: isoNow() });
+      });
+
+      const searchDocs = buildSearchDocuments({
+        projectId,
+        snapshotId,
+        units: inventory.units,
+        symbols: finalSymbols,
+        evidence: finalEvidence,
+        bodiesByHash,
+      });
+      search.rebuild(searchDocs, { snapshotId });
+
+      const published = store.getCurrentSnapshot(projectId);
+      search.close();
+
+      return {
+        ok: true,
+        mode,
+        published: true,
+        snapshot: published,
+        diff,
+        invalidation: invalidation || null,
+        counts: {
+          sourceUnits: inventory.units.length,
+          symbols: finalSymbols.length,
+          relationships: finalRelationships.length,
+          evidence: finalEvidence.length,
+        },
+        analyzer: {
+          analyzerId: analyzer.analyzerId,
+          analyzerVersion: analyzer.analyzerVersion,
+          analyzerRunId,
+        },
+      };
+    } catch (err) {
+      try {
+        search.close();
+      } catch {
+        // ignore
+      }
+      // Failed publish must not leave a new current pointer — publishSnapshot is last step.
+      if (err instanceof KnowledgeStoreError) throw err;
+      fail(REASON_CODES.PUBLISH_INCOMPLETE, 'snapshot publish failed', {
+        message: err && err.message ? String(err.message) : undefined,
+      });
+    }
+  }
+
+  function buildSearchDocuments({
+    projectId: pid,
+    snapshotId: sid,
+    units,
+    symbols,
+    evidence,
+    bodiesByHash,
+  }) {
+    const docs = [];
+    for (const u of units) {
+      docs.push({
+        docId: `doc:unit:${u.sourceUnitId}`,
+        projectId: pid,
+        snapshotId: sid,
+        kind: 'source-unit',
+        title: u.relativePath.split('/').pop(),
+        body: bodiesByHash[u.contentHash] || '',
+        fields: {
+          language: u.language,
+          relativePath: u.relativePath,
+        },
+        contentHash: u.contentHash,
+      });
+    }
+    for (const s of symbols) {
+      docs.push({
+        docId: `doc:symbol:${s.symbolId}`,
+        projectId: pid,
+        snapshotId: sid,
+        kind: 'symbol',
+        title: s.name,
+        body: `${s.name} ${s.symbolKind}`,
+        fields: { symbolKind: s.symbolKind },
+      });
+    }
+    for (const e of evidence) {
+      docs.push({
+        docId: `doc:evidence:${e.evidenceId}`,
+        projectId: pid,
+        snapshotId: sid,
+        kind: 'evidence',
+        title: e.relativePath || e.evidenceId,
+        body: e.relativePath || '',
+        fields: { relativePath: e.relativePath || '' },
+        contentHash: e.contentHash,
+      });
+    }
+    return docs;
+  }
+
+  /**
+   * Compare full rebuild vs incremental path semantics for tests.
+   * Returns normalized equality projection (ids + hashes only).
+   */
+  function projectEqualityView(snapshotId) {
+    const units = store.listSourceUnits(projectId, snapshotId).map(u => ({
+      sourceUnitId: u.sourceUnitId,
+      contentHash: u.contentHash,
+      relativePath: u.relativePath,
+    }));
+    const symbols = store.listSymbols(projectId, snapshotId).map(s => ({
+      symbolId: s.symbolId,
+      name: s.name,
+      symbolKind: s.symbolKind,
+      sourceHash: s.provenance && s.provenance.sourceHash,
+    }));
+    const relationships = store.listRelationships(projectId, snapshotId).map(r => ({
+      relationshipId: r.relationshipId,
+      fromSymbolId: r.fromSymbolId,
+      toSymbolId: r.toSymbolId,
+      relationshipType: r.relationshipType,
+    }));
+    units.sort((a, b) => a.sourceUnitId.localeCompare(b.sourceUnitId));
+    symbols.sort((a, b) => a.symbolId.localeCompare(b.symbolId));
+    relationships.sort((a, b) => a.relationshipId.localeCompare(b.relationshipId));
+    return { units, symbols, relationships };
+  }
+
+  function close() {
+    if (closed) return;
+    closed = true;
+    store.close();
+  }
+
+  function getStatus() {
+    return {
+      projectId,
+      knowledgeRoot,
+      readOnly,
+      closed,
+      store: store.getStatus(),
+    };
+  }
+
+  return {
+    projectId,
+    knowledgeRoot,
+    fullRebuild,
+    incrementalUpdate,
+    getCurrentSnapshot,
+    assertCurrentNotStale,
+    projectEqualityView,
+    getStatus,
+    close,
+    // test/diagnostic hooks
+    _store: store,
+    _planDiff: planInventoryDiff,
+    _buildInventory: () => buildSourceInventory({ trustedRoots }),
+  };
+}
+
+/** Stable random id helper if needed by callers */
+function newId(prefix) {
+  return `${prefix}-${crypto.randomBytes(6).toString('hex')}`;
+}
+
+module.exports = {
+  createSnapshotEngine,
+  openSnapshotEngine,
+  newId,
+};

--- a/src/projectIntelligence/index.js
+++ b/src/projectIntelligence/index.js
@@ -7,8 +7,9 @@
  * ZPI-03: KnowledgeStore SPI + SQLite metadata provider, locks, migrations.
  * ZPI-04: content-addressed store, trusted roots, path controls (GC design-only).
  * ZPI-05: Search SPI + Community lexical provider (Lucene layout/schema).
+ * ZPI-06: Snapshot + incremental update engine (diff, invalidation, atomic publish).
  *
- * Not included yet: RPG analyzer runtime, CLI/MCP.
+ * Not included yet: full RPG analyzer extractors (ZPI-07), CLI/MCP.
  */
 
 const constants = require('./constants');
@@ -21,6 +22,7 @@ const { runProjectIntelligenceContractTests } = require('./contractTestKit');
 const store = require('./store');
 const content = require('./content');
 const search = require('./search');
+const engine = require('./engine');
 
 module.exports = {
   // Vocabulary
@@ -77,4 +79,13 @@ module.exports = {
   search,
   createSearchProvider: search.createSearchProvider,
   openSearchProvider: search.openSearchProvider,
+
+  // Snapshot engine (ZPI-06)
+  engine,
+  createSnapshotEngine: engine.createSnapshotEngine,
+  openSnapshotEngine: engine.openSnapshotEngine,
+  createBaselineAnalyzer: engine.createBaselineAnalyzer,
+  planInventoryDiff: engine.planInventoryDiff,
+  planInvalidation: engine.planInvalidation,
+  buildSourceInventory: engine.buildSourceInventory,
 };

--- a/tests/project-intelligence-engine.test.js
+++ b/tests/project-intelligence-engine.test.js
@@ -1,0 +1,354 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createSnapshotEngine,
+  openSnapshotEngine,
+  planInventoryDiff,
+  planInvalidation,
+  buildSourceInventory,
+  KnowledgeStoreError,
+  REASON_CODES,
+  probeNodeSqlite,
+} = require('../src/projectIntelligence');
+
+const HAS_SQLITE = probeNodeSqlite().available;
+
+function tempDir(label = 'zpi-engine') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${label}-`));
+}
+
+function writeTree(root, files) {
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(root, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body, 'utf8');
+  }
+}
+
+function roots(srcDir) {
+  return [{ rootId: 'root-src', path: srcDir }];
+}
+
+test('diff planner classifies add/change/delete/unchanged', () => {
+  const prev = [
+    {
+      sourceUnitId: 'su:r:a.rpgle',
+      trustedRootId: 'r',
+      relativePath: 'a.rpgle',
+      contentHash: 'a'.repeat(64),
+      sizeBytes: 1,
+    },
+    {
+      sourceUnitId: 'su:r:b.rpgle',
+      trustedRootId: 'r',
+      relativePath: 'b.rpgle',
+      contentHash: 'b'.repeat(64),
+      sizeBytes: 1,
+    },
+  ];
+  const next = [
+    {
+      sourceUnitId: 'su:r:b.rpgle',
+      trustedRootId: 'r',
+      relativePath: 'b.rpgle',
+      contentHash: 'c'.repeat(64),
+      sizeBytes: 2,
+    },
+    {
+      sourceUnitId: 'su:r:c.rpgle',
+      trustedRootId: 'r',
+      relativePath: 'c.rpgle',
+      contentHash: 'd'.repeat(64),
+      sizeBytes: 1,
+    },
+  ];
+  const diff = planInventoryDiff(prev, next);
+  assert.equal(diff.deleted.length, 1);
+  assert.equal(diff.deleted[0].relativePath, 'a.rpgle');
+  assert.equal(diff.changed.length, 1);
+  assert.equal(diff.changed[0].next.relativePath, 'b.rpgle');
+  assert.equal(diff.added.length, 1);
+  assert.equal(diff.added[0].relativePath, 'c.rpgle');
+  assert.equal(diff.unchanged.length, 0);
+});
+
+test('invalidation drops derived facts for changed sources and keeps endpoints-safe relationships', () => {
+  const diff = planInventoryDiff(
+    [
+      {
+        sourceUnitId: 'su:1',
+        trustedRootId: 'r',
+        relativePath: 'a.rpgle',
+        contentHash: 'a'.repeat(64),
+        sizeBytes: 1,
+      },
+      {
+        sourceUnitId: 'su:2',
+        trustedRootId: 'r',
+        relativePath: 'b.rpgle',
+        contentHash: 'b'.repeat(64),
+        sizeBytes: 1,
+      },
+    ],
+    [
+      {
+        sourceUnitId: 'su:1',
+        trustedRootId: 'r',
+        relativePath: 'a.rpgle',
+        contentHash: 'z'.repeat(64),
+        sizeBytes: 1,
+      },
+      {
+        sourceUnitId: 'su:2',
+        trustedRootId: 'r',
+        relativePath: 'b.rpgle',
+        contentHash: 'b'.repeat(64),
+        sizeBytes: 1,
+      },
+    ]
+  );
+  const prev = {
+    symbols: [
+      { symbolId: 'sym:su:1', _sourceUnitId: 'su:1', provenance: { sourceUnitId: 'su:1' } },
+      { symbolId: 'sym:su:2', _sourceUnitId: 'su:2', provenance: { sourceUnitId: 'su:2' } },
+    ],
+    relationships: [
+      {
+        relationshipId: 'rel:1',
+        fromSymbolId: 'sym:su:1',
+        toSymbolId: 'sym:su:2',
+        provenance: { sourceUnitId: 'su:1' },
+      },
+      {
+        relationshipId: 'rel:2',
+        fromSymbolId: 'sym:su:2',
+        toSymbolId: 'sym:su:2',
+        provenance: { sourceUnitId: 'su:2' },
+      },
+    ],
+    evidence: [
+      { evidenceId: 'ev:1', sourceUnitId: 'su:1' },
+      { evidenceId: 'ev:2', sourceUnitId: 'su:2' },
+    ],
+  };
+  const plan = planInvalidation(diff, prev);
+  assert.ok(plan.invalidatedSourceUnitIds.includes('su:1'));
+  assert.equal(plan.kept.symbols.length, 1);
+  assert.equal(plan.kept.symbols[0].symbolId, 'sym:su:2');
+  assert.equal(plan.kept.evidence.length, 1);
+  // rel:1 invalidated because from endpoint/source changed; rel:2 kept
+  assert.equal(
+    plan.kept.relationships.some(r => r.relationshipId === 'rel:2'),
+    true
+  );
+  assert.equal(
+    plan.kept.relationships.some(r => r.relationshipId === 'rel:1'),
+    false
+  );
+});
+
+test('full rebuild publishes current snapshot and serves inventory', { skip: !HAS_SQLITE }, () => {
+  const root = tempDir();
+  const src = path.join(root, 'src');
+  const knowledgeRoot = path.join(root, 'pk');
+  writeTree(src, {
+    'ORDERPGM.rpgle': '**free\n// ORDERPGM calls CUSTINQ\n',
+    'CUSTINQ.rpgle': '**free\n// CUSTINQ\n',
+  });
+
+  const engine = createSnapshotEngine({
+    knowledgeRoot,
+    projectId: 'proj-demo',
+    trustedRoots: roots(src),
+  });
+  try {
+    const result = engine.fullRebuild();
+    assert.equal(result.ok, true);
+    assert.equal(result.published, true);
+    assert.equal(result.snapshot.status, 'published');
+    assert.equal(result.counts.sourceUnits, 2);
+    assert.ok(result.counts.symbols >= 2);
+
+    const current = engine.getCurrentSnapshot();
+    assert.equal(current.snapshotId, result.snapshot.snapshotId);
+    engine.assertCurrentNotStale();
+  } finally {
+    engine.close();
+  }
+});
+
+test('full vs incremental converge on same equality projection', { skip: !HAS_SQLITE }, () => {
+  const mk = files => {
+    const root = tempDir();
+    const src = path.join(root, 'src');
+    const knowledgeRoot = path.join(root, 'pk');
+    writeTree(src, files);
+    return { root, src, knowledgeRoot };
+  };
+
+  const finalFiles = {
+    'ORDERPGM.rpgle': '**free\n// ORDERPGM calls CUSTINQ\n',
+    'CUSTINQ.rpgle': '**free\n// CUSTINQ customer\n',
+    'HELPER.rpgle': '**free\n// HELPER\n',
+  };
+
+  // Path A: full rebuild of final
+  const a = mk(finalFiles);
+  const engA = createSnapshotEngine({
+    knowledgeRoot: a.knowledgeRoot,
+    projectId: 'proj-demo',
+    trustedRoots: roots(a.src),
+  });
+  engA.fullRebuild();
+  const viewA = engA.projectEqualityView(engA.getCurrentSnapshot().snapshotId);
+  engA.close();
+
+  // Path B: full of subset, then incremental add HELPER
+  const b = mk({
+    'ORDERPGM.rpgle': finalFiles['ORDERPGM.rpgle'],
+    'CUSTINQ.rpgle': finalFiles['CUSTINQ.rpgle'],
+  });
+  const engB = createSnapshotEngine({
+    knowledgeRoot: b.knowledgeRoot,
+    projectId: 'proj-demo',
+    trustedRoots: roots(b.src),
+  });
+  engB.fullRebuild();
+  writeTree(b.src, { 'HELPER.rpgle': finalFiles['HELPER.rpgle'] });
+  const inc = engB.incrementalUpdate();
+  assert.equal(inc.mode === 'incremental' || inc.mode === 'incremental-noop', true);
+  assert.ok(inc.diff.counts.added >= 1);
+  const viewB = engB.projectEqualityView(engB.getCurrentSnapshot().snapshotId);
+  engB.close();
+
+  assert.deepEqual(viewA.units, viewB.units);
+  assert.deepEqual(viewA.symbols, viewB.symbols);
+  assert.deepEqual(viewA.relationships, viewB.relationships);
+});
+
+test('stale snapshot refusal when sources change', { skip: !HAS_SQLITE }, () => {
+  const root = tempDir();
+  const src = path.join(root, 'src');
+  const knowledgeRoot = path.join(root, 'pk');
+  writeTree(src, { 'A.rpgle': '**free\n// A\n' });
+  const engine = createSnapshotEngine({
+    knowledgeRoot,
+    projectId: 'proj-demo',
+    trustedRoots: roots(src),
+  });
+  try {
+    engine.fullRebuild();
+    fs.writeFileSync(path.join(src, 'A.rpgle'), '**free\n// A changed\n', 'utf8');
+    assert.throws(
+      () => engine.assertCurrentNotStale(),
+      err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.SNAPSHOT_STALE
+    );
+  } finally {
+    engine.close();
+  }
+});
+
+test('parallel writer rejected', { skip: !HAS_SQLITE }, () => {
+  const root = tempDir();
+  const src = path.join(root, 'src');
+  const knowledgeRoot = path.join(root, 'pk');
+  writeTree(src, { 'A.rpgle': 'x\n' });
+  const a = createSnapshotEngine({
+    knowledgeRoot,
+    projectId: 'proj-demo',
+    trustedRoots: roots(src),
+  });
+  try {
+    assert.throws(
+      () =>
+        openSnapshotEngine({
+          knowledgeRoot,
+          projectId: 'proj-demo',
+          trustedRoots: roots(src),
+          readOnly: false,
+        }),
+      err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.WRITER_CONFLICT
+    );
+  } finally {
+    a.close();
+  }
+});
+
+test('transaction rollback keeps previous current pointer', { skip: !HAS_SQLITE }, () => {
+  const root = tempDir();
+  const src = path.join(root, 'src');
+  const knowledgeRoot = path.join(root, 'pk');
+  writeTree(src, { 'A.rpgle': '**free\n// A\n' });
+  const engine = createSnapshotEngine({
+    knowledgeRoot,
+    projectId: 'proj-demo',
+    trustedRoots: roots(src),
+  });
+  try {
+    const first = engine.fullRebuild();
+    const firstId = first.snapshot.snapshotId;
+
+    // Force failure inside store transaction by sealing then trying write via put on closed path:
+    // Simulate crash: throw from withTransaction after mutating by monkey-patching putSymbol
+    const store = engine._store;
+    const original = store.putSymbol;
+    store.putSymbol = () => {
+      throw new Error('simulated crash during publish');
+    };
+    writeTree(src, { 'B.rpgle': '**free\n// B\n' });
+    assert.throws(
+      () => engine.incrementalUpdate(),
+      /simulated crash|publish failed|transaction failed/i
+    );
+    store.putSymbol = original;
+
+    const current = engine.getCurrentSnapshot();
+    assert.equal(current.snapshotId, firstId);
+  } finally {
+    engine.close();
+  }
+});
+
+test('incremental no-op when sources unchanged', { skip: !HAS_SQLITE }, () => {
+  const root = tempDir();
+  const src = path.join(root, 'src');
+  const knowledgeRoot = path.join(root, 'pk');
+  writeTree(src, { 'A.rpgle': '**free\n// A\n' });
+  const engine = createSnapshotEngine({
+    knowledgeRoot,
+    projectId: 'proj-demo',
+    trustedRoots: roots(src),
+  });
+  try {
+    engine.fullRebuild();
+    const again = engine.incrementalUpdate();
+    assert.ok(
+      again.mode === 'incremental-noop' || again.mode === 'full-noop' || again.published === false
+    );
+  } finally {
+    engine.close();
+  }
+});
+
+test('buildSourceInventory is deterministic', () => {
+  const root = tempDir();
+  const src = path.join(root, 'src');
+  writeTree(src, {
+    'b/X.rpgle': 'one\r\n',
+    'a/Y.rpgle': '\uFEFFtwo\n',
+  });
+  const a = buildSourceInventory({ trustedRoots: roots(src) });
+  const b = buildSourceInventory({ trustedRoots: roots(src) });
+  assert.equal(a.inventoryHash, b.inventoryHash);
+  assert.equal(a.unitCount, 2);
+  assert.deepEqual(
+    a.units.map(u => u.relativePath),
+    b.units.map(u => u.relativePath)
+  );
+});


### PR DESCRIPTION
## Summary

- Implements **ZPI-06 — Snapshot and Incremental Update Engine**.
- Source inventory with deterministic content hashing (canonical text).
- Diff planner: added/changed/deleted/unchanged.
- Invalidation of derived facts for changed/deleted units; keep unchanged.
- Baseline inventory analyzer (until ZPI-07 RPG extractors).
- Atomic publish: SQLite metadata + pointer, then search rebuild.
- Stale refusal, parallel writer rejection, transaction rollback.

## Test plan

- [x] full vs incremental equivalence
- [x] stale snapshot refusal
- [x] parallel writer rejection
- [x] rollback keeps previous current
- [x] format/lint/typecheck/test:contract/package:smoke