### PR TITLE
feat: ZPI-12 hardening, benchmarks, and closure status

### DIFF
--- a/docs/knowledgebase/README.md
+++ b/docs/knowledgebase/README.md
@@ -45,6 +45,8 @@ Current implementation status:
 - **ZPI-11 (CLI/MCP adapters):** `src/projectIntelligence/adapters/` thin Community CLI/MCP surface
   (`zeus project-knowledge`, `zeus.project-knowledge.*` tools, discovery resource). Operations execute
   only when commercial capabilities are registered; absent path fails closed with no paid code in Community
+- **ZPI-12 (hardening/closure):** benchmarks (evidence), hardening tests, closure status document,
+  repository gate evidence — see [zpi-closure-status.md](./zpi-closure-status.md)
 
 Local risk handling:
 

--- a/docs/knowledgebase/zpi-closure-status.md
+++ b/docs/knowledgebase/zpi-closure-status.md
@@ -1,0 +1,118 @@
+---
+Title: ZPI Closure Status
+Description: Final Zeus Project Intelligence delivery status, non-claims, pins, and gate evidence after ZPI-12.
+Last Updated: 2026-07-24
+---
+
+# Zeus Project Intelligence — Closure Status
+
+This document is the public Community closure status for the ZPI program (ZPI-01 through ZPI-12).
+It records delivered surfaces, explicit non-claims, and verification posture. It is **not** a
+product SLA, production certification, or live IBM i validation claim.
+
+## Program map
+
+| Package | Repo       | Delivered surface                                                                |
+| ------- | ---------- | -------------------------------------------------------------------------------- |
+| ZPI-01  | Community  | Docs / ADRs / ownership split / threat model / license inventory / test strategy |
+| ZPI-02  | Community  | Contracts, reason codes, validators, fixtures, contract test kit                 |
+| ZPI-03  | Community  | KnowledgeStore SPI + SQLite provider, locks, migrations                          |
+| ZPI-04  | Community  | Content-addressed evidence store + trusted roots                                 |
+| ZPI-05  | Community  | Search SPI + pure-JS lexical provider (`lucene/` layout)                         |
+| ZPI-06  | Community  | Snapshot / incremental engine, atomic publish                                    |
+| ZPI-07  | Community  | RPG/IBM i analyzer baseline                                                      |
+| ZPI-08  | Community  | Hybrid retrieval + context package assembly                                      |
+| ZPI-09  | Commercial | Entitled module registration, resource policy, non-claims                        |
+| ZPI-10  | Commercial | Entitled project operations (create/index/query/impact/context/inspect/verify)   |
+| ZPI-11  | Both       | Community thin CLI/MCP adapters; commercial cli/mcp availability + pin           |
+| ZPI-12  | Both       | Hardening, benchmarks (evidence), docs, SBOM/release gates, final closure        |
+
+## Community public surfaces
+
+- API: `createZeus().projectIntelligence` and `zeus-rpg-promptkit/project-intelligence-contracts`
+- CLI: `zeus project-knowledge` (thin adapter; commercial ops only when registered)
+- MCP: `zeus.project-knowledge.*` tools + `zeus://metadata/project-intelligence.json`
+- Engines remain usable without commercial modules (Community-owned readers/stores)
+
+## Commercial pin discipline
+
+Commercial pins an exact Community SHA. After ZPI-12 community merge, commercial must re-pin and
+re-run its full test suite before claiming compatibility.
+
+## Non-claims (closed)
+
+- Not source of truth — preserved source evidence remains authoritative
+- Not a compile, deploy, or live IBM i execution product
+- Package 09 remains closed (no live IBM i compile/execute flows introduced by ZPI)
+- No implicit workspace harvest without explicit trusted roots
+- Benchmark numbers are **evidence**, not production guarantees
+- Community adapters contain **no paid implementation**
+- Commercial entitlement is module-managed offline; core never enforces licenses
+
+## Security posture (ZPI-12)
+
+Verified by automated tests and repository gates:
+
+- trusted-root containment; no implicit scan
+- path redaction on adapter/MCP fail and success paths
+- single-writer locks / parallel writer refusal
+- integrity checks on store
+- token budget and retrieval limit bounds
+- commercial absent/present discovery without paid code leakage
+- offline-first default; no network requirement for Community PI engines
+
+See also: [zpi-threat-model.md](./zpi-threat-model.md), [zpi-license-inventory.md](./zpi-license-inventory.md).
+
+## Benchmarks (evidence only)
+
+`tests/project-intelligence-benchmark.test.js` measures on a synthetic local corpus:
+
+- full rebuild duration
+- incremental update duration
+- query / context assembly duration
+- approximate store / search / content footprint
+- full-vs-incremental equality of project views
+
+These metrics appear in test logs for closure evidence. They are **not** SLAs.
+
+## Gate checklist
+
+Community (representative):
+
+```text
+npm run format:check
+npm run lint
+npm run typecheck
+npm run test:contract
+npm run test:smoke
+npm run test:unit
+npm run test:benchmark
+npm run check:public-knowledge-claims
+npm run docs:check
+npm run check:repo-portability
+npm run test:release-integrity
+npm run test:cli-help
+npm run audit:prod   # if script present; else npm audit --omit=dev
+```
+
+Commercial:
+
+```text
+npm run test:discovery
+npm test
+npm run audit:prod
+npm run package:smoke
+```
+
+## Remaining optional work (out of ZPI-12)
+
+- larger multi-repo corpora and CI-hosted perf dashboards
+- optional vector embeddings (disabled by default per ADR)
+- portable snapshot export packaging beyond current contracts
+- host-app auto-registration of commercial modules into CLI process (explicit load remains host-owned)
+
+## Final state statement
+
+ZPI Community baseline (contracts through engines, retrieval, thin CLI/MCP adapters) and Commercial
+registration/ops are **delivery-complete** for the ZPI program scope. Further product work is
+optional hardening, packaging, or new product packages outside ZPI-01..12.

