### PR TITLE
feat(pi): Track C portable export, corpora, embeddings default off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`module`, `modules`, `licenseDocumentPath`, `publicKeyPath`) with precedence
   CLI → env → profile; no marketplace or auto-discovery (`createHostZeus` /
   `registerCommercialModules`, `zeus profiles` display, config UI metadata).
+- Project Intelligence depth (Track C): portable snapshot export package
+  (`exportPortableSnapshotPackage` / `openPortableSnapshotPackage`), offline
+  multi-program corpora fixtures (`listCorpora` / `materializeCorpus`), and
+  explicit embeddings policy default **off** (storage opt-in only; Community
+  ranking remains lexical-only per ADR-010).
 
 ### Changed
 

--- a/docs/knowledgebase/zpi-closure-status.md
+++ b/docs/knowledgebase/zpi-closure-status.md
@@ -114,10 +114,17 @@ npm run package:smoke
 
 ## Remaining optional work (out of ZPI-12)
 
-- larger multi-repo corpora and CI-hosted perf dashboards
-- optional vector embeddings (disabled by default per ADR)
-- portable snapshot export packaging beyond current contracts
+- larger multi-repo corpora and CI-hosted perf dashboards (beyond Track C mini corpus)
+- optional vector **ranking** engines (storage opt-in exists; Community ranking stays lexical)
 - host-app auto-registration of commercial modules into CLI process (explicit load remains host-owned)
+
+### Track C (optional depth) — shipped on Community main after beta.3
+
+| Item                               | Location                                                                                           |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Portable snapshot export packaging | `src/projectIntelligence/export/` — `exportPortableSnapshotPackage`, `openPortableSnapshotPackage` |
+| Offline corpora fixtures           | `src/projectIntelligence/corpora/` — `mini-multi-program-rpg`                                      |
+| Embeddings default off             | `src/projectIntelligence/search/embeddingPolicy.js` — ranking never uses vectors in Community v1   |
 
 ## Final state statement
 

