### PR TITLE
docs(architecture): Track E ADR-009..013 delivered-status hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- architecture ADR-009…013 bodies aligned from “ZPI-01 documentation baseline” language to
+  **accepted + delivered** status, with delivery pointers and Track C notes (embeddings default off,
+  portable export); architecture index status table refreshed.
+
 ### Fixed
 
 ### Security

--- a/docs/architecture/adr-009-project-intelligence-ownership.md
+++ b/docs/architecture/adr-009-project-intelligence-ownership.md
@@ -1,12 +1,12 @@
 ---
 Title: ADR-009 Project Intelligence Ownership Split
 Description: Community and Commercial ownership boundaries for Zeus Project Intelligence contracts, default backends, and entitlement-gated operations.
-Last Updated: 2026-07-22
+Last Updated: 2026-07-25
 ---
 
 # ADR-009: Project Intelligence Ownership Split
 
-**Status:** Accepted for ZPI-01 documentation baseline
+**Status:** Accepted; Community baseline delivered (ZPI-02…12); Commercial entitled ops shipped privately
 
 ## Context
 
@@ -24,7 +24,8 @@ Without an explicit ownership split, two failure modes become likely:
 ZPI must remain local-first, offline by default, and compatible with the existing capability
 registry, safety model, and thin CLI/MCP projection strategy.
 
-Package 09 is closed. ZPI-01 must not reopen Package 09 or introduce new live IBM i behavior.
+Package 09 is closed. Project Intelligence must not reopen Package 09 or introduce new live IBM i
+behavior as a default product path.
 
 ## Decision
 
@@ -41,6 +42,8 @@ Community owns the neutral, Apache-2.0 project-intelligence baseline:
 - deterministic bounded context-package contracts and default offline policy
 - artifact readers, validators, contract tests, and fail-closed reason-code catalogs
 - thin CLI, API, and MCP-neutral capability contracts and adapters
+- optional depth engines that remain Community-owned (portable snapshot export packaging, offline
+  corpora fixtures, embeddings policy default **off** — Track C)
 
 Community must remain complete and useful without any Commercial module. A user must be able to:
 
@@ -87,15 +90,29 @@ never depend on Commercial code, entitlements, or proprietary store formats.
 - Any persisted format needed to read Community-owned project knowledge must remain documented and
   readable without Commercial code.
 - Retrieval hits, rankings, and context packages are derived aids, not canonical source evidence.
-- Package 09 remains closed. ZPI does not add live IBM i compile, execute, or differential flows.
+- Package 09 remains closed. ZPI does not add live IBM i compile, execute, or differential flows as
+  a default product path.
+
+## Delivery
+
+| Layer                                     | Location / status                                                                  |
+| ----------------------------------------- | ---------------------------------------------------------------------------------- |
+| Contracts, reason codes, fixtures         | `src/projectIntelligence/` (ZPI-02) — shipped                                      |
+| SQLite store, content CAS, lexical search | Community engines (ZPI-03…05) — shipped                                            |
+| Snapshot / incremental engine             | ZPI-06 — shipped                                                                   |
+| RPG analyzer baseline                     | ZPI-07 — shipped                                                                   |
+| Retrieval / context                       | ZPI-08 — shipped                                                                   |
+| Thin CLI/MCP adapters                     | ZPI-11 — shipped                                                                   |
+| Entitled commercial PI ops                | private commercial package (ZPI-09…10) — shipped                                   |
+| Public closure / non-claims               | [`../knowledgebase/zpi-closure-status.md`](../knowledgebase/zpi-closure-status.md) |
 
 ## Consequences
 
-- ZPI can evolve as an open-core system without making Community a stub.
-- Commercial features can add value through registration and policy without redefining core data
+- Community is a complete local project-knowledge platform, not a stub.
+- Commercial features add value through registration and policy without redefining core data
   ownership.