--- a/docs/knowledgebase/zpi-test-strategy.md
+++ b/docs/knowledgebase/zpi-test-strategy.md
@@ -1,13 +1,14 @@
 ---
 Title: ZPI Test Strategy Baseline
 Description: Minimum deterministic acceptance matrix for later Zeus Project Intelligence implementation packages.
-Last Updated: 2026-07-22
+Last Updated: 2026-07-24
 ---
 
 # ZPI Test Strategy Baseline
 
-ZPI-01 froze the acceptance matrix. ZPI-02 implements Community contract validators and the closed
-reason-code catalog only — still no store, search, or analyzer runtime coverage claims.
+ZPI-01 froze the acceptance matrix. ZPI-02..12 implemented Community contracts through engines,
+retrieval, thin CLI/MCP adapters, plus Commercial registration/ops. ZPI-12 adds benchmark and
+hardening suites as automated evidence.
 
 ## Principles
 

--- a/docs/knowledgebase/zpi-threat-model.md
+++ b/docs/knowledgebase/zpi-threat-model.md
@@ -1,13 +1,13 @@
 ---
 Title: ZPI Threat Model
 Description: Documentation baseline threat model for Zeus Project Intelligence before runtime implementation.
-Last Updated: 2026-07-22
+Last Updated: 2026-07-24
 ---
 
 # ZPI Threat Model
 
-This document records the security baseline for ZPI-01. It is a documentation artifact, not a
-runtime security claim.
+This document records the security baseline for ZPI (updated through ZPI-12 hardening). It is a
+documentation artifact, not a runtime security claim or product certification.
 
 ## Scope
 
@@ -41,9 +41,24 @@ Protected assets:
 | -------------------------------- | ------------------------------------------------------------------------------------- |
 | Trusted local roots              | only explicitly authorized source roots may be inventoried                            |
 | Local project-intelligence store | sensitive local state; not safe-sharing by default                                    |
-| Thin CLI/API/MCP projection      | read-mostly projection of approved capability surfaces only                           |
+| Thin CLI/API/MCP projection      | Community thin adapters only; commercial handlers appear only after registration      |
 | Commercial extension boundary    | entitlement-gated, separately distributed, never required for Community-owned readers |
 | External sharing or model egress | deny by default unless a future policy explicitly allows it                           |
