### PR TITLE
fix(release): attestation verify signer flags mutual exclusivity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,9 +344,10 @@ jobs:
             RESULT_FILE=$(mktemp)
             ERROR_FILE=$(mktemp)
             set +e
+            # signer-repo and signer-workflow are mutually exclusive in current gh CLI.
+            # Prefer signer-workflow: it binds both repository and workflow path.
             gh attestation verify "$TARBALL" \
               --repo "$GITHUB_REPOSITORY" \
-              --signer-repo "$GITHUB_REPOSITORY" \
               --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release.yml" \
               --source-digest "$SOURCE_SHA" \
               --format json >"$RESULT_FILE" 2>"$ERROR_FILE"

--- a/tests/release-integrity.test.js
+++ b/tests/release-integrity.test.js
@@ -128,7 +128,8 @@ test('attestation subject is the exact captured tarball', () => {
 test('canonical verification binds the expected repository', () => {
   assert.match(job('attest'), /gh attestation verify "\$TARBALL"/);
   assert.match(job('attest'), /--repo "\$GITHUB_REPOSITORY"/);
-  assert.match(job('attest'), /--signer-repo "\$GITHUB_REPOSITORY"/);
+  // signer-repo and signer-workflow are mutually exclusive in current gh CLI.
+  assert.doesNotMatch(job('attest'), /--signer-repo /);
 });
 
 test('canonical verification binds the expected signer workflow', () => {


### PR DESCRIPTION
## Summary
Release run for `0.2.0-beta.3` failed at attestation verification because current `gh attestation verify` rejects combining `--signer-repo` and `--signer-workflow`.

## Fix
- Keep `--repo` and `--signer-workflow` only (workflow path already binds the repo).
- Update `tests/release-integrity.test.js` accordingly.

## Context
- Build + multi-platform verify of beta.3 already succeeded.
- Tag/publish were correctly skipped after attestation failure.
- After merge, re-dispatch Release with `0.2.0-beta.3`.