-- Later implementation packages must treat Community full rebuild and artifact readers as the
-  reference behavior that Commercial extensions may optimize but not replace.
+- Community full rebuild, readers, and portable export remain the reference behavior that Commercial
+  may orchestrate but must not replace or hide.
 
 ## Alternatives considered
 
@@ -105,5 +122,6 @@ never depend on Commercial code, entitlements, or proprietary store formats.
   testing, and artifact portability.
 - **Put entitlement checks into Community adapters.** Rejected because ADR-006 keeps entitlement out
   of the core.
-- **Reopen Package 09 for project-intelligence runtime hooks.** Rejected because ZPI-01 is a docs
-  package and Package 09 is explicitly closed.
+- **Reopen Package 09 for project-intelligence runtime hooks.** Rejected because Package 09 remains
+  closed as a default product path; owner-gated offline IBM i validation stays Enterprise-scoped and
+  live-off-by-default.

--- a/docs/architecture/adr-010-default-store-and-search.md
+++ b/docs/architecture/adr-010-default-store-and-search.md
@@ -1,12 +1,12 @@
 ---
 Title: ADR-010 Default Store and Search Architecture
-Description: SQLite metadata, content-addressed evidence storage, and Lucene lexical retrieval as the Community default project-intelligence backends.
-Last Updated: 2026-07-22
+Description: SQLite metadata, content-addressed evidence storage, and Lucene-layout lexical retrieval as the Community default project-intelligence backends.
+Last Updated: 2026-07-25
 ---
 
 # ADR-010: Default Store and Search Architecture
 
-**Status:** Accepted for ZPI-01 documentation baseline
+**Status:** Accepted; Community backends delivered (ZPI-03…05); embeddings default off (Track C)
 
 ## Context
 
@@ -27,9 +27,10 @@ The default backend must support:
 Community adopts this default backend architecture:
 
 - SQLite for canonical project, snapshot, source-unit, symbol, relationship, and migration
-  metadata
+  metadata (`node:sqlite` / DatabaseSync where available)
 - content-addressed local files for preserved evidence payloads and large immutable source content
-- Apache Lucene for lexical retrieval over published Community snapshots
+- Lucene-**layout** lexical retrieval over published Community snapshots (pure-JS inverted index under
+  the project `lucene/` layout; architecture target remains Apache Lucene-compatible SPI)
 
 This baseline is local-first and offline by default. No external database, search service,
 embedding service, or mandatory daemon is required.
@@ -40,7 +41,7 @@ embedding service, or mandatory daemon is required.
 | ----------------------- | ------------------------------------------------------------------------------------------- |
 | SQLite                  | canonical derived metadata, indexes of record, lifecycle state, migrations, current pointer |
 | Content-addressed files | immutable evidence blobs and preserved source payloads                                      |
-| Lucene                  | lexical retrieval over published snapshot content and metadata                              |
+| Lucene layout / lexical | lexical retrieval over published snapshot content and metadata                              |
 
 ### Determinism requirements
 
@@ -74,16 +75,27 @@ The Community default backend does not require:
 - commercial policy modules
 - a second proprietary registry for retrieval or search behavior
 
-Vector-ready schema fields may be added later only as optional extensions. Lexical retrieval remains
-the mandatory Community baseline.
+Vector-ready schema fields exist as **optional storage**. Embeddings remain **disabled by default**
+(`resolveEmbeddingPolicy`); Community ranking is lexical-only and does not consume vectors until a
+future approved ranking engine is explicitly adopted. Lexical retrieval remains the mandatory
+Community baseline.
+
+## Delivery
+
+| Backend                               | Community location                 | Notes                 |
+| ------------------------------------- | ---------------------------------- | --------------------- |
+| SQLite KnowledgeStore                 | `src/projectIntelligence/store/`   | ZPI-03                |
+| Content CAS                           | `src/projectIntelligence/content/` | ZPI-04                |
+| Lexical search SPI + pure-JS provider | `src/projectIntelligence/search/`  | ZPI-05; Lucene layout |
+| Embedding policy (default off)        | `search/embeddingPolicy.js`        | Track C               |
 
 ## Consequences
 