--- a/scripts/test-inventory.config.js
+++ b/scripts/test-inventory.config.js
@@ -29,6 +29,7 @@ module.exports = {
       'tests/project-intelligence-retrieval.test.js',
       'tests/project-intelligence-adapters.test.js',
       'tests/project-intelligence-hardening.test.js',
+      'tests/project-intelligence-export-corpora.test.js',
     ],
     smoke: [
       'tests/reproducible-output.test.js',

--- a/src/projectIntelligence/corpora/index.js
+++ b/src/projectIntelligence/corpora/index.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Project Intelligence offline corpora registry (Track C).
+ * Fixtures for tests/benchmarks — not customer source.
+ */
+
+const mini = require('./miniMultiProgramCorpus');
+
+const CORPORA = Object.freeze({
+  [mini.CORPUS_ID]: Object.freeze({
+    id: mini.CORPUS_ID,
+    version: mini.CORPUS_VERSION,
+    title: 'Mini multi-program RPG corpus',
+    description:
+      'Synthetic multi-program RPG/SQL corpus for indexing, retrieval, and portable export tests.',
+    materialize: mini.materializeCorpus,
+    listFiles: mini.listFiles,
+  }),
+});
+
+function listCorpora() {
+  return Object.values(CORPORA).map(c => ({
+    id: c.id,
+    version: c.version,
+    title: c.title,
+    description: c.description,
+    fileCount: c.listFiles().length,
+  }));
+}
+
+function getCorpus(corpusId) {
+  const id = String(corpusId || '').trim();
+  return CORPORA[id] || null;
+}
+
+function materializeCorpus(corpusId, targetDir, deps) {
+  const corpus = getCorpus(corpusId);
+  if (!corpus) {
+    const err = new Error(`Unknown project-intelligence corpus: ${corpusId}`);
+    err.code = 'UNKNOWN_PI_CORPUS';
+    throw err;
+  }
+  return corpus.materialize(targetDir, deps);
+}
+
+module.exports = {
+  CORPORA,
+  listCorpora,
+  getCorpus,
+  materializeCorpus,
+  miniMultiProgramCorpus: mini,
+};

--- a/src/projectIntelligence/corpora/miniMultiProgramCorpus.js
+++ b/src/projectIntelligence/corpora/miniMultiProgramCorpus.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * Multi-program RPG corpus fixture for PI depth tests and benchmarks (Track C).
+ * Synthetic offline corpus — no live IBM i, no customer source.
+ */
+
+const CORPUS_ID = 'mini-multi-program-rpg';
+const CORPUS_VERSION = '1.0.0';
+
+/**
+ * @typedef {{ relativePath: string, body: string }} CorpusFile
+ */
+
+/** @type {readonly CorpusFile[]} */
+const FILES = Object.freeze([
+  Object.freeze({
+    relativePath: 'QRPGLESRC/ORDERPGM.rpgle',
+    body: [
+      '**free',
+      '// ORDERPGM — root order entry',
+      'dcl-s orderId packed(7:0);',
+      'dcl-s customerId packed(7:0);',
+      'orderId = 1001;',
+      'customerId = 42;',
+      'callp ValidateOrder(orderId);',
+      'callp WriteOrder(orderId:customerId);',
+      '',
+    ].join('\n'),
+  }),
+  Object.freeze({
+    relativePath: 'QRPGLESRC/VALIDATE.rpgle',
+    body: [
+      '**free',
+      '// VALIDATE — order validation helper',
+      'dcl-proc ValidateOrder;',
+      '  dcl-pi *n;',
+      '    orderId packed(7:0) const;',
+      '  end-pi;',
+      '  if orderId <= 0;',
+      '    // invalid',
+      '  endif;',
+      'end-proc;',
+      '',
+    ].join('\n'),
+  }),
+  Object.freeze({
+    relativePath: 'QRPGLESRC/WRITEORD.rpgle',
+    body: [
+      '**free',
+      '// WRITEORD — persist order header',
+      'dcl-proc WriteOrder;',
+      '  dcl-pi *n;',
+      '    orderId packed(7:0) const;',
+      '    customerId packed(7:0) const;',
+      '  end-pi;',
+      '  // insert into ORDERHDR',
+      'end-proc;',
+      '',
+    ].join('\n'),
+  }),
+  Object.freeze({
+    relativePath: 'QRPGLESRC/CUSTINQ.rpgle',
+    body: [
+      '**free',
+      '// CUSTINQ — customer inquiry',
+      'dcl-s customerId packed(7:0);',
+      'customerId = 42;',
+      'callp LoadCustomer(customerId);',
+      '',
+    ].join('\n'),
+  }),
+  Object.freeze({
+    relativePath: 'QRPGLESRC/LOADCUST.rpgle',
+    body: [
+      '**free',
+      '// LOADCUST — load customer master',
+      'dcl-proc LoadCustomer;',
+      '  dcl-pi *n;',
+      '    customerId packed(7:0) const;',
+      '  end-pi;',
+      '  // select from CUSTMAST',
+      'end-proc;',
+      '',
+    ].join('\n'),
+  }),
+  Object.freeze({
+    relativePath: 'QSQLSRC/ORDERHDR.sql',
+    body: [
+      'CREATE TABLE ORDERHDR (',
+      '  ORDER_ID INTEGER NOT NULL,',
+      '  CUSTOMER_ID INTEGER NOT NULL,',
+      '  STATUS CHAR(1)',
+      ');',
+      '',
+    ].join('\n'),
+  }),
+]);
+
+function listFiles() {
+  return FILES.map(f => ({
+    relativePath: f.relativePath,
+    bytes: Buffer.byteLength(f.body, 'utf8'),
+  }));
+}
+
+/**
+ * Materialize corpus files under targetDir (creates directories).
+ * @param {string} targetDir absolute or relative path
+ * @param {{ fs?: typeof import('fs'), path?: typeof import('path') }} [deps]
+ * @returns {{ corpusId: string, version: string, root: string, files: string[] }}
+ */
+function materializeCorpus(targetDir, deps = {}) {
+  const fs = deps.fs || require('fs');
+  const path = deps.path || require('path');
+  if (typeof targetDir !== 'string' || !targetDir.trim()) {
+    throw new Error('targetDir is required');
+  }
+  const root = path.resolve(targetDir);
+  const written = [];
+  for (const file of FILES) {
+    const abs = path.join(root, file.relativePath);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, file.body, 'utf8');
+    written.push(file.relativePath);
+  }
+  return {
+    corpusId: CORPUS_ID,
+    version: CORPUS_VERSION,
+    root,
+    files: written,
+    fileCount: written.length,
+  };
+}
+
+module.exports = {
+  CORPUS_ID,
+  CORPUS_VERSION,
+  FILES,
+  listFiles,
+  materializeCorpus,
+};

--- a/src/projectIntelligence/export/index.js
+++ b/src/projectIntelligence/export/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const portable = require('./portableSnapshotPackage');
+
+module.exports = {
+  PORTABLE_PACKAGE_SCHEMA: portable.PORTABLE_PACKAGE_SCHEMA,
+  PORTABLE_PACKAGE_KIND: portable.PORTABLE_PACKAGE_KIND,
+  exportPortableSnapshotPackage: portable.exportPortableSnapshotPackage,
+  openPortableSnapshotPackage: portable.openPortableSnapshotPackage,
+  stripAbsolutePathsDeep: portable.stripAbsolutePathsDeep,
+};