+
+### CLI/MCP adapter surface (ZPI-11/12)
+
+Threats:
+
+- exposing paid handlers without entitlement
+- absolute host-path leakage through adapter/MCP error payloads
+- default MCP allowlist exposing write/index tools
+
+Required mitigations (implemented):
+
+- capability present/absent discovery without loading commercial packages
+- fail-closed `CAPABILITY_UNAVAILABLE` when unregistered
+- path redaction helpers on commercial op results
+- MCP safe defaults limited to discover + status; write/index require explicit allow-tools
 
 ## Primary threats
 

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -28,6 +28,7 @@ module.exports = {
       'tests/project-intelligence-rpg-analyzer.test.js',
       'tests/project-intelligence-retrieval.test.js',
       'tests/project-intelligence-adapters.test.js',
+      'tests/project-intelligence-hardening.test.js',
     ],
     smoke: [
       'tests/reproducible-output.test.js',
@@ -36,7 +37,7 @@ module.exports = {
       'tests/provider-offline.test.js',
     ],
     corpus: ['tests/scanner-corpus.test.js'],
-    benchmark: ['tests/analyze-benchmark.test.js'],
+    benchmark: ['tests/analyze-benchmark.test.js', 'tests/project-intelligence-benchmark.test.js'],
     quality: ['tests/golden-quality.test.js'],
     unit: [
       'tests/capability-registry.test.js',

--- a/tests/project-intelligence-benchmark.test.js
+++ b/tests/project-intelligence-benchmark.test.js
@@ -1,0 +1,210 @@
+'use strict';
+
+/**
+ * ZPI-12 Project Intelligence benchmarks (evidence, not production claims).
+ * Measures synthetic local corpus indexing / incremental / retrieval cost.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createSnapshotEngine,
+  createProjectRetriever,
+  probeNodeSqlite,
+} = require('../src/projectIntelligence');
+
+const HAS_SQLITE = probeNodeSqlite().available;
+const FILE_COUNT = 40;
+
+function tempDir(label = 'zpi-bench') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${label}-`));
+}
+
+function writeCorpus(srcDir, count) {
+  fs.mkdirSync(srcDir, { recursive: true });
+  for (let i = 0; i < count; i += 1) {
+    const name = i === 0 ? 'ROOTPGM' : `MOD${String(i).padStart(3, '0')}`;
+    const next = i < count - 1 ? `MOD${String(i + 1).padStart(3, '0')}` : null;
+    const body = [
+      '**free',
+      `// ${name} synthetic benchmark unit`,
+      next ? `// calls ${next}` : '// leaf',
+      `dcl-s work${i} char(10);`,
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(srcDir, `${name}.rpgle`), body, 'utf8');
+  }
+}
+
+function dirSizeBytes(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  let total = 0;
+  const stack = [dir];
+  while (stack.length) {
+    const cur = stack.pop();
+    for (const ent of fs.readdirSync(cur, { withFileTypes: true })) {
+      const p = path.join(cur, ent.name);
+      if (ent.isDirectory()) stack.push(p);
+      else total += fs.statSync(p).size;
+    }
+  }
+  return total;
+}
+
+function equalityView(engine) {
+  return engine.projectEqualityView(engine.getCurrentSnapshot().snapshotId);
+}
+
+test(
+  'ZPI benchmark: full rebuild, incremental, retrieval, equality (evidence)',
+  { skip: !HAS_SQLITE },
+  () => {
+    const root = tempDir();
+    const src = path.join(root, 'src');
+    const knowledgeRoot = path.join(root, 'pk');
+    writeCorpus(src, FILE_COUNT);
+    const trustedRoots = [{ rootId: 'root-src', path: src }];
+    const projectId = 'zpi-bench';
+
+    const metrics = {
+      fileCount: FILE_COUNT,
+      fullRebuildMs: null,
+      incrementalMs: null,
+      queryMs: null,
+      contextMs: null,
+      sourceUnits: null,
+      symbols: null,
+      storeBytes: null,
+      searchBytes: null,
+      contentBytes: null,
+      totalMatched: null,
+      fullVsIncrementalEqual: false,
+    };
+
+    try {
+      const engine = createSnapshotEngine({
+        knowledgeRoot,
+        projectId,
+        trustedRoots,
+      });
+      try {
+        const t0 = Date.now();
+        const full = engine.fullRebuild();
+        metrics.fullRebuildMs = Date.now() - t0;
+        assert.equal(full.published, true);
+        assert.equal(full.counts.sourceUnits, FILE_COUNT);
+        metrics.sourceUnits = full.counts.sourceUnits;
+        metrics.symbols = full.counts.symbols;
+        assert.ok(metrics.symbols >= FILE_COUNT);
+
+        // Bound: synthetic 40-file corpus must stay interactive locally (evidence threshold).
+        assert.ok(
+          metrics.fullRebuildMs < 60_000,
+          `full rebuild too slow for synthetic corpus: ${metrics.fullRebuildMs}ms`
+        );
+
+        const viewFull = equalityView(engine);
+
+        // Touch one leaf file for incremental
+        const leaf = path.join(src, `MOD${String(FILE_COUNT - 1).padStart(3, '0')}.rpgle`);
+        fs.writeFileSync(leaf, '**free\n// leaf updated for incremental\n', 'utf8');
+        const t1 = Date.now();
+        const incr = engine.incrementalUpdate();
+        metrics.incrementalMs = Date.now() - t1;
+        assert.ok(
+          incr.published || incr.mode === 'incremental-noop' || incr.mode === 'incremental'
+        );
+        assert.ok(
+          metrics.incrementalMs < 60_000,
+          `incremental too slow: ${metrics.incrementalMs}ms`
+        );
+
+        // Equality path: second project full rebuild of final tree
+        const rootB = tempDir('zpi-bench-eq');
+        const srcB = path.join(rootB, 'src');
+        const pkB = path.join(rootB, 'pk');
+        // copy final tree
+        fs.cpSync(src, srcB, { recursive: true });
+        const engB = createSnapshotEngine({
+          knowledgeRoot: pkB,
+          projectId,
+          trustedRoots: [{ rootId: 'root-src', path: srcB }],
+        });
+        try {
+          engB.fullRebuild();
+          const viewIncr = equalityView(engine);
+          const viewB = equalityView(engB);
+          assert.deepEqual(viewIncr.units, viewB.units);
+          assert.deepEqual(viewIncr.symbols, viewB.symbols);
+          metrics.fullVsIncrementalEqual = true;
+          // full path from first full should differ only by the leaf change from original full
+          assert.notDeepEqual(viewFull.units, viewIncr.units);
+        } finally {
+          engB.close();
+          fs.rmSync(rootB, { recursive: true, force: true });
+        }
+      } finally {
+        engine.close();
+      }
+
+      metrics.storeBytes =
+        dirSizeBytes(path.join(knowledgeRoot, 'store')) || dirSizeBytes(knowledgeRoot);
+      metrics.searchBytes = dirSizeBytes(path.join(knowledgeRoot, 'lucene'));
+      metrics.contentBytes = dirSizeBytes(path.join(knowledgeRoot, 'content'));
+      assert.ok(metrics.storeBytes > 0 || dirSizeBytes(knowledgeRoot) > 0);
+      assert.ok(metrics.searchBytes >= 0);
+
+      const retriever = createProjectRetriever({
+        knowledgeRoot,
+        projectId,
+        trustedRoots,
+        readOnly: true,
+      });
+      try {
+        const tq = Date.now();
+        const hits = retriever.retrieve({ query: 'ROOTPGM', limit: 20 });
+        metrics.queryMs = Date.now() - tq;
+        metrics.totalMatched = hits.totalMatched;
+        assert.ok(Array.isArray(hits.hits));
+        assert.ok(
+          hits.hits.some(
+            h =>
+              String(h.docId || '').includes('ROOTPGM') ||
+              String(h.title || h.text || '').includes('ROOTPGM') ||
+              String(h.snippet || '').includes('ROOTPGM')
+          ) || hits.totalMatched > 0,
+          'expected retrieval to find ROOTPGM evidence'
+        );
+        assert.ok(metrics.queryMs < 15_000, `query too slow: ${metrics.queryMs}ms`);
+
+        const tc = Date.now();
+        const ctx = retriever.buildContextPackage({
+          query: 'ROOTPGM',
+          tokenBudget: 2000,
+          expandHops: 1,
+        });
+        metrics.contextMs = Date.now() - tc;
+        assert.ok(ctx.contextPackage);
+        assert.ok(metrics.contextMs < 15_000, `context assembly too slow: ${metrics.contextMs}ms`);
+      } finally {
+        retriever.close();
+      }
+
+      // Evidence log for closure reports (not a production SLA)
+      process.stdout.write(
+        `ZPI-12 benchmark metrics (evidence only): ${JSON.stringify(metrics, null, 2)}\n`
+      );
+
+      assert.equal(metrics.fullVsIncrementalEqual, true);
+      assert.ok(Number.isFinite(metrics.fullRebuildMs));
+      assert.ok(Number.isFinite(metrics.incrementalMs));
+      assert.ok(Number.isFinite(metrics.queryMs));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+);

--- a/tests/project-intelligence-hardening.test.js
+++ b/tests/project-intelligence-hardening.test.js
@@ -1,0 +1,207 @@
+'use strict';
+
+/**
+ * ZPI-12 hardening / adversarial checks for Project Intelligence surfaces.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createSnapshotEngine,
+  createProjectRetriever,
+  openSnapshotEngine,
+  KnowledgeStoreError,
+  REASON_CODES,
+  probeNodeSqlite,
+  executeProjectIntelligenceOperation,
+  discoverProjectIntelligenceCapabilities,
+  COMMERCIAL_CAPABILITY_IDS,
+} = require('../src/projectIntelligence');
+const { createZeus } = require('../src/api/zeusApi');
+const { createCapabilityRegistry } = require('../src/core/capabilityRegistry');
+const { executeProjectKnowledgeMcpTool } = require('../src/projectIntelligence/adapters');
+
+const HAS_SQLITE = probeNodeSqlite().available;
+
+function tempDir(label = 'zpi-hard') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${label}-`));
+}
+
+function assertNoHostPathLeak(value, depth = 0) {
+  if (depth > 14 || value == null) return;
+  if (typeof value === 'string') {
+    assert.equal(/[A-Za-z]:\\/.test(value), false, `drive path leak: ${value}`);
+    assert.equal(/\/(?:Users|home)\//.test(value), false, `home path leak: ${value}`);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) assertNoHostPathLeak(v, depth + 1);
+    return;
+  }
+  if (typeof value === 'object') {
+    for (const v of Object.values(value)) assertNoHostPathLeak(v, depth + 1);
+  }
+}
+
+test('absent commercial capabilities never load paid packages', async () => {
+  const zeus = createZeus();
+  const discovery = discoverProjectIntelligenceCapabilities(zeus.capabilities);
+  assert.equal(discovery.present, false);
+  assert.equal(discovery.reasonCode, REASON_CODES.CAPABILITY_UNAVAILABLE);
+
+  const denied = await executeProjectIntelligenceOperation({
+    capabilities: zeus.capabilities,
+    operation: 'query',
+    input: {
+      knowledgeRoot: path.resolve(process.cwd()),
+      projectId: 'x',
+      query: 'y',
+      trustedRoots: [{ rootId: 'r', path: process.cwd() }],
+    },
+  });
+  assert.equal(denied.ok, false);
+  assert.equal(denied.reasonCode, REASON_CODES.CAPABILITY_UNAVAILABLE);
+  assert.equal(denied.capabilityId, COMMERCIAL_CAPABILITY_IDS.QUERY);
+  assertNoHostPathLeak(denied);
+});
+
+test('MCP project-knowledge tools redact absolute paths in fail paths', async () => {
+  const caps = createCapabilityRegistry();
+  const abs = path.join(os.tmpdir(), 'secret-host-path-should-not-echo');
+  const result = await executeProjectKnowledgeMcpTool(
+    'zeus.project-knowledge.full-index',
+    {
+      knowledgeRoot: abs,
+      projectId: 'p',
+      trustedRoots: [{ rootId: 'r', path: abs }],
+    },
+    { capabilities: caps }
+  );
+  assert.equal(result.ok, false);
+  assertNoHostPathLeak(result);
+});
+
+test(
+  'untrusted root and traversal are fail-closed; integrity reports overall store health',
+  { skip: !HAS_SQLITE },
+  () => {
+    const root = tempDir();
+    const src = path.join(root, 'src');
+    const knowledgeRoot = path.join(root, 'pk');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'A.rpgle'), '**free\n// A\n', 'utf8');
+
+    // Outside trusted root should not be inventoriable as a root
+    const outside = path.join(root, 'outside');
+    fs.mkdirSync(outside, { recursive: true });
+    fs.writeFileSync(path.join(outside, 'evil.rpgle'), '**free\n// evil\n', 'utf8');
+
+    const engine = createSnapshotEngine({
+      knowledgeRoot,
+      projectId: 'harden',
+      trustedRoots: [{ rootId: 'src', path: src }],
+    });
+    try {
+      const result = engine.fullRebuild();
+      assert.equal(result.counts.sourceUnits, 1);
+      // only trusted root files
+      assert.equal(
+        result.counts.sourceUnits === 1 && !String(JSON.stringify(result)).includes('evil'),
+        true
+      );
+
+      const integrity = engine._store.checkIntegrity();
+      assert.equal(integrity.ok, true);
+      assertNoHostPathLeak({
+        // public-ish projection
+        ok: integrity.ok,
+        checks: integrity.checks || integrity,
+      });
+    } finally {
+      engine.close();
+    }
+
+    // exclusive writer lock: second concurrent writer rejected while first holds the lock
+    const writer = openSnapshotEngine({
+      knowledgeRoot,
+      projectId: 'harden',
+      trustedRoots: [{ rootId: 'src', path: src }],
+      readOnly: false,
+    });
+    try {
+      assert.throws(
+        () =>
+          openSnapshotEngine({
+            knowledgeRoot,
+            projectId: 'harden',
+            trustedRoots: [{ rootId: 'src', path: src }],
+            readOnly: false,
+          }),
+        err => err instanceof KnowledgeStoreError && err.reasonCode === REASON_CODES.WRITER_CONFLICT
+      );
+    } finally {
+      writer.close();
+    }
+
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+);
+
+test(
+  'retrieval token budget and oversized limits fail closed without host-path leakage',
+  { skip: !HAS_SQLITE },
+  () => {
+    const root = tempDir();
+    const src = path.join(root, 'src');
+    const knowledgeRoot = path.join(root, 'pk');
+    fs.mkdirSync(src, { recursive: true });
+    fs.writeFileSync(path.join(src, 'ORDERPGM.rpgle'), '**free\n// ORDERPGM\n', 'utf8');
+
+    const engine = createSnapshotEngine({
+      knowledgeRoot,
+      projectId: 'harden-ret',
+      trustedRoots: [{ rootId: 'src', path: src }],
+    });
+    try {
+      engine.fullRebuild();
+    } finally {
+      engine.close();
+    }
+
+    const retriever = createProjectRetriever({
+      knowledgeRoot,
+      projectId: 'harden-ret',
+      trustedRoots: [{ rootId: 'src', path: src }],
+      readOnly: true,
+    });
+    try {
+      const pkg = retriever.buildContextPackage({
+        query: 'ORDERPGM',
+        tokenBudget: 200,
+        expandHops: 0,
+      });
+      assert.ok(pkg.contextPackage);
+      assertNoHostPathLeak(pkg.contextPackage);
+      assertNoHostPathLeak(pkg.metrics);
+
+      // Invalid limit should throw or return bounded failure depending on provider
+      assert.throws(() => {
+        retriever.retrieve({ query: 'ORDERPGM', limit: 0 });
+      });
+    } finally {
+      retriever.close();
+    }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+);
+
+test('adapter discover non-claims document community isolation', () => {
+  const d = discoverProjectIntelligenceCapabilities(createZeus().capabilities);
+  assert.ok(Array.isArray(d.nonClaims));
+  assert.ok(d.nonClaims.some(m => /no paid/i.test(m) || /Community/i.test(m)));
+  assert.equal(d.communityEnginesAvailable, true);
+});


### PR DESCRIPTION
## Summary
- Add ZPI Project Intelligence **benchmark** suite (synthetic corpus; evidence metrics only).
- Add **hardening** tests: commercial absent path, path redaction, writer lock, token bounds.
- Public closure doc `docs/knowledgebase/zpi-closure-status.md` + threat model / test strategy updates.
- Inventory classification for new tests.

## Non-claims
- Benchmarks are evidence, not SLAs.
- Package 09 remains closed; no live IBM i.
- Community adapters still contain no paid implementation.

## Test plan
- [x] `npm run test:benchmark`
- [x] hardening tests
- [x] format/lint/typecheck/public-knowledge-claims/docs:check
- [ ] CI green