-- Community implementation packages can target a clear local baseline before advanced policy work.
+- Community has a shipped local baseline for persistence and lexical search.
 - Commercial modules can add orchestration or advanced ranking through public contracts without
   replacing the default storage and search foundations.
-- Dependency selection for actual SQLite and Lucene bindings becomes a governance event that must
-  preserve Apache-2.0 compatibility and offline operation.
+- Any future Lucene native binding or embedding ranking engine is a governance event that must
+  preserve Apache-2.0 compatibility, offline defaults, and fail-closed semantics.
 
 ## Alternatives considered
 
@@ -94,3 +106,5 @@ the mandatory Community baseline.
 - **SQLite full-text only.** Rejected because ZPI needs a stronger lexical retrieval baseline and a
   clear path to bounded search-specific schema evolution.
 - **Commercial-only default backends.** Rejected because Community must remain complete and useful.
+- **Embeddings-on ranking by default.** Rejected because ADR-010 keeps optional vectors storage-only
+  until an explicit, reviewed ranking engine is adopted.

--- a/docs/architecture/adr-011-evidence-and-provenance.md
+++ b/docs/architecture/adr-011-evidence-and-provenance.md
@@ -1,12 +1,12 @@
 ---
 Title: ADR-011 Evidence and Provenance Model
 Description: Canonical evidence, derivation lineage, and export-disclosure provenance rules for Zeus Project Intelligence.
-Last Updated: 2026-07-22
+Last Updated: 2026-07-25
 ---
 
 # ADR-011: Evidence and Provenance Model
 
-**Status:** Accepted for ZPI-01 documentation baseline
+**Status:** Accepted; enforced in Community PI contracts and portable export packaging
 
 ## Context
 
@@ -59,6 +59,9 @@ normalizes:
 - non-claims such as `sourceOfTruth: false` for summaries, ranks, and context packages
 - disclosure-safe placeholders for local paths or sensitive roots when applicable
 
+Portable snapshot packages (Track C) are export-disclosure surfaces: they must redact absolute host
+paths, refuse path leakage, and remain explicitly non-canonical.
+
 ### Canonical evidence rules
 
 - Canonical evidence is always anchored to source evidence provenance.
@@ -69,12 +72,21 @@ normalizes:
 - Proprietary modules may add private artifacts, but they must not redefine Community provenance
   meanings.
 
+## Delivery
+
+| Concern                           | Enforcement                                                     |
+| --------------------------------- | --------------------------------------------------------------- |
+| Contract schemas and non-claims   | `src/projectIntelligence/contracts.js`, validators, fixtures    |
+| Reason codes for export/redaction | `REASON_CODES.EXPORT_DENIED`, `REDACTION_REQUIRED`, …           |
+| Portable package non-claims       | `exportPortableSnapshotPackage` / `openPortableSnapshotPackage` |
+| Contract tests                    | `runProjectIntelligenceContractTests`                           |
+
 ## Consequences
 
-- Later implementation packages can separate auditability from privacy and export concerns.
+- Auditability, privacy, and export disclosure remain separable threat models.
 - Security and testing work can target provenance spoofing, stale serving, and export leakage as
   distinct failure modes.
-- Community contract tests can enforce that derived retrieval or context layers never masquerade as
+- Community contract tests enforce that derived retrieval or context layers never masquerade as
   source evidence.
 
 ## Alternatives considered

--- a/docs/architecture/adr-012-snapshots-and-migrations.md
+++ b/docs/architecture/adr-012-snapshots-and-migrations.md
@@ -1,20 +1,20 @@
 ---
 Title: ADR-012 Snapshots and Migrations
 Description: Immutable publication, current-pointer semantics, and Community-owned migration rules for Zeus Project Intelligence.
-Last Updated: 2026-07-22
+Last Updated: 2026-07-25
 ---
 
 # ADR-012: Snapshots and Migrations
 