--- a/src/projectIntelligence/export/portableSnapshotPackage.js
+++ b/src/projectIntelligence/export/portableSnapshotPackage.js
@@ -1,0 +1,343 @@
+'use strict';
+
+/**
+ * Portable snapshot export packaging (Track C / ADR-011 export-disclosure).
+ *
+ * Builds a redacted, offline package of a published snapshot for transfer or
+ * archival. Host absolute paths are never written. Package 09 / live IBM i are
+ * out of scope.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { openSnapshotEngine } = require('../engine/snapshotEngine');
+const { fail, REASON_CODES } = require('../store/errors');
+const { SNAPSHOT_STATUSES } = require('../constants');
+const { resolveEmbeddingPolicy, shouldRetainVectorField } = require('../search/embeddingPolicy');
+
+const PORTABLE_PACKAGE_SCHEMA = 'zeus.project-knowledge-portable-snapshot@1';
+const PORTABLE_PACKAGE_KIND = 'project-knowledge-portable-snapshot';
+
+function sha256OfFile(filePath) {
+  const hash = crypto.createHash('sha256');
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest('hex');
+}
+
+function sha256OfString(text) {
+  return crypto.createHash('sha256').update(String(text), 'utf8').digest('hex');
+}
+
+function redactString(value) {
+  return String(value || '')
+    .replace(/[A-Za-z]:\\[^\s"']+/g, '<redacted-path>')
+    .replace(/\/(?:Users|home)\/[^\s"']+/g, '<redacted-path>');
+}
+
+function stripAbsolutePathsDeep(value, depth = 0) {
+  if (depth > 14) return null;
+  if (value == null) return value;
+  if (typeof value === 'string') return redactString(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (Array.isArray(value)) return value.map(v => stripAbsolutePathsDeep(v, depth + 1));
+  if (typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (
+        k === 'path' ||
+        k === 'absolutePath' ||
+        k === 'realPath' ||
+        k === 'dbPath' ||
+        k === 'knowledgeRoot'
+      ) {
+        out[k] = typeof v === 'string' ? '<redacted-path>' : null;
+        continue;
+      }
+      if (String(k).startsWith('_')) continue;
+      out[k] = stripAbsolutePathsDeep(v, depth + 1);
+    }
+    return out;
+  }
+  return null;
+}
+
+function writeJsonAtomic(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const body = `${JSON.stringify(value, null, 2)}\n`;
+  const tmp = `${filePath}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, body, 'utf8');
+  fs.renameSync(tmp, filePath);
+  return sha256OfString(body);
+}
+
+function assertNoHostPathLeak(serialized) {
+  if (/[A-Za-z]:\\/.test(serialized) || /\/(?:Users|home)\//.test(serialized)) {
+    fail(REASON_CODES.EXPORT_DENIED, 'portable export refused: host path leakage detected');
+  }
+}
+
+/**
+ * Export a published snapshot to a portable directory package.
+ *
+ * @param {object} options
+ * @param {string} options.knowledgeRoot absolute knowledge root
+ * @param {string} options.projectId
+ * @param {string} options.outputDir absolute destination directory (created)
+ * @param {string} [options.snapshotId] defaults to current published snapshot
+ * @param {object[]} [options.trustedRoots] required when opening engine needs them
+ * @param {boolean} [options.includeSearchDocs=true]
+ * @param {boolean} [options.includeVectors=false] vectors only when embeddings policy allows
+ * @returns {object} export result (no absolute paths)
+ */
+function exportPortableSnapshotPackage(options = {}) {
+  const knowledgeRoot = options.knowledgeRoot;
+  const projectId = options.projectId;
+  const outputDir = options.outputDir;
+  if (typeof knowledgeRoot !== 'string' || !path.isAbsolute(knowledgeRoot)) {
+    fail(REASON_CODES.PATH_UNSAFE, 'knowledgeRoot must be an absolute path');
+  }
+  if (typeof projectId !== 'string' || !projectId.trim()) {
+    fail(REASON_CODES.PROJECT_ID_INVALID, 'projectId is required');
+  }
+  if (typeof outputDir !== 'string' || !path.isAbsolute(outputDir)) {
+    fail(REASON_CODES.PATH_UNSAFE, 'outputDir must be an absolute path');
+  }
+
+  const embeddingPolicy = resolveEmbeddingPolicy(options);
+  const includeSearchDocs = options.includeSearchDocs !== false;
+  const includeVectors =
+    options.includeVectors === true && shouldRetainVectorField(embeddingPolicy);
+
+  let engine;
+  try {
+    engine = openSnapshotEngine({
+      knowledgeRoot,
+      projectId: projectId.trim(),
+      trustedRoots: options.trustedRoots || [],
+      readOnly: true,
+    });
+
+    const current = engine.getCurrentSnapshot();
+    if (!current) {
+      fail(REASON_CODES.SNAPSHOT_NOT_FOUND, 'no current published snapshot');
+    }
+    const snapshotId = options.snapshotId ? String(options.snapshotId).trim() : current.snapshotId;
+    if (current.snapshotId !== snapshotId) {
+      // Allow exporting non-current only if store can still list it
+      const listed = engine._store.getSnapshot(projectId.trim(), snapshotId);
+      if (!listed) {
+        fail(REASON_CODES.SNAPSHOT_NOT_FOUND, 'snapshot not found');
+      }
+      if (listed.status !== SNAPSHOT_STATUSES.PUBLISHED && listed.status !== 'published') {
+        fail(REASON_CODES.SNAPSHOT_NOT_PUBLISHED, 'only published snapshots may be exported');
+      }
+    }
+
+    const equalityView = engine.projectEqualityView(snapshotId);
+    const project = engine._store.getProject
+      ? engine._store.getProject(projectId.trim())
+      : { projectId: projectId.trim() };
+    const snapshot =
+      (engine._store.getSnapshot && engine._store.getSnapshot(projectId.trim(), snapshotId)) ||
+      current;
+
+    fs.mkdirSync(outputDir, { recursive: true });
+    const files = {};
+
+    files['project.json'] = writeJsonAtomic(
+      path.join(outputDir, 'project.json'),
+      stripAbsolutePathsDeep({
+        projectId: projectId.trim(),
+        displayName: project && project.displayName,
+        schemaVersion: project && project.schemaVersion,
+      })
+    );
+    files['snapshot.json'] = writeJsonAtomic(
+      path.join(outputDir, 'snapshot.json'),
+      stripAbsolutePathsDeep({
+        projectId: projectId.trim(),
+        snapshotId,
+        status: snapshot.status || SNAPSHOT_STATUSES.PUBLISHED,
+        sourceInventoryHash: snapshot.sourceInventoryHash,
+        publishedAt: snapshot.publishedAt,
+        createdAt: snapshot.createdAt,
+      })
+    );
+    files['equality-view.json'] = writeJsonAtomic(
+      path.join(outputDir, 'equality-view.json'),
+      stripAbsolutePathsDeep(equalityView)
+    );
+
+    let searchDocCount = 0;
+    if (includeSearchDocs) {
+      const luceneDocsPath = path.join(knowledgeRoot, 'lucene', 'docs.json');
+      if (fs.existsSync(luceneDocsPath)) {
+        let docs;
+        try {
+          docs = JSON.parse(fs.readFileSync(luceneDocsPath, 'utf8'));
+        } catch {
+          fail(REASON_CODES.INDEX_CORRUPT, 'search docs unreadable for export');
+        }
+        if (!Array.isArray(docs)) {
+          fail(REASON_CODES.INDEX_CORRUPT, 'search docs must be an array');
+        }
+        const portableDocs = docs
+          .filter(d => d && d.projectId === projectId.trim() && d.snapshotId === snapshotId)
+          .map(d => {
+            const copy = stripAbsolutePathsDeep({ ...d });
+            if (!includeVectors) delete copy.vector;
+            delete copy.termFreqs;
+            delete copy.titleTokens;
+            return copy;
+          });
+        searchDocCount = portableDocs.length;
+        fs.mkdirSync(path.join(outputDir, 'search'), { recursive: true });
+        files['search/docs.json'] = writeJsonAtomic(
+          path.join(outputDir, 'search', 'docs.json'),
+          portableDocs
+        );
+      }
+    }
+
+    const nonClaims = Object.freeze([
+      'Not source of truth — preserved source evidence remains authoritative',
+      'Portable package is advisory and offline-only',
+      'Absolute host paths are redacted',
+      'Embeddings default off; vectors included only when explicitly opted in',
+      'Package 09 / live IBM i not included',
+    ]);
+
+    const manifest = {
+      kind: PORTABLE_PACKAGE_KIND,
+      schema: PORTABLE_PACKAGE_SCHEMA,
+      projectId: projectId.trim(),
+      snapshotId,
+      createdAt: new Date().toISOString(),
+      sourceOfTruth: false,
+      advisory: true,
+      offlineOnly: true,
+      embeddings: {
+        included: includeVectors,
+        policyReasonCode: embeddingPolicy.reasonCode,
+        useForRanking: false,
+      },
+      counts: {
+        sourceUnits: equalityView.units.length,
+        symbols: equalityView.symbols.length,
+        relationships: equalityView.relationships.length,
+        searchDocs: searchDocCount,
+      },
+      files,
+      nonClaims: [...nonClaims],
+    };
+
+    const manifestBody = `${JSON.stringify(manifest, null, 2)}\n`;
+    assertNoHostPathLeak(manifestBody);
+    for (const rel of Object.keys(files)) {
+      const part = fs.readFileSync(path.join(outputDir, rel), 'utf8');
+      assertNoHostPathLeak(part);
+    }
+    writeJsonAtomic(path.join(outputDir, 'portable-manifest.json'), manifest);
+
+    return stripAbsolutePathsDeep({
+      ok: true,
+      kind: PORTABLE_PACKAGE_KIND,
+      schema: PORTABLE_PACKAGE_SCHEMA,
+      projectId: projectId.trim(),
+      snapshotId,
+      counts: manifest.counts,
+      embeddings: manifest.embeddings,
+      files: Object.keys(files).concat(['portable-manifest.json']).sort(),
+      nonClaims: [...nonClaims],
+    });
+  } finally {
+    if (engine) {
+      try {
+        engine.close();
+      } catch {
+        // ignore
+      }
+    }
+  }
+}
+
+/**
+ * Open and validate a portable snapshot package (read-only inspect).
+ *
+ * @param {object} options
+ * @param {string} options.packageDir absolute path to package directory
+ * @returns {object}
+ */
+function openPortableSnapshotPackage(options = {}) {
+  const packageDir = options.packageDir;
+  if (typeof packageDir !== 'string' || !path.isAbsolute(packageDir)) {
+    fail(REASON_CODES.PATH_UNSAFE, 'packageDir must be an absolute path');
+  }
+  const manifestPath = path.join(packageDir, 'portable-manifest.json');
+  if (!fs.existsSync(manifestPath)) {
+    fail(REASON_CODES.EXPORT_DENIED, 'portable-manifest.json missing');
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  } catch {
+    fail(REASON_CODES.EXPORT_DENIED, 'portable-manifest.json unreadable');
+  }
+  if (!manifest || manifest.schema !== PORTABLE_PACKAGE_SCHEMA) {
+    fail(REASON_CODES.SCHEMA_VERSION_UNSUPPORTED, 'unsupported portable package schema');
+  }
+  if (manifest.sourceOfTruth === true) {
+    fail(REASON_CODES.CANONICALITY_VIOLATION, 'portable packages must not claim sourceOfTruth');
+  }
+
+  const files = manifest.files || {};
+  for (const [rel, expectedHash] of Object.entries(files)) {
+    const abs = path.join(packageDir, rel);
+    if (!fs.existsSync(abs)) {
+      fail(REASON_CODES.EXPORT_DENIED, `package part missing: ${rel}`);
+    }
+    const actual = sha256OfFile(abs);
+    // expectedHash from writeJsonAtomic is hash of body including trailing newline
+    if (expectedHash && actual !== expectedHash) {
+      // recompute from string write path — accept either file hash match
+      const body = fs.readFileSync(abs, 'utf8');
+      if (sha256OfString(body) !== expectedHash && actual !== expectedHash) {
+        fail(REASON_CODES.CONTENT_HASH_MISMATCH, `package part hash mismatch: ${rel}`);
+      }
+    }
+    assertNoHostPathLeak(fs.readFileSync(abs, 'utf8'));
+  }
+
+  const equalityView = JSON.parse(
+    fs.readFileSync(path.join(packageDir, 'equality-view.json'), 'utf8')
+  );
+  let searchDocs = null;
+  const searchPath = path.join(packageDir, 'search', 'docs.json');
+  if (fs.existsSync(searchPath)) {
+    searchDocs = JSON.parse(fs.readFileSync(searchPath, 'utf8'));
+  }
+
+  return stripAbsolutePathsDeep({
+    ok: true,
+    kind: PORTABLE_PACKAGE_KIND,
+    schema: PORTABLE_PACKAGE_SCHEMA,
+    projectId: manifest.projectId,
+    snapshotId: manifest.snapshotId,
+    counts: manifest.counts,
+    embeddings: manifest.embeddings,
+    equalityView,
+    searchDocCount: Array.isArray(searchDocs) ? searchDocs.length : 0,
+    nonClaims: manifest.nonClaims || [],
+    sourceOfTruth: false,
+    advisory: true,
+  });
+}
+
+module.exports = {
+  PORTABLE_PACKAGE_SCHEMA,
+  PORTABLE_PACKAGE_KIND,
+  exportPortableSnapshotPackage,
+  openPortableSnapshotPackage,
+  stripAbsolutePathsDeep,
+};

