### PR TITLE
chore: prepare public Community release 0.2.0-beta.3

### DIFF
--- a/.github/RELEASE_NOTES_v0.2.0-beta.3.md
+++ b/.github/RELEASE_NOTES_v0.2.0-beta.3.md
@@ -1,0 +1,69 @@
+## Zeus RPG PromptKit 0.2.0-beta.3
+
+Public Community beta after Zeus Project Intelligence (ZPI) delivery and the commercial host loader.
+
+**Purpose of Beta 3**
+
+- Ship the Project Intelligence Community baseline (contracts through engines, retrieval, and context packages).
+- Provide thin CLI/MCP Project Intelligence adapters with commercial present/absent behavior only.
+- Expose an explicit commercial module host loader (`createHostZeus` / `registerCommercialModules`) with no auto-discovery and no paid handlers in Community.
+- Document ZPI closure status, non-claims, and the next-release maintainer checklist.
+- Publish under the hardened single-artifact release workflow (checksum, SBOM, and build-provenance attestation required).
+
+**Major additions since Beta 2**
+
+- Project Intelligence: contracts, SQLite knowledge store, content-addressed store, pure-JS lexical search, snapshot/incremental engine, RPG/IBM i analyzer baseline, hybrid retrieval and context assembly.
+- CLI: `zeus project-knowledge` thin adapter.
+- MCP: `zeus.project-knowledge.*` tools and metadata resource when registered.
+- API: `createHostZeus`, `registerCommercialModules`, and `zeus-rpg-promptkit/project-intelligence-contracts`.
+- Hardening and benchmark evidence suites (metrics are evidence only, not SLAs).
+- Public closure status: `docs/knowledgebase/zpi-closure-status.md`.
+
+**Non-claims**
+
+- Project Knowledge is not source of truth; preserved source evidence remains authoritative.
+- Not a compile, deploy, or live IBM i execution product.
+- Community adapters contain no paid commercial implementation.
+- Core does not enforce commercial licenses (ADR-006).
+- Benchmark numbers are evidence, not production guarantees.
+
+**Installation from GitHub release tarball (recommended for beta)**
+
+```bash
+npm install https://github.com/gzeuner/zeus-rpg-promptkit/releases/download/v0.2.0-beta.3/zeus-rpg-promptkit-0.2.0-beta.3.tgz
+```
+
+**Verify the release**
+
+```bash
+# checksums
+sha256sum --check SHA256SUMS
+# smoke from tarball only
+mkdir /tmp/verify && cd /tmp/verify && npm init -y && npm install ../zeus-rpg-promptkit-0.2.0-beta.3.tgz && ./node_modules/.bin/zeus --help
+```
+
+**Provenance**
+
+This release uses the hardened workflow: one immutable source commit on `main`, one npm tarball,
+checksum file, CycloneDX SBOM, and build-provenance attestation for that same artifact. The
+historical beta.2 attestation exception is **not** reused. See
+[release-integrity policy](https://github.com/gzeuner/zeus-rpg-promptkit/blob/main/docs/maintainers/release-integrity.md).
+
+**Supported environments**
+
+- Node.js >= 20 (tested on 20 and current LTS)
+- Linux and Windows runners in CI
+
+**Known limitations**
+
+- Type checking covers the declared core contract subset, not the complete JavaScript repository.
+- Some legacy no-unused-vars exceptions remain outside hardened paths.
+- Selected remote IBM i / Db2 behavior requires environment-specific validation.
+- Experimental surfaces remain experimental as documented.
+
+**Upgrade note**
+Beta 2 (v0.2.0-beta.2) remains available as an immutable historical prerelease. Prefer Beta 3 for
+Project Intelligence and the commercial host loader. After installing Beta 3, commercial modules
+must pin this Community SHA before claiming compatibility.
+
+This is a **prerelease**. Contracts may evolve before 0.2.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Release prep notes for the next public cut after ZPI delivery. Version number is **not** bumped
-until owner decision (see [`docs/maintainers/next-release-checklist.md`](docs/maintainers/next-release-checklist.md)).
+### Added
+
+### Changed
+
+### Fixed
+
+### Security
+
+## [0.2.0-beta.3] - 2026-07-25
+
+Public Community beta after Zeus Project Intelligence (ZPI) delivery and the commercial host loader.
 
 ### Added
 
@@ -18,7 +27,9 @@ until owner decision (see [`docs/maintainers/next-release-checklist.md`](docs/ma
   with commercial capability present/absent behavior;
 - explicit commercial module host loader (`createHostZeus` / `registerCommercialModules`) for
   operator-configured package path or name — no auto-discovery and no paid handlers in Community;
-- ZPI hardening and benchmark evidence suites; public closure status documentation.
+- ZPI hardening and benchmark evidence suites; public closure status documentation
+  (`docs/knowledgebase/zpi-closure-status.md`);
+- maintainer next-release checklist after beta.2.
 
 ### Changed
 
@@ -28,7 +39,20 @@ until owner decision (see [`docs/maintainers/next-release-checklist.md`](docs/ma
 ### Security
 
 - commercial loader fails closed on missing path/entry; absolute paths redacted in loader results;
-- Project Intelligence non-claims and trusted-root policy remain fail-closed.
+- Project Intelligence non-claims and trusted-root policy remain fail-closed;
+- future releases continue to require single-artifact build, checksum, SBOM, and build-provenance
+  attestation (beta.2 historical attestation exception is **not** reused);
+- production dependency tree pins `brace-expansion@5.0.8` (GHSA-mh99-v99m-4gvg; DoS via unbounded
+  expansion).
+
+### Known Limitations (Beta)
+
+- type checking currently covers the declared core contract subset, not the complete JavaScript
+  repository;
+- some legacy `no-unused-vars` exceptions remain outside the hardened paths;
+- selected remote IBM i and Db2 behavior still requires environment-specific validation;
+- experimental surfaces remain experimental as documented;
+- Project Knowledge is not source of truth and does not compile, deploy, or execute live IBM i.
 
 ## [0.2.0-beta.2] - 2026-07-12
 

--- a/README.md
+++ b/README.md
@@ -179,15 +179,14 @@ npm run demo:run
 Scripts und Release-Prozess: `package.json`, `CONTRIBUTING.md`, `CHANGELOG.md` und
 `.github/workflows/release.yml`.
 
-**Beta-Status (0.2.0-beta.2):** Vorabversion. Kernverträge stabilisieren sich, einzelne Oberflächen
-bleiben experimentell. Details in den GitHub-Release-Notes und im CHANGELOG. Vor produktiver Nutzung
-von Artefakten lokal `npm run docs:check` und `npm run package:smoke` ausführen sowie den Golden-Path
-beachten.
+**Beta-Status (0.2.0-beta.3):** Vorabversion nach Project-Intelligence-Lieferung und Commercial Host
+Loader. Kernverträge stabilisieren sich, einzelne Oberflächen bleiben experimentell. Details in den
+GitHub-Release-Notes und im CHANGELOG. Vor produktiver Nutzung von Artefakten lokal
+`npm run docs:check` und `npm run package:smoke` ausführen sowie den Golden-Path beachten.
 
-Bei Beta.2 sind Checksumme, SBOM und saubere Installation verifiziert, aber es gibt keine gültige
-öffentliche Artifact-Attestation, weil unveränderlicher Tag und veröffentlichte Artefaktquelle
-voneinander abweichen. Die dokumentierte historische Ausnahme und die strengere Policy für künftige
-Releases stehen in
+Beta.3 nutzt den gehärteten Single-Artifact-Release-Workflow (Checksumme, SBOM und
+Build-Provenance-Attestation). Die historische Attestations-Ausnahme von Beta.2 gilt **nicht** für
+dieses Release. Policy:
 [`docs/maintainers/release-integrity.md`](docs/maintainers/release-integrity.md).
 
 ### Golden Corpus und Qualitätsmetriken

--- a/docs/maintainers/next-release-checklist.md
+++ b/docs/maintainers/next-release-checklist.md
@@ -1,13 +1,12 @@
 ---
 Title: Next Release Checklist
-Description: Maintainer checklist for the next public Community release after 0.2.0-beta.2 and ZPI delivery.
-Last Updated: 2026-07-24
+Description: Maintainer checklist for Community releases after 0.2.0-beta.3.
+Last Updated: 2026-07-25
 ---
 
 # Next release checklist (Community)
 
-Current package version on `main`: **0.2.0-beta.2** (historical attestation exception documented in
-[`release-integrity.md`](./release-integrity.md)).
+Current package version on `main` after this cut lands: **0.2.0-beta.3**.
 
 This checklist prepares a **future** release. It does **not** create tags, publish npm packages, or
 bypass owner approval.
@@ -16,7 +15,7 @@ bypass owner approval.
 
 | Candidate      | When                                                        |
 | -------------- | ----------------------------------------------------------- |
-| `0.2.0-beta.3` | Incremental public beta after ZPI + commercial host loader  |
+| `0.2.0-beta.4` | Incremental public beta if more surface lands before freeze |
 | `0.2.0`        | Only after owner decision that beta surface is freeze-ready |
 
 ## Preflight (local)
@@ -42,26 +41,26 @@ When the version is bumped and CHANGELOG / release notes exist:
 npm run release:preflight -- --version <target-version>
 ```
 
-## Content checklist
+## Content checklist (0.2.0-beta.3)
 
-- [ ] `package.json` / `package-lock.json` version match target
-- [ ] `CHANGELOG.md` has exactly one `## [<version>] - YYYY-MM-DD` section for the target
-- [ ] `.github/RELEASE_NOTES_v<version>.md` exists
-- [ ] Tool catalog regenerated if CLI surface changed (`zeus docs:generate-catalog`)
-- [ ] Public claims guard still green
-- [ ] No accidental commercial/paid code in Community tree
-- [ ] Release workflow builds **one** artifact and attests that artifact (no historical exception)
+- [x] `package.json` / `package-lock.json` version match target
+- [x] `CHANGELOG.md` has exactly one `## [0.2.0-beta.3] - YYYY-MM-DD` section
+- [x] `.github/RELEASE_NOTES_v0.2.0-beta.3.md` exists
+- [x] Tool catalog regenerated for package version (`zeus docs:generate-catalog`)
+- [x] Public claims guard still green (run before merge)
+- [x] No accidental commercial/paid code in Community tree
+- [x] Release workflow builds **one** artifact and attests that artifact (no historical exception)
 
-## Notable delivered since beta.2 (document in next CHANGELOG)
+## Owner gates (not automated)
+
+- [ ] Tag + publish authorization for `v0.2.0-beta.3` via `workflow_dispatch` on `main`
+- [ ] Commercial pin bump to the released Community SHA after the release commit is on `main`
+- [ ] Confirm beta.2 historical attestation exception is **not** reused
+
+## Notable delivered in 0.2.0-beta.3
 
 - Project Intelligence Community baseline (ZPI-02…08 engines)
 - Thin CLI/MCP adapters + capability present/absent behavior (ZPI-11)
 - Hardening/benchmarks/closure status (ZPI-12)
 - Explicit commercial module host loader (`registerCommercialModules` / `createHostZeus`)
-- Docs alignment (DE/EN README, architecture index)
-
-## Owner gates (not automated)
-
-- [ ] Version number decision (beta.3 vs 0.2.0)
-- [ ] Tag + publish authorization
-- [ ] Commercial pin bump to the released Community SHA after merge
+- Docs alignment (DE/EN README, architecture index, ZPI closure status)

--- a/docs/tool-catalog.json
+++ b/docs/tool-catalog.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "package": {
     "name": "zeus-rpg-promptkit",
-    "version": "0.2.0-beta.2"
+    "version": "0.2.0-beta.3"
   },
-  "generatedAt": "2026-07-12T00:00:00.000Z",
+  "generatedAt": "2026-07-25T00:00:00.000Z",
   "cliFile": "cli/zeus.js",
   "commandRows": [
     {

--- a/docs/tool-catalog.md
+++ b/docs/tool-catalog.md
@@ -1,18 +1,18 @@
 <!-- 
 AUTO-GENERATED FILE – do not edit manually!
 Regenerate with: zeus docs:generate-catalog
-Last generated: 2026-07-12T00:00:00.000Z
+Last generated: 2026-07-25T00:00:00.000Z
 -->
 
 ---
 Title: Zeus RPG PromptKit Tool Catalog
 Description: Verbindlicher, sicherheitsklassifizierter Katalog aller CLI-Befehle und Workflow-Presets fuer Menschen und KI-Assistenten.
-Last Updated: 2026-07-12
+Last Updated: 2026-07-25
 ---
 
 # Zeus RPG PromptKit Tool Catalog
 
-Package: `zeus-rpg-promptkit@0.2.0-beta.2`
+Package: `zeus-rpg-promptkit@0.2.0-beta.3`
 
 This document is the authoritative tool reference for Zeus RPG PromptKit.
 All AI assistants (GPT, Claude, Grok, Copilot, local agents) should treat this file as the single source of truth for command purpose, risk level, and usage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeus-rpg-promptkit",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeus-rpg-promptkit",
-      "version": "0.2.0-beta.2",
+      "version": "0.2.0-beta.3",
       "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.6.0",
@@ -807,9 +807,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeus-rpg-promptkit",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-beta.3",
   "description": "Evidence and Investigation Platform for IBM i — turn source, metadata and runtime evidence into reproducible, review-ready artifacts with humans in control.",
   "main": "cli/zeus.js",
   "exports": {

--- a/tests/tool-catalog-generator.test.js
+++ b/tests/tool-catalog-generator.test.js
@@ -42,8 +42,8 @@ test('catalog model is deterministic and preserves the public command contracts'
   const first = buildCatalogModel({ repoRoot: projectRoot, env: {} });
   const second = buildCatalogModel({ repoRoot: projectRoot, env: {} });
   assert.deepEqual(first, second);
-  assert.equal(first.generatedAt, '2026-07-12T00:00:00.000Z');
-  assert.deepEqual(first.package, { name: 'zeus-rpg-promptkit', version: '0.2.0-beta.2' });
+  assert.equal(first.generatedAt, '2026-07-25T00:00:00.000Z');
+  assert.deepEqual(first.package, { name: 'zeus-rpg-promptkit', version: '0.2.0-beta.3' });
 
   const investigate = first.commandRows.find(entry => entry.command === 'investigate');
   assert.deepEqual(investigate.aliases, ['investigation']);
@@ -114,7 +114,7 @@ test('release-date fallback rejects calendar dates that JavaScript would normali
   try {
     fs.writeFileSync(
       path.join(root, 'CHANGELOG.md'),
-      '# Changelog\n\n## [0.2.0-beta.2] - 2026-02-30\n',
+      '# Changelog\n\n## [0.2.0-beta.3] - 2026-02-30\n',
       'utf8'
     );
     assert.throws(() => resolveGeneratedAt(root, {}), /invalid release date/);
@@ -199,7 +199,7 @@ test('generation works in an exported tree without Git metadata', () => {
   try {
     assert.equal(fs.existsSync(path.join(root, '.git')), false);
     const model = buildCatalogModel({ repoRoot: root, env: {} });
-    assert.equal(model.generatedAt, '2026-07-12T00:00:00.000Z');
+    assert.equal(model.generatedAt, '2026-07-25T00:00:00.000Z');
     assert.equal(model.commandRows.length, COMMAND_ORDER.length);
     const attributes = new Set(
       fs.readFileSync(path.join(root, '.gitattributes'), 'utf8').split(/\r?\n/).filter(Boolean)


### PR DESCRIPTION
## Summary
- Bumps Community package version from `0.2.0-beta.2` to `0.2.0-beta.3`.
- Moves ZPI + commercial host loader notes from `[Unreleased]` into a dated CHANGELOG section.
- Adds `.github/RELEASE_NOTES_v0.2.0-beta.3.md` for the hardened single-artifact release workflow.
- Regenerates the tool catalog and updates catalog-generator test expectations for the new version/date.
- Pins production `brace-expansion@5.0.8` (GHSA-mh99-v99m-4gvg).
- Updates maintainer next-release checklist and README beta status.

## Non-goals (this PR)
- Does **not** create the `v0.2.0-beta.3` tag.
- Does **not** run `workflow_dispatch` publish.
- Does **not** pin Commercial (that follows after this lands on `main` and owner authorizes the release).

## Local gates
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run check:public-knowledge-claims`
- `npm run docs:check`
- `npm run check:repo-portability`
- `npm test`
- `npm run test:benchmark`
- `npm run test:release-integrity`
- `npm run package:smoke`
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities after pin)

## Owner follow-up after merge
1. Confirm CI green on `main`.
2. Authorize `workflow_dispatch` Release with version `0.2.0-beta.3`.
3. Re-pin Commercial to the released Community SHA and re-run commercial gates.