-**Status:** Accepted for ZPI-01 documentation baseline
+**Status:** Accepted; snapshot / incremental engine delivered (ZPI-06)
 
 ## Context
 
 Zeus already uses manifests, reproducible artifacts, and versioned contracts. ZPI adds longer-lived
 project state that must survive rebuilds, reopen safely, and reject torn or stale generations.
 
-The term `snapshot` is already overloaded across Zeus. ZPI needs a tighter glossary and publication
-model before persistence code lands.
+The term `snapshot` is already overloaded across Zeus. ZPI needs a tight glossary and publication
+model so persistence code and commercial orchestration share one state machine.
 
 ## Decision
 
@@ -61,12 +61,26 @@ If source deletion, rename, corruption, or migration mismatch means a published 
 longer be treated as current, ZPI must surface that state explicitly through closed reason codes and
 lineage classes such as `STALE` or `INVALIDATED`.
 
+### Portable snapshot packaging
+
+A **portable snapshot package** (Track C) is a redacted offline export of a **published** snapshot
+for transfer or archive. It is not a second current pointer, not a mutable workspace, and not
+source of truth. Import/open validates schema and integrity and must fail closed on path leakage.
+
+## Delivery
+
+| Concern                           | Community location                                 |
+| --------------------------------- | -------------------------------------------------- |
+| Full rebuild / incremental update | `src/projectIntelligence/engine/snapshotEngine.js` |
+| Diff / invalidation planning      | `engine/diffPlanner.js`, `engine/invalidation.js`  |
+| Store migrations                  | `store/migrations.js`                              |
+| Portable export                   | `export/portableSnapshotPackage.js`                |
+
 ## Consequences
 
-- ZPI can support deterministic reopen, rebuild, and validation behavior without hiding torn state.
-- Later implementation packages have a clear separation between canonical published state and
-  transient build state.
-- Commercial incremental refresh work must converge on the same published-snapshot model rather than
+- Deterministic reopen, rebuild, and validation behavior does not hide torn state.
+- Canonical published state stays separate from transient build state.
+- Commercial incremental refresh must converge on the same published-snapshot model rather than
   inventing a parallel state machine.
 
 ## Alternatives considered

--- a/docs/architecture/adr-013-retrieval-and-context-policy.md
+++ b/docs/architecture/adr-013-retrieval-and-context-policy.md
@@ -1,12 +1,12 @@
 ---
 Title: ADR-013 Retrieval and Context Policy
 Description: Deterministic Community retrieval and context-package policy with optional Commercial extensions.
-Last Updated: 2026-07-22
+Last Updated: 2026-07-25
 ---
 
 # ADR-013: Retrieval and Context Policy
 
-**Status:** Accepted for ZPI-01 documentation baseline
+**Status:** Accepted; retrieval and context assembly delivered (ZPI-08)
 
 ## Context
 
@@ -28,6 +28,7 @@ Community owns a complete default retrieval and context-assembly policy that is:
 - deterministic for a pinned snapshot, query, and engine version
 - evidence-first, with explicit omission reporting
 - compatible with thin CLI, API, and MCP-neutral capability contracts
+- lexical-first for Community ranking (embeddings storage optional; ranking default off per ADR-010)
 
 The Community default policy must be able to:
 
@@ -46,7 +47,7 @@ resource governance, but they must not:
 - weaken safety levels or trust-zone declarations
 - change thin adapter discovery semantics without a contract revision
 - make Community-owned artifacts unreadable without proprietary code
-- reopen Package 09 or add live IBM i execution behavior
+- reopen Package 09 or add live IBM i execution behavior as a default product path
 
 ### Context-package rules
 
@@ -61,17 +62,25 @@ Every context package must:
 A token budget constrains size, not sensitivity. Export or egress controls remain separate safety
 concerns and must fail closed when the destination policy does not permit disclosure.
 
