### PR TITLE
feat: ZPI-07 RPG IBM i analyzer baseline

### DIFF
--- a/docs/knowledgebase/README.md
+++ b/docs/knowledgebase/README.md
@@ -37,8 +37,10 @@ Current implementation status:
 - **ZPI-05 (search):** `src/projectIntelligence/search/` Search SPI + Community pure-JS lexical
   provider under the standard `lucene/` layout
 - **ZPI-06 (snapshots):** `src/projectIntelligence/engine/` inventory, diff planner, invalidation,
-  baseline analyzer, atomic publish + current pointer / incremental update — still no full RPG
-  extractors (ZPI-07), CLI, or MCP adapters
+  atomic publish + current pointer / incremental update
+- **ZPI-07 (RPG analyzer):** `src/projectIntelligence/analyzers/` RPG/CL parser adapters over
+  Community scanners, source spans, unresolved reference model, default engine analyzer —
+  still no retrieval/context assembly (ZPI-08), CLI, or MCP adapters
 
 Local risk handling:
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -13,7 +13,8 @@ ZPI-03 adds the SQLite metadata store under `src/projectIntelligence/store/`.
 ZPI-04 adds the content-addressed blob store under `src/projectIntelligence/content/`.
 ZPI-05 adds the search SPI and Community lexical provider under `src/projectIntelligence/search/`.
 ZPI-06 adds the snapshot/incremental engine under `src/projectIntelligence/engine/`.