--- a/src/projectIntelligence/index.js
+++ b/src/projectIntelligence/index.js
@@ -10,6 +10,7 @@
  * ZPI-06: Snapshot + incremental update engine (diff, invalidation, atomic publish).
  * ZPI-07: RPG/IBM i analyzer baseline (parser adapters, spans, unresolved model).
  * ZPI-08: Retrieval + context assembly (hybrid lexical/graph, token budgets).
+ * Track C: portable snapshot export packaging, offline corpora, embeddings default off.
  *
  * Commercial module registration is external (ZPI-09/10). CLI/MCP thin adapters: ZPI-11.
  */
@@ -28,6 +29,8 @@ const engine = require('./engine');
 const analyzers = require('./analyzers');
 const retrieval = require('./retrieval');
 const adapters = require('./adapters');
+const portableExport = require('./export');
+const corpora = require('./corpora');
 
 module.exports = {
   // Vocabulary
@@ -114,4 +117,21 @@ module.exports = {
   listProjectKnowledgeMcpTools: adapters.listProjectKnowledgeMcpTools,
   COMMERCIAL_CAPABILITY_IDS: adapters.COMMERCIAL_CAPABILITY_IDS,
   PUBLIC_OPERATIONS: adapters.PUBLIC_OPERATIONS,
+
+  // Track C — portable export packaging
+  export: portableExport,
+  PORTABLE_PACKAGE_SCHEMA: portableExport.PORTABLE_PACKAGE_SCHEMA,
+  PORTABLE_PACKAGE_KIND: portableExport.PORTABLE_PACKAGE_KIND,
+  exportPortableSnapshotPackage: portableExport.exportPortableSnapshotPackage,
+  openPortableSnapshotPackage: portableExport.openPortableSnapshotPackage,
+
+  // Track C — offline corpora fixtures
+  corpora,
+  listCorpora: corpora.listCorpora,
+  getCorpus: corpora.getCorpus,
+  materializeCorpus: corpora.materializeCorpus,
+
+  // Track C — embeddings policy (default off)
+  EMBEDDINGS_DEFAULT_ENABLED: search.EMBEDDINGS_DEFAULT_ENABLED,
+  resolveEmbeddingPolicy: search.resolveEmbeddingPolicy,
 };

--- a/src/projectIntelligence/search/embeddingPolicy.js
+++ b/src/projectIntelligence/search/embeddingPolicy.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * Optional vector embeddings policy for Project Intelligence search (Track C / ADR-010).
+ *
+ * Community v1 ranking is lexical-only. Vector fields on search documents are
+ * schema-ready storage only. Embeddings stay disabled unless an operator
+ * explicitly opts in — and even then Community ranking does not consume vectors
+ * until a future approved embedding engine is wired.
+ */
+
+const EMBEDDINGS_DEFAULT_ENABLED = false;
+
+const EMBEDDING_POLICY_REASON = Object.freeze({
+  DISABLED_BY_DEFAULT: 'EMBEDDINGS_DISABLED_BY_DEFAULT',
+  EXPLICITLY_DISABLED: 'EMBEDDINGS_EXPLICITLY_DISABLED',
+  EXPLICITLY_ENABLED_STORAGE_ONLY: 'EMBEDDINGS_ENABLED_STORAGE_ONLY',
+  COMMUNITY_RANKING_LEXICAL_ONLY: 'COMMUNITY_RANKING_LEXICAL_ONLY',
+});
+
+/**
+ * Resolve embedding policy from operator options / env.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.enableEmbeddings]
+ * @param {boolean} [options.embeddings]
+ * @param {object} [options.env]
+ * @returns {{
+ *   enabled: boolean,
+ *   useForRanking: boolean,
+ *   reasonCode: string,
+ *   message: string
+ * }}
+ */
+function resolveEmbeddingPolicy(options = {}) {
+  const env = options.env || process.env;
+  const envRaw = env && (env.ZEUS_PI_ENABLE_EMBEDDINGS || env.ZEUS_PROJECT_INTELLIGENCE_EMBEDDINGS);
+  const envEnabled =
+    envRaw != null &&
+    !['0', 'false', 'no', 'off', ''].includes(String(envRaw).trim().toLowerCase());
+
+  let explicit = null;
+  if (options.enableEmbeddings != null) explicit = Boolean(options.enableEmbeddings);
+  else if (options.embeddings != null) explicit = Boolean(options.embeddings);
+
+  if (explicit === false) {
+    return {
+      enabled: false,
+      useForRanking: false,
+      reasonCode: EMBEDDING_POLICY_REASON.EXPLICITLY_DISABLED,
+      message: 'Embeddings explicitly disabled by operator options.',
+    };
+  }
+
+  if (explicit === true || envEnabled) {
+    return {
+      enabled: true,
+      // Community lexical ranking never consumes vectors in v1 (ADR-010).
+      useForRanking: false,
+      reasonCode: EMBEDDING_POLICY_REASON.EXPLICITLY_ENABLED_STORAGE_ONLY,
+      message:
+        'Embeddings enabled for optional vector storage only; Community ranking remains lexical-only.',
+    };
+  }
+
+  return {
+    enabled: EMBEDDINGS_DEFAULT_ENABLED,
+    useForRanking: false,
+    reasonCode: EMBEDDING_POLICY_REASON.DISABLED_BY_DEFAULT,
+    message:
+      'Embeddings disabled by default (ADR-010). Set enableEmbeddings:true or ZEUS_PI_ENABLE_EMBEDDINGS=1 for storage-only opt-in.',
+  };
+}
+
+/**
+ * Whether vector payloads may be retained on indexed documents.
+ * Ranking never uses them in Community v1.
+ */
+function shouldRetainVectorField(policy) {
+  return Boolean(policy && policy.enabled);
+}
+
+/**
+ * Community ranking must ignore vectors regardless of storage policy.
+ */
+function rankingUsesEmbeddings(policy) {
+  return Boolean(policy && policy.useForRanking === true);
+}
+
+module.exports = {
+  EMBEDDINGS_DEFAULT_ENABLED,
+  EMBEDDING_POLICY_REASON,
+  resolveEmbeddingPolicy,
+  shouldRetainVectorField,
+  rankingUsesEmbeddings,
+};

--- a/src/projectIntelligence/search/index.js
+++ b/src/projectIntelligence/search/index.js
@@ -13,6 +13,7 @@ const ranking = require('./ranking');
 const invertedIndex = require('./invertedIndex');
 const fileIndexStore = require('./fileIndexStore');
 const searchProvider = require('./searchProvider');
+const embeddingPolicy = require('./embeddingPolicy');
 
 module.exports = {
   ...constants,
@@ -26,4 +27,10 @@ module.exports = {
   resolveIndexDir: fileIndexStore.resolveIndexDir,
   createSearchProvider: searchProvider.createSearchProvider,
   openSearchProvider: searchProvider.openSearchProvider,
+  // Track C — embeddings default off
+  EMBEDDINGS_DEFAULT_ENABLED: embeddingPolicy.EMBEDDINGS_DEFAULT_ENABLED,
+  EMBEDDING_POLICY_REASON: embeddingPolicy.EMBEDDING_POLICY_REASON,
+  resolveEmbeddingPolicy: embeddingPolicy.resolveEmbeddingPolicy,
+  shouldRetainVectorField: embeddingPolicy.shouldRetainVectorField,
+  rankingUsesEmbeddings: embeddingPolicy.rankingUsesEmbeddings,
 };

--- a/src/projectIntelligence/search/invertedIndex.js
+++ b/src/projectIntelligence/search/invertedIndex.js
@@ -5,15 +5,19 @@ const { scoreDocument, compareHits } = require('./ranking');
 const { normalizeSearchDocument } = require('./documentSchema');
 const { DEFAULT_LIMIT, MAX_LIMIT } = require('./constants');
 const { fail, REASON_CODES } = require('../store/errors');
+const { resolveEmbeddingPolicy, shouldRetainVectorField } = require('./embeddingPolicy');
 
 /**
  * In-memory inverted index (serializable).
+ * @param {object} [options]
+ * @param {object} [options.embeddingPolicy] resolved embedding policy (default: disabled)
  */
-function createInvertedIndex() {
+function createInvertedIndex(options = {}) {
   /** @type {Map<string, object>} */
   const docs = new Map();
   /** @type {Map<string, Map<string, number>>} term -> docId -> tf */
   const postings = new Map();
+  const embeddingPolicy = options.embeddingPolicy || resolveEmbeddingPolicy(options);
 
   function clear() {
     docs.clear();
@@ -22,6 +26,11 @@ function createInvertedIndex() {
 
   function addDocument(rawDoc) {
     const doc = normalizeSearchDocument(rawDoc);
+    // Embeddings default off: strip vector payloads unless storage is explicitly enabled.
+    // Community ranking remains lexical-only even when vectors are retained (ADR-010).
+    if (!shouldRetainVectorField(embeddingPolicy)) {
+      delete doc.vector;
+    }
     // Replace existing
     if (docs.has(doc.docId)) {
       removeDocument(doc.docId);

--- a/src/projectIntelligence/search/searchProvider.js
+++ b/src/projectIntelligence/search/searchProvider.js
@@ -18,12 +18,14 @@ const {
   indexPaths,
 } = require('./fileIndexStore');
 const { fail, REASON_CODES, KnowledgeStoreError } = require('../store/errors');
+const { resolveEmbeddingPolicy } = require('./embeddingPolicy');
 
 /**
  * Create a Community lexical search provider (ZPI-05).
  *
  * Lucene-compatible SPI surface under the project `lucene/` layout.
  * Engine is pure-JS inverted index with deterministic ranking.
+ * Embeddings default off (Track C / ADR-010).
  */
 function createSearchProvider(options = {}) {
   const readOnly = Boolean(options.readOnly);
@@ -32,8 +34,9 @@ function createSearchProvider(options = {}) {
   let snapshotId = options.snapshotId || null;
   let generation = 1;
   let closed = false;
+  const embeddingPolicy = resolveEmbeddingPolicy(options);
 
-  const index = createInvertedIndex();
+  const index = createInvertedIndex({ embeddingPolicy, ...options });
 
   // Load existing if present
   if (exists(indexDir)) {
@@ -225,6 +228,11 @@ function createSearchProvider(options = {}) {
       engineVersion: ENGINE_VERSION,
       analyzer: analyzerIdentity(),
       searchSchemaVersion: SEARCH_SCHEMA_VERSION,
+      embeddingPolicy: {
+        enabled: embeddingPolicy.enabled,
+        useForRanking: embeddingPolicy.useForRanking,
+        reasonCode: embeddingPolicy.reasonCode,
+      },
       closed,
     };
   }
@@ -244,6 +252,7 @@ function createSearchProvider(options = {}) {
     recoverFromCorrupt,
     getStatus,
     close,
+    embeddingPolicy,
     // identity helpers
     ENGINE_ID,
     SEARCH_SCHEMA_VERSION,

--- a/tests/project-intelligence-export-corpora.test.js
+++ b/tests/project-intelligence-export-corpora.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createSnapshotEngine,
+  createSearchProvider,
+  exportPortableSnapshotPackage,
+  openPortableSnapshotPackage,
+  listCorpora,
+  materializeCorpus,
+  resolveEmbeddingPolicy,
+  EMBEDDINGS_DEFAULT_ENABLED,
+  PORTABLE_PACKAGE_SCHEMA,
+  probeNodeSqlite,
+} = require('../src/projectIntelligence');
+
+const HAS_SQLITE = probeNodeSqlite().available;
+
+function tempDir(label = 'zpi-c') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `${label}-`));
+}
+
+test('embeddings are disabled by default and ranking never uses them', () => {
+  assert.equal(EMBEDDINGS_DEFAULT_ENABLED, false);
+  const policy = resolveEmbeddingPolicy({});
+  assert.equal(policy.enabled, false);
+  assert.equal(policy.useForRanking, false);
+
+  const enabled = resolveEmbeddingPolicy({ enableEmbeddings: true });
+  assert.equal(enabled.enabled, true);
+  assert.equal(enabled.useForRanking, false);
+
+  const index = createSearchProvider({
+    indexDir: path.join(tempDir('emb'), 'lucene'),
+    projectId: 'p1',
+    snapshotId: 's1',
+  });
+  assert.equal(index.embeddingPolicy.enabled, false);
+  index.indexDocuments([
+    {
+      docId: 'd1',
+      projectId: 'p1',
+      snapshotId: 's1',
+      kind: 'source-unit',
+      title: 'ORDERPGM',
+      body: 'order validate write',
+      vector: { dims: 2, values: [0.1, 0.9], modelId: 'test' },
+    },
+  ]);
+  const hits = index.search({ query: 'order' });
+  assert.ok(hits.hits.length >= 1);
+  // stored document should not retain vector when embeddings default off
+  const serialized = index._index.serialize();
+  const doc = serialized.docs.find(d => d.docId === 'd1');
+  assert.ok(doc);
+  assert.equal(doc.vector == null || doc.vector === null, true);
+  index.close();
+});
+
+test('listCorpora and materialize mini multi-program corpus', () => {
+  const listed = listCorpora();
+  assert.ok(listed.some(c => c.id === 'mini-multi-program-rpg'));
+  const root = tempDir('corpus');
+  const result = materializeCorpus('mini-multi-program-rpg', root);
+  assert.equal(result.fileCount, 6);
+  assert.ok(fs.existsSync(path.join(result.root, 'QRPGLESRC', 'ORDERPGM.rpgle')));
+  assert.ok(fs.existsSync(path.join(result.root, 'QSQLSRC', 'ORDERHDR.sql')));
+});
+
+test('portable snapshot export package is redacted and openable', { skip: !HAS_SQLITE }, () => {
+  const root = tempDir('export');
+  const src = path.join(root, 'src');
+  const knowledgeRoot = path.join(root, 'pk');
+  const exportDir = path.join(root, 'portable');
+  materializeCorpus('mini-multi-program-rpg', src);
+
+  const engine = createSnapshotEngine({
+    knowledgeRoot,
+    projectId: 'export-demo',
+    displayName: 'Export demo',
+    trustedRoots: [{ rootId: 'src', path: src }],
+  });
+  const rebuild = engine.fullRebuild();
+  assert.equal(rebuild.published, true);
+  const snapshotId = rebuild.snapshot.snapshotId;
+  engine.close();
+
+  const exported = exportPortableSnapshotPackage({
+    knowledgeRoot,
+    projectId: 'export-demo',
+    outputDir: exportDir,
+    trustedRoots: [{ rootId: 'src', path: src }],
+  });
+  assert.equal(exported.ok, true);
+  assert.equal(exported.schema, PORTABLE_PACKAGE_SCHEMA);
+  assert.equal(exported.snapshotId, snapshotId);
+  assert.ok(exported.counts.sourceUnits >= 1);
+  assert.equal(exported.embeddings.included, false);
+  assert.equal(exported.embeddings.useForRanking, false);
+  const leak = JSON.stringify(exported);
+  assert.equal(/[A-Za-z]:\\/.test(leak), false);
+  assert.equal(/\/Users\//.test(leak), false);
+
+  const opened = openPortableSnapshotPackage({ packageDir: exportDir });
+  assert.equal(opened.ok, true);
+  assert.equal(opened.projectId, 'export-demo');
+  assert.equal(opened.snapshotId, snapshotId);
+  assert.ok(opened.equalityView.units.length >= 1);
+  assert.equal(opened.sourceOfTruth, false);
+  assert.equal(JSON.stringify(opened).includes(src), false);
+});
+
+test('portable export fails closed when knowledge root missing', { skip: !HAS_SQLITE }, () => {
+  assert.throws(
+    () =>
+      exportPortableSnapshotPackage({
+        knowledgeRoot: path.join(tempDir('missing'), 'nope'),
+        projectId: 'x',
+        outputDir: path.join(tempDir('out'), 'pkg'),
+      }),
+    err => Boolean(err && (err.reasonCode || err.message))
+  );
+});


### PR DESCRIPTION
## Summary
Track **C** Project Intelligence depth (post ZPI-12 optional work):

- **Portable snapshot export** — `exportPortableSnapshotPackage` / `openPortableSnapshotPackage` (redacted, offline, integrity-checked)
- **Corpora** — `listCorpora` / `materializeCorpus` with `mini-multi-program-rpg`
- **Embeddings default off** — `resolveEmbeddingPolicy`; vectors stripped unless explicitly enabled; ranking stays lexical-only (ADR-010)

## Test plan
- [x] `npm run format:check` / lint / typecheck
- [x] `npm run test:discovery`
- [x] `npm test` (full suite green)
- [x] new `tests/project-intelligence-export-corpora.test.js`