+## Delivery
+
+| Concern                          | Community location                                   |
+| -------------------------------- | ---------------------------------------------------- |
+| Hybrid lexical + graph retrieval | `src/projectIntelligence/retrieval/`                 |
+| Context assembly + omissions     | `retrieval/contextAssembler.js`                      |
+| Token budgets                    | `retrieval/tokenBudget.js`                           |
+| Thin commercial dispatch surface | adapters + commercial entitled ops (private package) |
+
 ## Consequences
 
-- Community remains able to build useful local context packages without paid policy modules.
-- Commercial modules gain a clear extension surface that does not fork CLI/MCP adapter behavior.
-- Later implementation packages can test deterministic retrieval and omission behavior against one
-  documented baseline.
+- Community can build useful local context packages without paid policy modules.
+- Commercial modules have a clear extension surface that does not fork CLI/MCP adapter behavior.
+- Deterministic retrieval and omission behavior is testable against one documented baseline.
 
 ## Alternatives considered
 
 - **Commercial-only context assembly.** Rejected because Community would cease to be a complete
   local evidence platform.
 - **Treat context packages as canonical evidence.** Rejected because assembly output is a derived aid.
-- **Use retrieval or context policy to reopen Package 09 behaviors.** Rejected because ZPI-01 is
-  documentation-only and Package 09 remains closed.
+- **Use retrieval or context policy to reopen Package 09 behaviors.** Rejected because Package 09
+  remains closed as a default product path.

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,32 +1,32 @@
 ---
 Title: Zeus RPG PromptKit Architecture Documentation
-Description: Accepted architecture decisions, kernel definition, dependency rules, contracts, capability model, safety trust zones, open-core module boundaries, and ZPI baseline contracts.
-Last Updated: 2026-07-24
+Description: Accepted architecture decisions, kernel definition, dependency rules, contracts, capability model, safety trust zones, open-core module boundaries, and delivered ZPI contracts.
+Last Updated: 2026-07-25
 ---
 
 # Architecture Documentation
 
-This directory contains the authoritative architecture baseline for Zeus RPG PromptKit.
+This directory contains the authoritative architecture decisions for Zeus RPG PromptKit.
 
 All subsequent implementation and agent guidance must be consistent with these decisions.
 
 ## Accepted Architecture Decision Records (ADRs)
 