-Full RPG analyzer extractors and CLI/MCP packages remain later.
+ZPI-07 adds the RPG/IBM i analyzer baseline under `src/projectIntelligence/analyzers/`.
+Retrieval/context assembly and CLI/MCP packages remain later.
 
 ## Contract IDs (stable)
 

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -25,6 +25,7 @@ module.exports = {
       'tests/project-intelligence-content.test.js',
       'tests/project-intelligence-search.test.js',
       'tests/project-intelligence-engine.test.js',
+      'tests/project-intelligence-rpg-analyzer.test.js',
     ],
     smoke: [
       'tests/reproducible-output.test.js',

--- a/src/api/zeusApi.js
+++ b/src/api/zeusApi.js
@@ -862,8 +862,8 @@ const zeus = {
   // Generation Validation Foundation (Iteration 29): offline candidate validation.
   // Never mutates the analyzed source workspace. review-ready is not compile readiness.
   generationValidation,
-  // Project Intelligence (ZPI-02..06: contracts, store, content, search, snapshots).
-  // Full RPG extractors (ZPI-07) and CLI/MCP adapters remain later.
+  // Project Intelligence (ZPI-02..07: contracts through RPG analyzer baseline).
+  // Retrieval/context assembly (ZPI-08) and CLI/MCP adapters remain later.
   projectIntelligence,
   // External module contracts (Iteration 30): trusted in-process registration only.
   // Core does not parse licenses or enforce commercial entitlement.

--- a/src/projectIntelligence/analyzers/constants.js
+++ b/src/projectIntelligence/analyzers/constants.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const ANALYZER_ID = 'zeus.rpg-ibmi-baseline';
+const ANALYZER_VERSION = '1.0.0';
+
+/** Language families handled by the RPG/IBM i baseline analyzer. */
+const LANGUAGE_FAMILIES = Object.freeze({
+  RPG: 'rpg',
+  CL: 'cl',
+  SQL: 'sql',
+  BND: 'binder',
+  OTHER: 'other',
+});
+
+module.exports = {
+  ANALYZER_ID,
+  ANALYZER_VERSION,
+  LANGUAGE_FAMILIES,
+};

--- a/src/projectIntelligence/analyzers/index.js
+++ b/src/projectIntelligence/analyzers/index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const constants = require('./constants');
+const parserAdapters = require('./parserAdapters');
+const spans = require('./spans');
+const { createRpgAnalyzer, ANALYZER_ID, ANALYZER_VERSION } = require('./rpgAnalyzer');
+
+module.exports = {
+  ...constants,
+  createRpgAnalyzer,
+  ANALYZER_ID,
+  ANALYZER_VERSION,
+  parseSourceUnit: parserAdapters.parseSourceUnit,
+  classifyUnitLanguage: parserAdapters.classifyUnitLanguage,
+  evidenceToSpan: spans.evidenceToSpan,
+  collectSpansFromEvidenceList: spans.collectSpansFromEvidenceList,
+};

--- a/src/projectIntelligence/analyzers/parserAdapters.js
+++ b/src/projectIntelligence/analyzers/parserAdapters.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const path = require('path');
+const { scanRpgFile } = require('../../scanner/rpgScanner');
+const { scanClFile } = require('../../scanner/clScanner');
+const { LANGUAGE_FAMILIES } = require('./constants');
+
+function classifyUnitLanguage(unit) {
+  const lang = String(unit.language || '').toLowerCase();
+  const ext = path.extname(unit.relativePath || '').toLowerCase();
+  if (lang === 'clle' || lang === 'clp' || ext === '.clle' || ext === '.clp') {
+    return LANGUAGE_FAMILIES.CL;
+  }
+  if (lang === 'sql' || ext === '.sql') {
+    return LANGUAGE_FAMILIES.SQL;
+  }
+  if (ext === '.bnd' || ext === '.binder' || ext === '.bndsrc' || lang === 'bnd') {
+    return LANGUAGE_FAMILIES.BND;
+  }
+  if (
+    lang === 'rpgle' ||
+    lang === 'sqlrpgle' ||
+    lang === 'rpg' ||
+    ext === '.rpgle' ||
+    ext === '.sqlrpgle' ||
+    ext === '.rpg'
+  ) {
+    return LANGUAGE_FAMILIES.RPG;
+  }
+  return LANGUAGE_FAMILIES.OTHER;
+}
+
+/**
+ * Parse a source unit with the appropriate Community scanner adapter.
+ * Uses in-memory content only (no disk re-read required).
+ */
+function parseSourceUnit(unit, body) {
+  const family = classifyUnitLanguage(unit);
+  // Virtual path for scanner identity (basename matters for program name)
+  const virtualPath = unit.relativePath || `${unit.sourceUnitId}.rpgle`;
+  const content = body == null ? '' : String(body);
+
+  if (family === LANGUAGE_FAMILIES.CL) {
+    const result = scanClFile(virtualPath, { content });
+    return { family, scan: result };
+  }
+
+  // RPG, SQLRPGLE, binder, and unknown source-like files go through RPG pipeline
+  // (binder detection is internal to scanContent).
+  const result = scanRpgFile(virtualPath, {
+    content,
+    sourceType: family === LANGUAGE_FAMILIES.SQL ? 'SQL' : undefined,
+  });
+  return { family, scan: result };
+}
+
+module.exports = {
+  classifyUnitLanguage,
+  parseSourceUnit,
+  LANGUAGE_FAMILIES,
+};

--- a/src/projectIntelligence/analyzers/rpgAnalyzer.js
+++ b/src/projectIntelligence/analyzers/rpgAnalyzer.js
@@ -1,0 +1,685 @@
+'use strict';
+
+const path = require('path');
+const { DERIVATION_CLASSES, ANALYZER_RUN_STATUSES, EVIDENCE_CLASSES } = require('../constants');
+const CONTRACT_IDS = require('../contractIds');
+const { ANALYZER_ID, ANALYZER_VERSION } = require('./constants');
+const { parseSourceUnit, LANGUAGE_FAMILIES } = require('./parserAdapters');
+const { collectSpansFromEvidenceList } = require('./spans');
+
+function normalizeName(name) {
+  return String(name || '')
+    .trim()
+    .toUpperCase();
+}
+
+function unitProgramName(unit) {
+  return normalizeName(
+    path.basename(unit.relativePath || '', path.extname(unit.relativePath || ''))
+  );
+}
+
+function makeProvenance({
+  projectId,
+  snapshotId,
+  contentHash,
+  analyzerId,
+  analyzerVersion,
+  derivationClass,
+  sourceUnitId,
+}) {
+  return {
+    projectId,
+    snapshotId,
+    sourceHash: contentHash,
+    analyzerId,
+    analyzerVersion,
+    derivationClass,
+    sourceUnitId,
+  };
+}
+
+/**
+ * Deterministic RPG/IBM i knowledge analyzer (ZPI-07).
+ *
+ * Wraps Community scanners as parser adapters and projects results into
+ * versioned ZPI symbols, relationships, evidence, and source spans.
+ * Unresolved calls become UNRESOLVED_SYMBOL targets with explicit relationships.
+ */
+function createRpgAnalyzer(options = {}) {
+  const analyzerId = options.analyzerId || ANALYZER_ID;
+  const analyzerVersion = options.analyzerVersion || ANALYZER_VERSION;
+
+  function analyze({ projectId, snapshotId, units, bodiesByHash = {} }) {
+    const symbols = [];
+    const relationships = [];
+    const evidence = [];
+    const sourceSpans = [];
+    const unresolved = [];
+
+    const sortedUnits = [...(units || [])].sort((a, b) =>
+      a.sourceUnitId.localeCompare(b.sourceUnitId)
+    );
+
+    /** @type {Map<string, string>} program/module name -> symbolId */
+    const knownPrograms = new Map();
+    /** @type {Map<string, string>} procedure name -> symbolId (local exports) */
+    const knownProcedures = new Map();
+
+    // Pass 1: declare unit-level PROGRAM symbols and scan
+    const scans = [];
+    for (const unit of sortedUnits) {
+      const body = bodiesByHash[unit.contentHash] || '';
+      const { family, scan } = parseSourceUnit(unit, body);
+      const programName = unitProgramName(unit);
+      const programSymbolId = `sym:program:${unit.sourceUnitId}`;
+      knownPrograms.set(programName, programSymbolId);
+
+      const unitEvidenceId = `ev:${unit.sourceUnitId}:unit`;
+      evidence.push({
+        schemaVersion: 1,
+        kind: 'project-knowledge-evidence',
+        contractId: CONTRACT_IDS.EVIDENCE,
+        projectId,
+        snapshotId,
+        evidenceId: unitEvidenceId,
+        sourceUnitId: unit.sourceUnitId,
+        contentHash: unit.contentHash,
+        evidenceClass: EVIDENCE_CLASSES.SOURCE,
+        trustedRootId: unit.trustedRootId,
+        relativePath: unit.relativePath,
+        sourceSpanIds: [],
+      });
+
+      symbols.push({
+        schemaVersion: 1,
+        kind: 'project-knowledge-symbol',
+        contractId: CONTRACT_IDS.SYMBOL,
+        projectId,
+        snapshotId,
+        symbolId: programSymbolId,
+        name: programName,
+        symbolKind:
+          family === LANGUAGE_FAMILIES.CL
+            ? 'PROGRAM'
+            : family === LANGUAGE_FAMILIES.BND
+              ? 'SERVICE_PROGRAM'
+              : 'PROGRAM',
+        provenance: makeProvenance({
+          projectId,
+          snapshotId,
+          contentHash: unit.contentHash,
+          analyzerId,
+          analyzerVersion,
+          derivationClass: DERIVATION_CLASSES.VERIFIED,
+          sourceUnitId: unit.sourceUnitId,
+        }),
+        evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+        sourceSpanIds: [],
+        confidence: 'high',
+        _sourceUnitId: unit.sourceUnitId,
+      });
+
+      scans.push({ unit, family, scan, programName, programSymbolId, unitEvidenceId });
+    }
+
+    // Pass 2: project scan entities and resolve references
+    for (const entry of scans) {
+      const { unit, scan, programName, programSymbolId, unitEvidenceId } = entry;
+      const ctx = {
+        projectId,
+        snapshotId,
+        sourceUnitId: unit.sourceUnitId,
+        contentHash: unit.contentHash,
+      };
+
+      // Procedures
+      for (const proc of scan.procedures || []) {
+        const name = normalizeName(proc.name);
+        if (!name) continue;
+        const symbolId = `sym:proc:${unit.sourceUnitId}:${name}`;
+        knownProcedures.set(`${programName}::${name}`, symbolId);
+        knownProcedures.set(name, symbolId);
+        const { spans, ids } = collectSpansFromEvidenceList(ctx, proc.evidence || []);
+        sourceSpans.push(...spans);
+        const evId = `ev:proc:${unit.sourceUnitId}:${name}`;
+        evidence.push({
+          schemaVersion: 1,
+          kind: 'project-knowledge-evidence',
+          contractId: CONTRACT_IDS.EVIDENCE,
+          projectId,
+          snapshotId,
+          evidenceId: evId,
+          sourceUnitId: unit.sourceUnitId,
+          contentHash: unit.contentHash,
+          evidenceClass: EVIDENCE_CLASSES.SOURCE,
+          trustedRootId: unit.trustedRootId,
+          relativePath: unit.relativePath,
+          sourceSpanIds: ids,
+        });
+        symbols.push({
+          schemaVersion: 1,
+          kind: 'project-knowledge-symbol',
+          contractId: CONTRACT_IDS.SYMBOL,
+          projectId,
+          snapshotId,
+          symbolId,
+          name,
+          symbolKind: 'PROCEDURE',
+          provenance: makeProvenance({
+            projectId,
+            snapshotId,
+            contentHash: unit.contentHash,
+            analyzerId,
+            analyzerVersion,
+            derivationClass: DERIVATION_CLASSES.VERIFIED,
+            sourceUnitId: unit.sourceUnitId,
+          }),
+          evidenceReferences: [
+            { id: evId, kind: 'source' },
+            { id: unitEvidenceId, kind: 'source' },
+          ],
+          sourceSpanIds: ids,
+          confidence: 'high',
+          _sourceUnitId: unit.sourceUnitId,
+        });
+      }
+
+      // Prototypes
+      for (const proto of scan.prototypes || []) {
+        const name = normalizeName(proto.name);
+        if (!name) continue;
+        const symbolId = `sym:proto:${unit.sourceUnitId}:${name}`;
+        const { spans, ids } = collectSpansFromEvidenceList(ctx, proto.evidence || []);
+        sourceSpans.push(...spans);
+        symbols.push({
+          schemaVersion: 1,
+          kind: 'project-knowledge-symbol',
+          contractId: CONTRACT_IDS.SYMBOL,
+          projectId,
+          snapshotId,
+          symbolId,
+          name,
+          symbolKind: 'PROTOTYPE',
+          provenance: makeProvenance({
+            projectId,
+            snapshotId,
+            contentHash: unit.contentHash,
+            analyzerId,
+            analyzerVersion,
+            derivationClass: DERIVATION_CLASSES.VERIFIED,
+            sourceUnitId: unit.sourceUnitId,
+          }),
+          evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+          sourceSpanIds: ids,
+          confidence: 'high',
+          _sourceUnitId: unit.sourceUnitId,
+        });
+      }
+
+      // Data structures
+      for (const ds of scan.dataStructures || []) {
+        const name = normalizeName(ds.name);
+        if (!name) continue;
+        const symbolId = `sym:ds:${unit.sourceUnitId}:${name}`;
+        const { spans, ids } = collectSpansFromEvidenceList(ctx, ds.evidence || []);
+        sourceSpans.push(...spans);
+        symbols.push({
+          schemaVersion: 1,
+          kind: 'project-knowledge-symbol',
+          contractId: CONTRACT_IDS.SYMBOL,
+          projectId,
+          snapshotId,
+          symbolId,
+          name,
+          symbolKind: 'DATA_STRUCTURE',
+          provenance: makeProvenance({
+            projectId,
+            snapshotId,
+            contentHash: unit.contentHash,
+            analyzerId,
+            analyzerVersion,
+            derivationClass: DERIVATION_CLASSES.VERIFIED,
+            sourceUnitId: unit.sourceUnitId,
+          }),
+          evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+          sourceSpanIds: ids,
+          confidence: 'medium',
+          _sourceUnitId: unit.sourceUnitId,
+        });
+      }
+
+      // Native files / tables
+      for (const file of [...(scan.nativeFiles || []), ...(scan.tables || [])]) {
+        const name = normalizeName(file.name);
+        if (!name) continue;
+        const symbolId = `sym:file:${name}`;
+        const { spans, ids } = collectSpansFromEvidenceList(ctx, file.evidence || []);
+        sourceSpans.push(...spans);
+        if (!symbols.some(s => s.symbolId === symbolId)) {
+          symbols.push({
+            schemaVersion: 1,
+            kind: 'project-knowledge-symbol',
+            contractId: CONTRACT_IDS.SYMBOL,
+            projectId,
+            snapshotId,
+            symbolId,
+            name,
+            symbolKind: 'FILE',
+            provenance: makeProvenance({
+              projectId,
+              snapshotId,
+              contentHash: unit.contentHash,
+              analyzerId,
+              analyzerVersion,
+              derivationClass: DERIVATION_CLASSES.INFERRED,
+              sourceUnitId: unit.sourceUnitId,
+            }),
+            evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+            sourceSpanIds: ids,
+            confidence: 'medium',
+            _sourceUnitId: unit.sourceUnitId,
+          });
+        }
+        relationships.push({
+          schemaVersion: 1,
+          kind: 'project-knowledge-relationship',
+          contractId: CONTRACT_IDS.RELATIONSHIP,
+          projectId,
+          snapshotId,
+          relationshipId: `rel:file:${programSymbolId}:${name}`,
+          relationshipType: 'FILE_READ',
+          fromSymbolId: programSymbolId,
+          toSymbolId: symbolId,
+          provenance: makeProvenance({
+            projectId,
+            snapshotId,
+            contentHash: unit.contentHash,
+            analyzerId,
+            analyzerVersion,
+            derivationClass: DERIVATION_CLASSES.INFERRED,
+            sourceUnitId: unit.sourceUnitId,
+          }),
+          evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+          confidence: 'medium',
+          _sourceUnitId: unit.sourceUnitId,
+        });
+      }
+
+      // SQL tables from statements
+      for (const sql of scan.sqlStatements || []) {
+        for (const table of sql.tables || []) {
+          const name = normalizeName(table);
+          if (!name) continue;
+          const symbolId = `sym:table:${name}`;
+          const { spans, ids } = collectSpansFromEvidenceList(ctx, sql.evidence || []);
+          sourceSpans.push(...spans);
+          if (!symbols.some(s => s.symbolId === symbolId)) {
+            symbols.push({
+              schemaVersion: 1,
+              kind: 'project-knowledge-symbol',
+              contractId: CONTRACT_IDS.SYMBOL,
+              projectId,
+              snapshotId,
+              symbolId,
+              name,
+              symbolKind: 'TABLE',
+              provenance: makeProvenance({
+                projectId,
+                snapshotId,
+                contentHash: unit.contentHash,
+                analyzerId,
+                analyzerVersion,
+                derivationClass: DERIVATION_CLASSES.INFERRED,
+                sourceUnitId: unit.sourceUnitId,
+              }),
+              evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+              sourceSpanIds: ids,
+              confidence: sql.unresolved ? 'low' : 'medium',
+              _sourceUnitId: unit.sourceUnitId,
+            });
+          }
+          relationships.push({
+            schemaVersion: 1,
+            kind: 'project-knowledge-relationship',
+            contractId: CONTRACT_IDS.RELATIONSHIP,
+            projectId,
+            snapshotId,
+            relationshipId: `rel:sql:${programSymbolId}:${name}:${sql.type || 'SQL'}`,
+            relationshipType: 'SQL_REFERENCE',
+            fromSymbolId: programSymbolId,
+            toSymbolId: symbolId,
+            provenance: makeProvenance({
+              projectId,
+              snapshotId,
+              contentHash: unit.contentHash,
+              analyzerId,
+              analyzerVersion,
+              derivationClass: DERIVATION_CLASSES.INFERRED,
+              sourceUnitId: unit.sourceUnitId,
+            }),
+            evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+            confidence: sql.unresolved ? 'low' : 'medium',
+            _sourceUnitId: unit.sourceUnitId,
+          });
+        }
+      }
+
+      // Copy / include
+      for (const copy of scan.copyMembers || []) {
+        const name = normalizeName(copy.name);
+        if (!name) continue;
+        const symbolId = `sym:copy:${name}`;
+        const { spans, ids } = collectSpansFromEvidenceList(ctx, copy.evidence || []);
+        sourceSpans.push(...spans);
+        if (!symbols.some(s => s.symbolId === symbolId)) {
+          symbols.push({
+            schemaVersion: 1,
+            kind: 'project-knowledge-symbol',
+            contractId: CONTRACT_IDS.SYMBOL,
+            projectId,
+            snapshotId,
+            symbolId,
+            name,
+            symbolKind: 'COPY_MEMBER',
+            provenance: makeProvenance({
+              projectId,
+              snapshotId,
+              contentHash: unit.contentHash,
+              analyzerId,
+              analyzerVersion,
+              derivationClass: DERIVATION_CLASSES.VERIFIED,
+              sourceUnitId: unit.sourceUnitId,
+            }),
+            evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+            sourceSpanIds: ids,
+            confidence: 'high',
+            _sourceUnitId: unit.sourceUnitId,
+          });
+        }
+        relationships.push({
+          schemaVersion: 1,
+          kind: 'project-knowledge-relationship',
+          contractId: CONTRACT_IDS.RELATIONSHIP,
+          projectId,
+          snapshotId,
+          relationshipId: `rel:copy:${programSymbolId}:${name}`,
+          relationshipType: 'COPY_INCLUDE',
+          fromSymbolId: programSymbolId,
+          toSymbolId: symbolId,
+          provenance: makeProvenance({
+            projectId,
+            snapshotId,
+            contentHash: unit.contentHash,
+            analyzerId,
+            analyzerVersion,
+            derivationClass: DERIVATION_CLASSES.VERIFIED,
+            sourceUnitId: unit.sourceUnitId,
+          }),
+          evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+          confidence: 'high',
+          _sourceUnitId: unit.sourceUnitId,
+        });
+      }
+
+      // Program calls
+      for (const call of scan.calls || []) {
+        const target = normalizeName(call.name);
+        if (!target) continue;
+        const { spans, ids } = collectSpansFromEvidenceList(ctx, call.evidence || []);
+        sourceSpans.push(...spans);
+        let toSymbolId = knownPrograms.get(target);
+        let relationshipType = 'PROGRAM_CALL';
+        let derivationClass = DERIVATION_CLASSES.INFERRED;
+        if (!toSymbolId) {
+          toSymbolId = `sym:unresolved:program:${target}`;
+          relationshipType = 'DYNAMIC_UNRESOLVED_CALL';
+          derivationClass = DERIVATION_CLASSES.UNRESOLVED;
+          if (!symbols.some(s => s.symbolId === toSymbolId)) {
+            symbols.push({
+              schemaVersion: 1,
+              kind: 'project-knowledge-symbol',
+              contractId: CONTRACT_IDS.SYMBOL,
+              projectId,
+              snapshotId,
+              symbolId: toSymbolId,
+              name: target,
+              symbolKind: 'UNRESOLVED_SYMBOL',
+              provenance: makeProvenance({
+                projectId,
+                snapshotId,
+                contentHash: unit.contentHash,
+                analyzerId,
+                analyzerVersion,
+                derivationClass: DERIVATION_CLASSES.UNRESOLVED,
+                sourceUnitId: unit.sourceUnitId,
+              }),
+              evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+              sourceSpanIds: ids,
+              confidence: 'low',
+              _sourceUnitId: unit.sourceUnitId,
+            });
+          }
+          unresolved.push({
+            kind: 'PROGRAM_CALL',
+            name: target,
+            fromSymbolId: programSymbolId,
+            sourceUnitId: unit.sourceUnitId,
+            spanIds: ids,
+          });
+        }
+        relationships.push({
+          schemaVersion: 1,
+          kind: 'project-knowledge-relationship',
+          contractId: CONTRACT_IDS.RELATIONSHIP,
+          projectId,
+          snapshotId,
+          relationshipId: `rel:call:${programSymbolId}:${target}`,
+          relationshipType,
+          fromSymbolId: programSymbolId,
+          toSymbolId,
+          provenance: makeProvenance({
+            projectId,
+            snapshotId,
+            contentHash: unit.contentHash,
+            analyzerId,
+            analyzerVersion,
+            derivationClass,
+            sourceUnitId: unit.sourceUnitId,
+          }),
+          evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+          confidence: toSymbolId.startsWith('sym:unresolved') ? 'low' : 'high',
+          _sourceUnitId: unit.sourceUnitId,
+        });
+      }
+
+      // Procedure calls
+      for (const pcall of scan.procedureCalls || []) {
+        const target = normalizeName(pcall.name);
+        if (!target) continue;
+        const { spans, ids } = collectSpansFromEvidenceList(ctx, pcall.evidence || []);
+        sourceSpans.push(...spans);
+        let toSymbolId =
+          knownProcedures.get(`${programName}::${target}`) || knownProcedures.get(target);
+        let relationshipType = 'BOUND_PROCEDURE_CALL';
+        let derivationClass = DERIVATION_CLASSES.INFERRED;
+        if (!toSymbolId || String(pcall.resolution).toUpperCase() === 'UNRESOLVED') {
+          if (!toSymbolId) {
+            toSymbolId = `sym:unresolved:proc:${target}`;
+            relationshipType = 'DYNAMIC_UNRESOLVED_CALL';
+            derivationClass = DERIVATION_CLASSES.UNRESOLVED;
+            if (!symbols.some(s => s.symbolId === toSymbolId)) {
+              symbols.push({
+                schemaVersion: 1,
+                kind: 'project-knowledge-symbol',
+                contractId: CONTRACT_IDS.SYMBOL,
+                projectId,
+                snapshotId,
+                symbolId: toSymbolId,
+                name: target,
+                symbolKind: 'UNRESOLVED_SYMBOL',
+                provenance: makeProvenance({
+                  projectId,
+                  snapshotId,
+                  contentHash: unit.contentHash,
+                  analyzerId,
+                  analyzerVersion,
+                  derivationClass: DERIVATION_CLASSES.UNRESOLVED,
+                  sourceUnitId: unit.sourceUnitId,
+                }),
+                evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+                sourceSpanIds: ids,
+                confidence: 'low',
+                _sourceUnitId: unit.sourceUnitId,
+              });
+            }
+            unresolved.push({
+              kind: 'PROCEDURE_CALL',
+              name: target,
+              fromSymbolId: programSymbolId,
+              sourceUnitId: unit.sourceUnitId,
+              spanIds: ids,
+              resolution: pcall.resolution || 'UNRESOLVED',
+            });
+          }
+        }
+        const fromId =
+          pcall.ownerKind === 'PROCEDURE' && pcall.ownerName
+            ? knownProcedures.get(`${programName}::${normalizeName(pcall.ownerName)}`) ||
+              programSymbolId
+            : programSymbolId;
+        relationships.push({
+          schemaVersion: 1,
+          kind: 'project-knowledge-relationship',
+          contractId: CONTRACT_IDS.RELATIONSHIP,
+          projectId,
+          snapshotId,
+          relationshipId: `rel:pcall:${fromId}:${target}`,
+          relationshipType,
+          fromSymbolId: fromId,
+          toSymbolId,
+          provenance: makeProvenance({
+            projectId,
+            snapshotId,
+            contentHash: unit.contentHash,
+            analyzerId,
+            analyzerVersion,
+            derivationClass,
+            sourceUnitId: unit.sourceUnitId,
+          }),
+          evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+          confidence: derivationClass === DERIVATION_CLASSES.UNRESOLVED ? 'low' : 'medium',
+          _sourceUnitId: unit.sourceUnitId,
+        });
+      }
+
+      // Service programs / modules / binding directories
+      for (const sp of scan.servicePrograms || []) {
+        const name = normalizeName(sp.name);
+        if (!name) continue;
+        const symbolId = `sym:srvpgm:${name}`;
+        if (!symbols.some(s => s.symbolId === symbolId)) {
+          symbols.push({
+            schemaVersion: 1,
+            kind: 'project-knowledge-symbol',
+            contractId: CONTRACT_IDS.SYMBOL,
+            projectId,
+            snapshotId,
+            symbolId,
+            name,
+            symbolKind: 'SERVICE_PROGRAM',
+            provenance: makeProvenance({
+              projectId,
+              snapshotId,
+              contentHash: unit.contentHash,
+              analyzerId,
+              analyzerVersion,
+              derivationClass: DERIVATION_CLASSES.INFERRED,
+              sourceUnitId: unit.sourceUnitId,
+            }),
+            evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+            sourceSpanIds: [],
+            confidence: 'medium',
+            _sourceUnitId: unit.sourceUnitId,
+          });
+        }
+        relationships.push({
+          schemaVersion: 1,
+          kind: 'project-knowledge-relationship',
+          contractId: CONTRACT_IDS.RELATIONSHIP,
+          projectId,
+          snapshotId,
+          relationshipId: `rel:srv:${programSymbolId}:${name}`,
+          relationshipType: 'SERVICE_PROGRAM_IMPORT',
+          fromSymbolId: programSymbolId,
+          toSymbolId: symbolId,
+          provenance: makeProvenance({
+            projectId,
+            snapshotId,
+            contentHash: unit.contentHash,
+            analyzerId,
+            analyzerVersion,
+            derivationClass: DERIVATION_CLASSES.INFERRED,
+            sourceUnitId: unit.sourceUnitId,
+          }),
+          evidenceReferences: [{ id: unitEvidenceId, kind: 'source' }],
+          confidence: 'medium',
+          _sourceUnitId: unit.sourceUnitId,
+        });
+      }
+    }
+
+    // Deterministic sort + dedupe
+    const dedupe = (arr, key) => {
+      const map = new Map();
+      for (const item of arr) map.set(item[key], item);
+      return Array.from(map.values()).sort((a, b) => String(a[key]).localeCompare(String(b[key])));
+    };
+
+    const finalSymbols = dedupe(symbols, 'symbolId');
+    const finalRelationships = dedupe(relationships, 'relationshipId');
+    const finalEvidence = dedupe(evidence, 'evidenceId');
+    const finalSpans = dedupe(sourceSpans, 'spanId');
+    unresolved.sort((a, b) => {
+      const ka = `${a.kind}:${a.name}:${a.fromSymbolId}`;
+      const kb = `${b.kind}:${b.name}:${b.fromSymbolId}`;
+      return ka.localeCompare(kb);
+    });
+
+    const analyzerRun = {
+      schemaVersion: 1,
+      kind: 'project-knowledge-analyzer-run',
+      contractId: CONTRACT_IDS.ANALYZER_RUN,
+      projectId,
+      snapshotId,
+      analyzerRunId: `run:${analyzerId}:${snapshotId}`,
+      analyzerId,
+      analyzerVersion,
+      inputInventoryHash: '',
+      status: ANALYZER_RUN_STATUSES.SUCCEEDED,
+    };
+
+    return {
+      analyzerRun,
+      symbols: finalSymbols,
+      relationships: finalRelationships,
+      evidence: finalEvidence,
+      sourceSpans: finalSpans,
+      unresolved,
+      analyzerId,
+      analyzerVersion,
+    };
+  }
+
+  return {
+    analyzerId,
+    analyzerVersion,
+    analyze,
+  };
+}
+
+module.exports = {
+  createRpgAnalyzer,
+  ANALYZER_ID,
+  ANALYZER_VERSION,
+};

--- a/src/projectIntelligence/analyzers/spans.js
+++ b/src/projectIntelligence/analyzers/spans.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const path = require('path');
+const CONTRACT_IDS = require('../contractIds');
+
+/**
+ * Convert scanner evidence (may include absolute paths) into ZPI source spans.
+ * Paths are never stored as absolute host paths.
+ */
+function evidenceToSpan({ projectId, snapshotId, sourceUnitId, contentHash, evidence, index = 0 }) {
+  if (!evidence || typeof evidence !== 'object') return null;
+  const startLine = Number(evidence.line || evidence.startLine || 1);
+  const endLine = Number(evidence.endLine || evidence.line || startLine);
+  if (!Number.isInteger(startLine) || startLine < 1) return null;
+  const spanId = `span:${sourceUnitId}:${startLine}-${endLine}:${index}`;
+  return {
+    schemaVersion: 1,
+    kind: 'project-knowledge-source-span',
+    contractId: CONTRACT_IDS.SOURCE_SPAN,
+    projectId,
+    snapshotId,
+    spanId,
+    sourceUnitId,
+    contentHash,
+    start: { line: startLine },
+    end: { line: Math.max(startLine, endLine) },
+  };
+}
+
+function collectSpansFromEvidenceList(ctx, evidenceList) {
+  const spans = [];
+  const ids = [];
+  (evidenceList || []).forEach((ev, i) => {
+    const span = evidenceToSpan({ ...ctx, evidence: ev, index: i });
+    if (span) {
+      spans.push(span);
+      ids.push(span.spanId);
+    }
+  });
+  return { spans, ids };
+}
+
+/**
+ * Safe display path for diagnostics — basename or relative only.
+ */
+function safePathLabel(filePath, fallbackRelative) {
+  if (fallbackRelative) return String(fallbackRelative).replace(/\\/g, '/');
+  if (!filePath) return '';
+  const s = String(filePath);
+  if (/^[A-Za-z]:[\\/]/.test(s) || s.startsWith('/') || s.startsWith('\\\\')) {
+    return path.basename(s);
+  }
+  return s.replace(/\\/g, '/');
+}
+
+module.exports = {
+  evidenceToSpan,
+  collectSpansFromEvidenceList,
+  safePathLabel,
+};

--- a/src/projectIntelligence/engine/index.js
+++ b/src/projectIntelligence/engine/index.js
@@ -9,6 +9,7 @@ const diffPlanner = require('./diffPlanner');
 const invalidation = require('./invalidation');
 const baselineAnalyzer = require('./baselineAnalyzer');
 const snapshotEngine = require('./snapshotEngine');
+const analyzers = require('../analyzers');
 
 module.exports = {
   buildSourceInventory: inventory.buildSourceInventory,
@@ -16,8 +17,10 @@ module.exports = {
   planInventoryDiff: diffPlanner.planInventoryDiff,
   planInvalidation: invalidation.planInvalidation,
   createBaselineAnalyzer: baselineAnalyzer.createBaselineAnalyzer,
-  ANALYZER_ID: baselineAnalyzer.ANALYZER_ID,
-  ANALYZER_VERSION: baselineAnalyzer.ANALYZER_VERSION,
+  createRpgAnalyzer: analyzers.createRpgAnalyzer,
+  ANALYZER_ID: analyzers.ANALYZER_ID,
+  ANALYZER_VERSION: analyzers.ANALYZER_VERSION,
+  BASELINE_ANALYZER_ID: baselineAnalyzer.ANALYZER_ID,
   createSnapshotEngine: snapshotEngine.createSnapshotEngine,
   openSnapshotEngine: snapshotEngine.openSnapshotEngine,
 };

--- a/src/projectIntelligence/engine/snapshotEngine.js
+++ b/src/projectIntelligence/engine/snapshotEngine.js
@@ -13,7 +13,7 @@ const { probeNodeSqlite } = require('../store/sqliteDriver');
 const { buildSourceInventory } = require('./inventory');
 const { planInventoryDiff } = require('./diffPlanner');
 const { planInvalidation } = require('./invalidation');
-const { createBaselineAnalyzer } = require('./baselineAnalyzer');
+const { createRpgAnalyzer } = require('../analyzers');
 
 const ARTIFACT_SCHEMA_VERSION = 1;
 
@@ -78,7 +78,7 @@ function createSnapshotEngine(options = {}) {
     knowledgeRoot,
     projectId,
     trustedRoots,
-    analyzer: analyzer || createBaselineAnalyzer(),
+    analyzer: analyzer || createRpgAnalyzer(),
     readOnly: false,
   });
 }
@@ -108,7 +108,7 @@ function openSnapshotEngine(options = {}) {
     knowledgeRoot,
     projectId: project.projectId,
     trustedRoots: trustedRoots || [],
-    analyzer: analyzer || createBaselineAnalyzer(),
+    analyzer: analyzer || createRpgAnalyzer(),
     readOnly,
   });
 }

