### PR TITLE
chore: prepare public Community release 0.2.0-beta.4

### DIFF
--- a/.github/RELEASE_NOTES_v0.2.0-beta.4.md
+++ b/.github/RELEASE_NOTES_v0.2.0-beta.4.md
@@ -1,0 +1,71 @@
+## Zeus RPG PromptKit 0.2.0-beta.4
+
+Public Community beta after Tracks B–E on top of the beta.3 Project Intelligence baseline.
+
+**Purpose of Beta 4**
+
+- Ship post-beta.3 operator and PI depth surface without cutting a non-beta `0.2.0` yet.
+- Make commercial host wiring ergonomic via explicit `profile.commercial` (CLI → env → profile).
+- Add portable snapshot export packaging, offline corpora fixtures, and embeddings **default off**.
+- Align ADR-009…013 bodies with accepted + delivered status.
+- Keep the hardened single-artifact release workflow (checksum, SBOM, build-provenance attestation).
+
+**Major additions since Beta 3**
+
+- Loader UX: `profile.commercial` for package path, module keys, and license path fields.
+- PI export: `exportPortableSnapshotPackage` / `openPortableSnapshotPackage` (redacted, offline).
+- PI corpora: `listCorpora` / `materializeCorpus` (`mini-multi-program-rpg`).
+- Embeddings policy: `resolveEmbeddingPolicy` — storage opt-in only; Community ranking stays lexical.
+- Architecture ADR hygiene (009–013 delivery pointers).
+- Freeze readiness notes for a future owner-gated `0.2.0` cut.
+
+**Non-claims**
+
+- Project Knowledge is not source of truth; preserved source evidence remains authoritative.
+- Not a compile, deploy, or live IBM i execution product.
+- Community adapters contain no paid commercial implementation.
+- Core does not enforce commercial licenses (ADR-006).
+- Benchmark numbers are evidence, not production guarantees.
+- This is a **prerelease** — not production certification of `0.2.0`.
+
+**Installation from GitHub release tarball (recommended for beta)**
+
+```bash
+npm install https://github.com/gzeuner/zeus-rpg-promptkit/releases/download/v0.2.0-beta.4/zeus-rpg-promptkit-0.2.0-beta.4.tgz
+```
+
+**Verify the release**
+
+```bash
+# checksums
+sha256sum --check SHA256SUMS
+# smoke from tarball only
+mkdir /tmp/verify && cd /tmp/verify && npm init -y && npm install ../zeus-rpg-promptkit-0.2.0-beta.4.tgz && ./node_modules/.bin/zeus --help
+```
+
+**Provenance**
+
+This release uses the hardened workflow: one immutable source commit on `main`, one npm tarball,
+checksum file, CycloneDX SBOM, and build-provenance attestation for that same artifact. The
+historical beta.2 attestation exception is **not** reused. See
+[release-integrity policy](https://github.com/gzeuner/zeus-rpg-promptkit/blob/main/docs/maintainers/release-integrity.md).
+
+**Supported environments**
+
+- Node.js >= 20 (tested on 20 and current LTS)
+- Linux and Windows runners in CI
+
+**Known limitations**
+
+- Type checking covers the declared core contract subset, not the complete JavaScript repository.
+- Some legacy no-unused-vars exceptions remain outside hardened paths.
+- Selected remote IBM i / Db2 behavior requires environment-specific validation.
+- Experimental surfaces remain experimental as documented.
+
+**Upgrade note**
+
+Prefer Beta 4 over Beta 3 for loader profile UX and PI export/corpora/embeddings policy. After
+installing Beta 4, commercial packages must re-pin this Community release SHA before claiming
+compatibility.
+
+This is a **prerelease**. Contracts may still evolve before `0.2.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Security
+
+## [0.2.0-beta.4] - 2026-07-25
+
+Public Community beta after Tracks B–E on top of the beta.3 ZPI baseline.
+
+### Added
+
 - commercial host loader operator UX: explicit `profile.commercial` fields
   (`module`, `modules`, `licenseDocumentPath`, `publicKeyPath`) with precedence
   CLI → env → profile; no marketplace or auto-discovery (`createHostZeus` /
@@ -18,18 +30,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-program corpora fixtures (`listCorpora` / `materializeCorpus`), and
   explicit embeddings policy default **off** (storage opt-in only; Community
   ranking remains lexical-only per ADR-010).
+- maintainer freeze-readiness package for a future `0.2.0` cut
+  (`docs/maintainers/freeze-readiness-0.2.0.md`).
 
 ### Changed
 
 - architecture ADR-009…013 bodies aligned from “ZPI-01 documentation baseline” language to
   **accepted + delivered** status, with delivery pointers and Track C notes (embeddings default off,
   portable export); architecture index status table refreshed.
-- maintainer freeze package for Track F: `docs/maintainers/freeze-readiness-0.2.0.md` + next-release
-  checklist pointer (preflight green; version/tag still owner-gated).
+- next-release checklist updated for post-beta.3 landings and freeze prep.
 
 ### Fixed
 
 ### Security
+
+- no Package 09 reopen; live IBM i remains out of Community product path
+- portable export continues to redact host paths and refuse path leakage
+- embeddings remain disabled by default (ADR-010)
+
+### Known Limitations (Beta)
+
+- type checking currently covers the declared core contract subset, not the complete JavaScript
+  repository;
+- some legacy `no-unused-vars` exceptions remain outside the hardened paths;
+- selected remote IBM i and Db2 behavior still requires environment-specific validation;
+- experimental surfaces remain experimental as documented;
+- Project Knowledge is not source of truth and does not compile, deploy, or execute live IBM i;
+- this prerelease is **not** a production certification of `0.2.0`.
 
 ## [0.2.0-beta.3] - 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -179,21 +179,21 @@ npm run demo:run
 Scripts und Release-Prozess: `package.json`, `CONTRIBUTING.md`, `CHANGELOG.md` und
 `.github/workflows/release.yml`.
 
-**Beta-Status (0.2.0-beta.3):** Vorabversion nach Project-Intelligence-Lieferung und Commercial Host
-Loader. Kernverträge stabilisieren sich, einzelne Oberflächen bleiben experimentell. Details in den
-GitHub-Release-Notes und im CHANGELOG. Vor produktiver Nutzung von Artefakten lokal
-`npm run docs:check` und `npm run package:smoke` ausführen sowie den Golden-Path beachten.
+**Beta-Status (0.2.0-beta.4):** Vorabversion nach Tracks B–E (Loader-Profile-UX, PI-Export/Corpora,
+Embeddings default off, ADR-Hygiene) auf der PI-Baseline von Beta.3. Kernverträge stabilisieren sich,
+einzelne Oberflächen bleiben experimentell. Details in den GitHub-Release-Notes und im CHANGELOG.
+Vor produktiver Nutzung von Artefakten lokal `npm run docs:check` und `npm run package:smoke`
+ausführen sowie den Golden-Path beachten.
 
-Veröffentlichte Prerelease-Assets: [`v0.2.0-beta.3`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.3)
-(Tarball, SBOM, SHA256SUMS, Build-Provenance-Attestation). Beta.3 nutzt den gehärteten
-Single-Artifact-Release-Workflow. Die historische Attestations-Ausnahme von Beta.2 gilt **nicht**
-für dieses Release. Policy:
-[`docs/maintainers/release-integrity.md`](docs/maintainers/release-integrity.md).
+Veröffentlichte Prerelease-Assets: [`v0.2.0-beta.4`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.4)
+(Tarball, SBOM, SHA256SUMS, Build-Provenance-Attestation). Nutzt den gehärteten
+Single-Artifact-Release-Workflow. Die historische Attestations-Ausnahme von Beta.2 gilt **nicht**.
+Policy: [`docs/maintainers/release-integrity.md`](docs/maintainers/release-integrity.md).
 
 Empfohlene Installation vom GitHub-Release-Tarball:
 
 ```bash
-npm install https://github.com/gzeuner/zeus-rpg-promptkit/releases/download/v0.2.0-beta.3/zeus-rpg-promptkit-0.2.0-beta.3.tgz
+npm install https://github.com/gzeuner/zeus-rpg-promptkit/releases/download/v0.2.0-beta.4/zeus-rpg-promptkit-0.2.0-beta.4.tgz
 ```
 
 ### Golden Corpus und Qualitätsmetriken
@@ -791,21 +791,22 @@ Key guardrails:
 
 ### Install and run
 
-**Beta status (0.2.0-beta.3):** prerelease after Project Intelligence delivery and the commercial host
-loader. Core contracts are stabilizing; some surfaces remain experimental. Details:
-[release notes](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.3) and
+**Beta status (0.2.0-beta.4):** prerelease after Tracks B–E (loader profile UX, PI export/corpora,
+embeddings default off, ADR hygiene) on the beta.3 Project Intelligence baseline. Core contracts
+are stabilizing; some surfaces remain experimental. Details:
+[release notes](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.4) and
 `CHANGELOG.md`. Before relying on artifacts locally, run `npm run docs:check` and
 `npm run package:smoke` and follow the golden path.
 
 Published prerelease assets (tarball, SBOM, SHA256SUMS, build-provenance attestation):
-[`v0.2.0-beta.3`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.3).
+[`v0.2.0-beta.4`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.4).
 The beta.2 historical attestation exception does **not** apply. Policy:
 [`docs/maintainers/release-integrity.md`](docs/maintainers/release-integrity.md).
 
 Recommended install from the GitHub release tarball:
 
 ```bash
-npm install https://github.com/gzeuner/zeus-rpg-promptkit/releases/download/v0.2.0-beta.3/zeus-rpg-promptkit-0.2.0-beta.3.tgz
+npm install https://github.com/gzeuner/zeus-rpg-promptkit/releases/download/v0.2.0-beta.4/zeus-rpg-promptkit-0.2.0-beta.4.tgz
 ```
 
 From a source checkout:

--- a/docs/knowledgebase/zpi-closure-status.md
+++ b/docs/knowledgebase/zpi-closure-status.md
@@ -10,9 +10,11 @@ This document is the public Community closure status for the ZPI program (ZPI-01
 It records delivered surfaces, explicit non-claims, and verification posture. It is **not** a
 product SLA, production certification, or live IBM i validation claim.
 
-**Shipped in public prerelease:** Community package **0.2.0-beta.3**
-([`v0.2.0-beta.3`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.3),
-source `f1b6f29b73e59089c2873146f65f277663e38a4b`).
+**Shipped in public prerelease:** Community package **0.2.0-beta.4**
+([`v0.2.0-beta.4`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.4)).
+ZPI Community baseline first shipped in
+[`v0.2.0-beta.3`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.3)
+(source `f1b6f29b73e59089c2873146f65f277663e38a4b`).
 
 ## Program map
 

--- a/docs/maintainers/next-release-checklist.md
+++ b/docs/maintainers/next-release-checklist.md
@@ -6,25 +6,22 @@ Last Updated: 2026-07-25
 
 # Next release checklist (Community)
 
-Current package version on `main`: **0.2.0-beta.3** (published as GitHub prerelease
-[`v0.2.0-beta.3`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.3),
-source tag target `f1b6f29b73e59089c2873146f65f277663e38a4b`).
+Current package version on `main` (this prep cut): **0.2.0-beta.4**.
 
-`main` tip (post-beta.3 Tracks B–E): verify with `git rev-parse HEAD` (assessed **2026-07-25** as
-`0e3c86b6a9a4124199bff6df5f3ba50ba983da34`).
+Last closed prerelease before this prep: [`v0.2.0-beta.3`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.3)
+@ `f1b6f29…`. After beta.4 publishes, update the closed-cut table below.
 
-This checklist prepares a **future** release. It does **not** create tags, publish npm packages, or
-bypass owner approval.
+This checklist prepares Community releases. Tag/publish still require the Release
+`workflow_dispatch` after merge to `main`.
 
 **Track F freeze package:** [`freeze-readiness-0.2.0.md`](./freeze-readiness-0.2.0.md)  
-(preflight green; version + tag still owner-gated).
+(preflight for freeze assessment; next non-beta cut remains owner-gated).
 
-## Recommended next version
+## Recommended next version (after beta.4)
 
-| Candidate      | When                                                        |
-| -------------- | ----------------------------------------------------------- |
-| `0.2.0-beta.4` | Incremental public beta if more surface lands before freeze |
-| `0.2.0`        | Only after owner decision that beta surface is freeze-ready |
+| Candidate | When                                                        |
+| --------- | ----------------------------------------------------------- |
+| `0.2.0`   | Only after owner decision that beta surface is freeze-ready |
 
 ## Preflight (local)
 
@@ -90,9 +87,15 @@ npm run release:preflight -- --version <target-version>
 - Docs alignment (DE/EN README, architecture index, ZPI closure status)
 - Hardened single-artifact release with checksum, SBOM, and build-provenance attestation
 
-### Landed on `main` after beta.3 (not yet in a release cut)
+### Closed cut: 0.2.0-beta.4 (2026-07-25) — fill after publish
 
-- #254 — `profile.commercial` loader operator UX
-- #255 — PI portable export, corpora, embeddings default off
-- #256 — ADR-009…013 delivered-status hygiene
-- #253 — published beta.3 status docs (already post-tag on main)
+| Gate                    | Result                      |
+| ----------------------- | --------------------------- |
+| Prep PR                 | (this release prep PR)      |
+| Tag / assets            | pending `workflow_dispatch` |
+| Source SHA              | set after tag               |
+| Commercial pin          | re-pin after publish        |
+| beta.2 exception reused | **no**                      |
+
+Included relative to beta.3: #254 loader UX, #255 PI export/corpora/embeddings-off, #256 ADR hygiene,
+#253 status docs, freeze-readiness package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeus-rpg-promptkit",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeus-rpg-promptkit",
-      "version": "0.2.0-beta.3",
+      "version": "0.2.0-beta.4",
       "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeus-rpg-promptkit",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "description": "Evidence and Investigation Platform for IBM i — turn source, metadata and runtime evidence into reproducible, review-ready artifacts with humans in control.",
   "main": "cli/zeus.js",
   "exports": {


### PR DESCRIPTION
## Summary
Owner-authorized Community prerelease **0.2.0-beta.4** prep:

- `package.json` / lock → `0.2.0-beta.4`
- CHANGELOG section for beta.4 (Tracks B–E delta)
- `.github/RELEASE_NOTES_v0.2.0-beta.4.md`
- README DE/EN beta status + tarball install URL
- ZPI closure status + next-release checklist updates

## After merge
1. `workflow_dispatch` Release with version `0.2.0-beta.4`
2. Verify assets + attestation
3. Commercial re-pin to release SHA

## Test plan
- [x] `npm run format:check`
- [x] `npm run check:public-knowledge-claims`
- [x] `npm run package:smoke` (beta.4 tarball)
- [x] version fields consistent in package + lock