### PR TITLE
fix(docs): regenerate tool catalog for 0.2.0-beta.4

### DIFF
--- a/docs/tool-catalog.json
+++ b/docs/tool-catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "package": {
     "name": "zeus-rpg-promptkit",
-    "version": "0.2.0-beta.3"
+    "version": "0.2.0-beta.4"
   },
   "generatedAt": "2026-07-25T00:00:00.000Z",
   "cliFile": "cli/zeus.js",

--- a/docs/tool-catalog.md
+++ b/docs/tool-catalog.md
@@ -12,7 +12,7 @@ Last Updated: 2026-07-25
 
 # Zeus RPG PromptKit Tool Catalog
 
-Package: `zeus-rpg-promptkit@0.2.0-beta.3`
+Package: `zeus-rpg-promptkit@0.2.0-beta.4`
 
 This document is the authoritative tool reference for Zeus RPG PromptKit.
 All AI assistants (GPT, Claude, Grok, Copilot, local agents) should treat this file as the single source of truth for command purpose, risk level, and usage.

--- a/tests/tool-catalog-generator.test.js
+++ b/tests/tool-catalog-generator.test.js
@@ -24,6 +24,7 @@ const {
 } = require('../src/docs/toolCatalogMetadata');
 
 const projectRoot = path.resolve(__dirname, '..');
+const packageIdentity = require(path.join(projectRoot, 'package.json'));
 
 function sha256(content) {
   return crypto.createHash('sha256').update(content).digest('hex');
@@ -43,7 +44,10 @@ test('catalog model is deterministic and preserves the public command contracts'
   const second = buildCatalogModel({ repoRoot: projectRoot, env: {} });
   assert.deepEqual(first, second);
   assert.equal(first.generatedAt, '2026-07-25T00:00:00.000Z');
-  assert.deepEqual(first.package, { name: 'zeus-rpg-promptkit', version: '0.2.0-beta.3' });
+  assert.deepEqual(first.package, {
+    name: 'zeus-rpg-promptkit',
+    version: packageIdentity.version,
+  });
 
   const investigate = first.commandRows.find(entry => entry.command === 'investigate');
   assert.deepEqual(investigate.aliases, ['investigation']);
@@ -114,7 +118,7 @@ test('release-date fallback rejects calendar dates that JavaScript would normali
   try {
     fs.writeFileSync(
       path.join(root, 'CHANGELOG.md'),
-      '# Changelog\n\n## [0.2.0-beta.3] - 2026-02-30\n',
+      `# Changelog\n\n## [${packageIdentity.version}] - 2026-02-30\n`,
       'utf8'
     );
     assert.throws(() => resolveGeneratedAt(root, {}), /invalid release date/);


### PR DESCRIPTION
## Summary
- Regenerate `docs/tool-catalog.md` / `.json` for package version 0.2.0-beta.4
- Make tool-catalog generator tests use `package.json` version instead of hardcoding beta.3

## Test plan
- [x] `node --test tests/tool-catalog-generator.test.js`