--- a/src/projectIntelligence/index.js
+++ b/src/projectIntelligence/index.js
@@ -8,8 +8,9 @@
  * ZPI-04: content-addressed store, trusted roots, path controls (GC design-only).
  * ZPI-05: Search SPI + Community lexical provider (Lucene layout/schema).
  * ZPI-06: Snapshot + incremental update engine (diff, invalidation, atomic publish).
+ * ZPI-07: RPG/IBM i analyzer baseline (parser adapters, spans, unresolved model).
  *
- * Not included yet: full RPG analyzer extractors (ZPI-07), CLI/MCP.
+ * Not included yet: retrieval/context assembly (ZPI-08), CLI/MCP.
  */
 
 const constants = require('./constants');
@@ -23,6 +24,7 @@ const store = require('./store');
 const content = require('./content');
 const search = require('./search');
 const engine = require('./engine');
+const analyzers = require('./analyzers');
 
 module.exports = {
   // Vocabulary
@@ -88,4 +90,8 @@ module.exports = {
   planInventoryDiff: engine.planInventoryDiff,
   planInvalidation: engine.planInvalidation,
   buildSourceInventory: engine.buildSourceInventory,
+
+  // RPG/IBM i analyzer (ZPI-07)
+  analyzers,
+  createRpgAnalyzer: analyzers.createRpgAnalyzer,
 };

--- a/tests/project-intelligence-rpg-analyzer.test.js
+++ b/tests/project-intelligence-rpg-analyzer.test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const {
+  createRpgAnalyzer,
+  createSnapshotEngine,
+  sha256Hex,
+  canonicalizeContent,
+  KnowledgeStoreError,
+  probeNodeSqlite,
+} = require('../src/projectIntelligence');
+
+const HAS_SQLITE = probeNodeSqlite().available;
+const FIXTURE_ORDER = path.join(__dirname, 'fixtures', 'v1-smoke', 'src', 'ORDERPGM.rpgle');
+const FIXTURE_INV = path.join(__dirname, 'fixtures', 'v1-smoke', 'src', 'INVPGM.rpgle');
+const FIXTURE_FREE = path.join(
+  __dirname,
+  'fixtures',
+  'sanitized-corpus',
+  'scanner',
+  'core-patterns',
+  'freeform-order.rpgle'
+);
+
+function unitFromBody(relativePath, body, rootId = 'root-src') {
+  const { bytes } = canonicalizeContent(body, { mode: 'text' });
+  const contentHash = sha256Hex(bytes);
+  return {
+    sourceUnitId: `su:${rootId}:${relativePath}`,
+    trustedRootId: rootId,
+    relativePath,
+    contentHash,
+    sizeBytes: bytes.length,
+    language: relativePath.endsWith('.clle') ? 'clle' : 'rpgle',
+    hashAlgorithm: 'sha256',
+    body,
+    bytes,
+  };
+}
+
+function analyzeFixtures(files) {
+  const analyzer = createRpgAnalyzer();
+  const units = [];
+  const bodiesByHash = {};
+  for (const [relativePath, body] of Object.entries(files)) {
+    const u = unitFromBody(relativePath, body);
+    units.push(u);
+    bodiesByHash[u.contentHash] = u.bytes.toString('utf8');
+  }
+  const result = analyzer.analyze({
+    projectId: 'proj-demo',
+    snapshotId: 'snap-test',
+    units,
+    bodiesByHash,
+  });
+  return result;
+}
+
+test('RPG analyzer extracts programs, procedures, copy, sql, calls with spans', () => {
+  const orderBody = fs.readFileSync(FIXTURE_ORDER, 'utf8');
+  const invBody = fs.readFileSync(FIXTURE_INV, 'utf8');
+  const result = analyzeFixtures({
+    'QRPGLESRC/ORDERPGM.rpgle': orderBody,
+    'QRPGLESRC/INVPGM.rpgle': invBody,
+  });
+
+  assert.equal(result.analyzerId, 'zeus.rpg-ibmi-baseline');
+  const kinds = new Set(result.symbols.map(s => s.symbolKind));
+  assert.ok(kinds.has('PROGRAM'));
+  assert.ok(kinds.has('PROCEDURE') || kinds.has('COPY_MEMBER') || kinds.has('TABLE'));
+
+  // ORDERPGM program symbol
+  const order = result.symbols.find(s => s.name === 'ORDERPGM' && s.symbolKind === 'PROGRAM');
+  assert.ok(order);
+  assert.ok(order.evidenceReferences.length >= 1);
+  assert.equal(order.provenance.derivationClass, 'VERIFIED');
+
+  // Copy include
+  const copyRel = result.relationships.find(r => r.relationshipType === 'COPY_INCLUDE');
+  assert.ok(copyRel, 'expected COPY_INCLUDE relationship');
+
+  // Resolved program call ORDERPGM -> INVPGM
+  const call = result.relationships.find(
+    r => r.relationshipType === 'PROGRAM_CALL' && r.toSymbolId.includes('INVPGM')
+  );
+  assert.ok(call, 'expected resolved PROGRAM_CALL to INVPGM');
+
+  // SQL table reference
+  const sqlRel = result.relationships.find(r => r.relationshipType === 'SQL_REFERENCE');
+  assert.ok(sqlRel, 'expected SQL_REFERENCE');
+
+  // Source spans present and line-bounded
+  assert.ok(result.sourceSpans.length >= 1);
+  for (const span of result.sourceSpans) {
+    assert.ok(span.start.line >= 1);
+    assert.ok(span.end.line >= span.start.line);
+    assert.ok(span.sourceUnitId);
+    assert.ok(span.contentHash);
+  }
+
+  // No absolute host paths in evidence relativePath
+  for (const ev of result.evidence) {
+    if (ev.relativePath) {
+      assert.equal(/^[A-Za-z]:[\\/]/.test(ev.relativePath), false);
+    }
+  }
+});
+
+test('unresolved procedure calls produce UNRESOLVED_SYMBOL model', () => {
+  const orderBody = fs.readFileSync(FIXTURE_ORDER, 'utf8');
+  const result = analyzeFixtures({
+    'QRPGLESRC/ORDERPGM.rpgle': orderBody,
+  });
+
+  // ProcessOrder is called but not defined in this single unit
+  const unresolvedSym = result.symbols.filter(s => s.symbolKind === 'UNRESOLVED_SYMBOL');
+  assert.ok(unresolvedSym.length >= 1, 'expected unresolved symbols');
+  assert.ok(result.unresolved.length >= 1);
+  assert.ok(result.unresolved.every(u => u.name && u.fromSymbolId));
+
+  const dyn = result.relationships.filter(r => r.relationshipType === 'DYNAMIC_UNRESOLVED_CALL');
+  assert.ok(dyn.length >= 1);
+  assert.ok(dyn.every(r => r.provenance.derivationClass === 'UNRESOLVED'));
+});
+
+test('analyzer output is deterministic across runs', () => {
+  const body = fs.readFileSync(FIXTURE_FREE, 'utf8');
+  const a = analyzeFixtures({ 'freeform-order.rpgle': body });
+  const b = analyzeFixtures({ 'freeform-order.rpgle': body });
+  assert.deepEqual(
+    a.symbols.map(s => s.symbolId),
+    b.symbols.map(s => s.symbolId)
+  );
+  assert.deepEqual(
+    a.relationships.map(r => r.relationshipId),
+    b.relationships.map(r => r.relationshipId)
+  );
+  assert.deepEqual(
+    a.sourceSpans.map(s => s.spanId),
+    b.sourceSpans.map(s => s.spanId)
+  );
+  assert.deepEqual(a.unresolved, b.unresolved);
+});
+
+test('ambiguous same basename across libraries remains separate source units', () => {
+  const body = '**free\ncall OTHER;\n';
+  const result = analyzeFixtures({
+    'LIBA/QRPGLESRC/SAMEPGM.rpgle': body,
+    'LIBB/QRPGLESRC/SAMEPGM.rpgle': body,
+  });
+  const programs = result.symbols.filter(s => s.symbolKind === 'PROGRAM' && s.name === 'SAMEPGM');
+  assert.equal(programs.length, 2);
+  assert.notEqual(programs[0].symbolId, programs[1].symbolId);
+});
+
+test(
+  'engine default uses RPG analyzer and publishes extractable graph',
+  { skip: !HAS_SQLITE },
+  () => {
+    const os = require('os');
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zpi-rpg-eng-'));
+    const src = path.join(root, 'src');
+    const knowledgeRoot = path.join(root, 'pk');
+    fs.mkdirSync(src, { recursive: true });
+    fs.copyFileSync(FIXTURE_ORDER, path.join(src, 'ORDERPGM.rpgle'));
+    fs.copyFileSync(FIXTURE_INV, path.join(src, 'INVPGM.rpgle'));
+
+    const engine = createSnapshotEngine({
+      knowledgeRoot,
+      projectId: 'proj-rpg',
+      trustedRoots: [{ rootId: 'root-src', path: src }],
+    });
+    try {
+      const published = engine.fullRebuild();
+      assert.equal(published.ok, true);
+      assert.equal(published.analyzer.analyzerId, 'zeus.rpg-ibmi-baseline');
+      const snapId = published.snapshot.snapshotId;
+      const symbols = engine._store.listSymbols('proj-rpg', snapId);
+      const rels = engine._store.listRelationships('proj-rpg', snapId);
+      assert.ok(symbols.some(s => s.name === 'ORDERPGM'));
+      assert.ok(
+        rels.some(
+          r => r.relationshipType === 'PROGRAM_CALL' || r.relationshipType === 'COPY_INCLUDE'
+        )
+      );
+    } finally {
+      engine.close();
+    }
+  }
+);
+
+test('graph projection sorts deterministically for equality views', { skip: !HAS_SQLITE }, () => {
+  const os = require('os');
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'zpi-rpg-eq-'));
+  const src = path.join(root, 'src');
+  const knowledgeRoot = path.join(root, 'pk');
+  fs.mkdirSync(src, { recursive: true });
+  fs.writeFileSync(path.join(src, 'A.rpgle'), '**free\ncall B;\n', 'utf8');
+  fs.writeFileSync(path.join(src, 'B.rpgle'), '**free\n// B\n', 'utf8');
+  const engine = createSnapshotEngine({
+    knowledgeRoot,
+    projectId: 'proj-eq',
+    trustedRoots: [{ rootId: 'root-src', path: src }],
+  });
+  try {
+    engine.fullRebuild();
+    const id = engine.getCurrentSnapshot().snapshotId;
+    const v1 = engine.projectEqualityView(id);
+    const v2 = engine.projectEqualityView(id);
+    assert.deepEqual(v1, v2);
+  } finally {
+    engine.close();
+  }
+});
+
+// silence unused import in non-sqlite environments
+void KnowledgeStoreError;


### PR DESCRIPTION
## Summary

- Implements **ZPI-07 — RPG/IBM i Analyzer Baseline**.
- Parser adapters for RPG/CL/binder via existing Community scanners (in-memory content).
- Projects programs, procedures, prototypes, DS, files/tables, SQL refs, copy includes, service programs.
- Source spans from scanner evidence (no absolute host paths).
- Unresolved program/procedure calls → `UNRESOLVED_SYMBOL` + `DYNAMIC_UNRESOLVED_CALL`.
- Default analyzer for snapshot engine (`zeus.rpg-ibmi-baseline`).

## Test plan

- [x] corpus fixtures (ORDERPGM/INVPGM, freeform)
- [x] unresolved + ambiguity
- [x] source spans + deterministic graph
- [x] engine integration
- [x] format/lint/typecheck/test:contract/package:smoke