-| ADR                                                 | Title                                 | Status                                              |
-| --------------------------------------------------- | ------------------------------------- | --------------------------------------------------- |
-| [001](adr-001-product-kernel.md)                    | Product Kernel                        | Accepted                                            |
-| [002](adr-002-dependency-direction.md)              | Dependency Direction                  | Accepted                                            |
-| [003](adr-003-versioned-contracts.md)               | Versioned Contracts                   | Accepted                                            |
-| [004](adr-004-capability-registry.md)               | Capability Registry                   | Accepted                                            |
-| [005](adr-005-safety-trust-zones.md)                | Safety Trust Zones                    | Accepted                                            |
-| [006](adr-006-commercial-extension-architecture.md) | Commercial Extension Architecture     | Accepted; executable registrar shipped              |
-| [007](adr-007-provider-neutral-contracts.md)        | Provider-Neutral AI Contracts         | Accepted                                            |
-| [008](adr-008-generation-validation-foundation.md)  | Generation Validation Foundation      | Accepted                                            |
-| [009](adr-009-project-intelligence-ownership.md)    | Project Intelligence Ownership Split  | Accepted; Community baseline delivered (ZPI-02..12) |
-| [010](adr-010-default-store-and-search.md)          | Default Store and Search Architecture | Accepted; Community backends delivered              |
-| [011](adr-011-evidence-and-provenance.md)           | Evidence and Provenance Model         | Accepted; enforced in Community PI contracts        |
-| [012](adr-012-snapshots-and-migrations.md)          | Snapshots and Migrations              | Accepted; snapshot engine delivered                 |
-| [013](adr-013-retrieval-and-context-policy.md)      | Retrieval and Context Policy          | Accepted; retrieval/context delivered               |
+| ADR                                                 | Title                                 | Status                                                         |
+| --------------------------------------------------- | ------------------------------------- | -------------------------------------------------------------- |
+| [001](adr-001-product-kernel.md)                    | Product Kernel                        | Accepted                                                       |
+| [002](adr-002-dependency-direction.md)              | Dependency Direction                  | Accepted                                                       |
+| [003](adr-003-versioned-contracts.md)               | Versioned Contracts                   | Accepted                                                       |
+| [004](adr-004-capability-registry.md)               | Capability Registry                   | Accepted                                                       |
+| [005](adr-005-safety-trust-zones.md)                | Safety Trust Zones                    | Accepted                                                       |
+| [006](adr-006-commercial-extension-architecture.md) | Commercial Extension Architecture     | Accepted; executable registrar shipped                         |
+| [007](adr-007-provider-neutral-contracts.md)        | Provider-Neutral AI Contracts         | Accepted                                                       |
+| [008](adr-008-generation-validation-foundation.md)  | Generation Validation Foundation      | Accepted                                                       |
+| [009](adr-009-project-intelligence-ownership.md)    | Project Intelligence Ownership Split  | Accepted; Community baseline delivered (ZPI-02…12 + Track C)   |
+| [010](adr-010-default-store-and-search.md)          | Default Store and Search Architecture | Accepted; Community backends delivered; embeddings default off |
+| [011](adr-011-evidence-and-provenance.md)           | Evidence and Provenance Model         | Accepted; enforced in Community PI contracts + portable export |
+| [012](adr-012-snapshots-and-migrations.md)          | Snapshots and Migrations              | Accepted; snapshot engine delivered                            |
+| [013](adr-013-retrieval-and-context-policy.md)      | Retrieval and Context Policy          | Accepted; retrieval/context delivered                          |
 
 ## Related Reviews
 
@@ -62,6 +62,13 @@ The tool catalog (`../tool-catalog.md`) is the published surface of the capabili
 
 ## Governance
 
-These ADRs were created as part of package 01 to establish a verified baseline before further packages. They are grounded in the actual module structure, metadata, and contracts present on main at the time of writing (see inspection of `cli/zeus.js`, `src/api/zeusApi.js`, `src/docs/toolCatalogMetadata.js`, `src/cli/commandMetadata.js`, `src/analyze/analyzeRunManifest.js`, `src/core/`, `src/bridge/`, `src/config/`, `docs/`, `README.md`, and `.github/copilot-instructions.md`).
+ADRs 001–008 establish the product kernel, contracts, capability model, safety, open-core modules,
+providers, and generation validation. ADRs 009–013 originally froze the ZPI documentation baseline
+(package ZPI-01) and are now **accepted with delivered Community implementations** (ZPI-02…12) plus
+optional Track C depth (portable export, corpora fixtures, embeddings default off). Delivery and
+non-claims: [`../knowledgebase/zpi-closure-status.md`](../knowledgebase/zpi-closure-status.md).
 
-Changes to these decisions require a new ADR or revision with explicit compatibility and security analysis.
+They remain grounded in the module structure and contracts on `main` (including
+`src/projectIntelligence/`, `cli/zeus.js`, `src/api/zeusApi.js`, capability/tool metadata, and public
+docs). Changes to these decisions require a new ADR or revision with explicit compatibility and
+security analysis.


### PR DESCRIPTION
## Summary
Track **E** ADR body hygiene:

- ADR-009…013: status from “ZPI-01 documentation baseline” → **accepted + delivered**
- Add **Delivery** sections with Community code pointers
- Note Track C (portable export, corpora, embeddings default off) where relevant
- Architecture index status table + governance blurb updated
- CHANGELOG Unreleased

## Test plan
- [x] `npm run format:check`
- [x] `npm run check:public-knowledge-claims`
- [x] `npm run docs:check`
- docs-only; no product behavior change