### PR TITLE
docs(maintainers): record v0.2.0-beta.4 published status

### DIFF
--- a/docs/maintainers/freeze-readiness-0.2.0.md
+++ b/docs/maintainers/freeze-readiness-0.2.0.md
@@ -16,19 +16,19 @@ version, or dispatch the Release workflow. Those remain **owner gates**.
 
 ## Status after beta.4
 
-| Item | State |
-| ---- | ----- |
-| `v0.2.0-beta.4` | **Published** (prerelease; tarball + SBOM + SHA256SUMS + attestation) |
-| Tag / tip SHA | `6a4789a41e827bd82d97b54bb3346e3b4228b152` — **do not re-tag** |
-| Commercial pin | re-pin PR targets this SHA (commercial repo) |
-| Full non-beta `0.2.0` | **still owner-gated** |
+| Item                  | State                                                                 |
+| --------------------- | --------------------------------------------------------------------- |
+| `v0.2.0-beta.4`       | **Published** (prerelease; tarball + SBOM + SHA256SUMS + attestation) |
+| Tag / tip SHA         | `6a4789a41e827bd82d97b54bb3346e3b4228b152` — **do not re-tag**        |
+| Commercial pin        | re-pin PR targets this SHA (commercial repo)                          |
+| Full non-beta `0.2.0` | **still owner-gated**                                                 |
 
 ## Recommendation (next cut)
 
-| Option | When |
-| ------ | ---- |
-| **Cut `0.2.0`** | Owner accepts post-beta.4 surface as freeze-ready |
-| **Hold** | Owner wants more product work or soak before non-beta |
+| Option          | When                                                  |
+| --------------- | ----------------------------------------------------- |
+| **Cut `0.2.0`** | Owner accepts post-beta.4 surface as freeze-ready     |
+| **Hold**        | Owner wants more product work or soak before non-beta |
 
 **Agent assessment:** beta.4 is shipped. Product freeze for non-beta `0.2.0` remains an **owner**
 decision (scope, messaging, support expectations). `0.2.0` is still not “production certification”
@@ -36,33 +36,33 @@ unless the owner separately asserts that bar.
 
 ## Delta since `v0.2.0-beta.3` (included in beta.4)
 
-| Area | PRs / commits | Notes |
-| ---- | ------------- | ----- |
-| Published status docs | #253 | README / checklist after beta.3 |
-| Commercial host loader UX | #254 | `profile.commercial` (CLI → env → profile) |
-| PI depth (Track C) | #255 | portable snapshot export, corpora, embeddings default off |
-| ADR hygiene (Track E) | #256 | ADR-009…013 accepted + delivered language |
-| Release prep beta.4 | #258 | version / CHANGELOG / release notes |
-| Tool catalog fix | #259 | catalog regenerated; version-agnostic tests |
+| Area                      | PRs / commits | Notes                                                     |
+| ------------------------- | ------------- | --------------------------------------------------------- |
+| Published status docs     | #253          | README / checklist after beta.3                           |
+| Commercial host loader UX | #254          | `profile.commercial` (CLI → env → profile)                |
+| PI depth (Track C)        | #255          | portable snapshot export, corpora, embeddings default off |
+| ADR hygiene (Track E)     | #256          | ADR-009…013 accepted + delivered language                 |
+| Release prep beta.4       | #258          | version / CHANGELOG / release notes                       |
+| Tool catalog fix          | #259          | catalog regenerated; version-agnostic tests               |
 
 No Package 09 reopen. No paid code in Community. No live IBM i default path.
 
 ## Preflight results (2026-07-25, local — pre beta.4 cut)
 
-| Gate | Result |
-| ---- | ------ |
-| `npm run format:check` | pass |
-| `npm run lint` | pass |
-| `npm run typecheck` | pass |
-| `npm run test:discovery` | pass (145 files classified) |
-| `npm test` | pass |
-| `npm run test:benchmark` | pass (evidence only) |
-| `npm run check:public-knowledge-claims` | pass |
-| `npm run docs:check` | pass |
-| `npm run check:repo-portability` | pass |
-| `npm run test:release-integrity` | pass |
-| `npm run package:smoke` | pass |
-| `npm audit --omit=dev --audit-level=high` | 0 vulnerabilities |
+| Gate                                      | Result                      |
+| ----------------------------------------- | --------------------------- |
+| `npm run format:check`                    | pass                        |
+| `npm run lint`                            | pass                        |
+| `npm run typecheck`                       | pass                        |
+| `npm run test:discovery`                  | pass (145 files classified) |
+| `npm test`                                | pass                        |
+| `npm run test:benchmark`                  | pass (evidence only)        |
+| `npm run check:public-knowledge-claims`   | pass                        |
+| `npm run docs:check`                      | pass                        |
+| `npm run check:repo-portability`          | pass                        |
+| `npm run test:release-integrity`          | pass                        |
+| `npm run package:smoke`                   | pass                        |
+| `npm audit --omit=dev --audit-level=high` | 0 vulnerabilities           |
 
 Re-run the full gate set on `main` before any future cut.
 

--- a/docs/maintainers/freeze-readiness-0.2.0.md
+++ b/docs/maintainers/freeze-readiness-0.2.0.md
@@ -1,6 +1,6 @@
 ---
 Title: Freeze readiness toward 0.2.0 (Track F)
-Description: Owner-facing freeze package after beta.3 and Tracks B–E. Does not tag or publish.
+Description: Owner-facing freeze package after beta.4. Full 0.2.0 remains owner-gated. Does not tag or publish.
 Last Updated: 2026-07-25
 ---
 
@@ -8,55 +8,67 @@ Last Updated: 2026-07-25
 
 **Classification:** maintainer / owner  
 **Date assessed:** 2026-07-25  
-**Community tip assessed:** `0e3c86b6a9a4124199bff6df5f3ba50ba983da34` (`main`)  
-**Last published prerelease:** [`v0.2.0-beta.3`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.3) @ `f1b6f29…`
+**Community tip assessed:** `6a4789a41e827bd82d97b54bb3346e3b4228b152` (`main`)  
+**Last published prerelease:** [`v0.2.0-beta.4`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.4) @ `6a4789a…`
 
 This document is the Track **F** freeze package. It does **not** create tags, bump the package
 version, or dispatch the Release workflow. Those remain **owner gates**.
 
-## Recommendation
+## Status after beta.4
 
-| Option                       | When                                                                                                         |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **Cut `0.2.0`**              | Owner accepts post-beta.3 surface (loader UX, PI export/corpora/embeddings-off, ADR hygiene) as freeze-ready |
-| **Cut `0.2.0-beta.4` first** | Owner wants another prerelease soak before non-beta                                                          |
-| **Hold**                     | Owner wants more product work before any release                                                             |
+| Item | State |
+| ---- | ----- |
+| `v0.2.0-beta.4` | **Published** (prerelease; tarball + SBOM + SHA256SUMS + attestation) |
+| Tag / tip SHA | `6a4789a41e827bd82d97b54bb3346e3b4228b152` — **do not re-tag** |
+| Commercial pin | re-pin PR targets this SHA (commercial repo) |
+| Full non-beta `0.2.0` | **still owner-gated** |
 
-**Agent assessment:** technical preflight on `main` is **green**. Product freeze is an **owner**
+## Recommendation (next cut)
+
+| Option | When |
+| ------ | ---- |
+| **Cut `0.2.0`** | Owner accepts post-beta.4 surface as freeze-ready |
+| **Hold** | Owner wants more product work or soak before non-beta |
+
+**Agent assessment:** beta.4 is shipped. Product freeze for non-beta `0.2.0` remains an **owner**
 decision (scope, messaging, support expectations). `0.2.0` is still not “production certification”
 unless the owner separately asserts that bar.
 
-## Delta since `v0.2.0-beta.3` (tag target `f1b6f29`)
+## Delta since `v0.2.0-beta.3` (included in beta.4)
 
-| Area                      | PRs / commits | Notes                                                     |
-| ------------------------- | ------------- | --------------------------------------------------------- |
-| Published status docs     | #253          | README / checklist after beta.3                           |
-| Commercial host loader UX | #254          | `profile.commercial` (CLI → env → profile)                |
-| PI depth (Track C)        | #255          | portable snapshot export, corpora, embeddings default off |
-| ADR hygiene (Track E)     | #256          | ADR-009…013 accepted + delivered language                 |
+| Area | PRs / commits | Notes |
+| ---- | ------------- | ----- |
+| Published status docs | #253 | README / checklist after beta.3 |
+| Commercial host loader UX | #254 | `profile.commercial` (CLI → env → profile) |
+| PI depth (Track C) | #255 | portable snapshot export, corpora, embeddings default off |
+| ADR hygiene (Track E) | #256 | ADR-009…013 accepted + delivered language |
+| Release prep beta.4 | #258 | version / CHANGELOG / release notes |
+| Tool catalog fix | #259 | catalog regenerated; version-agnostic tests |
 
 No Package 09 reopen. No paid code in Community. No live IBM i default path.
 
-## Preflight results (2026-07-25, local)
+## Preflight results (2026-07-25, local — pre beta.4 cut)
 
-| Gate                                      | Result                      |
-| ----------------------------------------- | --------------------------- |
-| `npm run format:check`                    | pass                        |
-| `npm run lint`                            | pass                        |
-| `npm run typecheck`                       | pass                        |
-| `npm run test:discovery`                  | pass (145 files classified) |
-| `npm test`                                | pass                        |
-| `npm run test:benchmark`                  | pass (evidence only)        |
-| `npm run check:public-knowledge-claims`   | pass                        |
-| `npm run docs:check`                      | pass                        |
-| `npm run check:repo-portability`          | pass                        |
-| `npm run test:release-integrity`          | pass                        |
-| `npm run package:smoke`                   | pass                        |
-| `npm audit --omit=dev --audit-level=high` | 0 vulnerabilities           |
+| Gate | Result |
+| ---- | ------ |
+| `npm run format:check` | pass |
+| `npm run lint` | pass |
+| `npm run typecheck` | pass |
+| `npm run test:discovery` | pass (145 files classified) |
+| `npm test` | pass |
+| `npm run test:benchmark` | pass (evidence only) |
+| `npm run check:public-knowledge-claims` | pass |
+| `npm run docs:check` | pass |
+| `npm run check:repo-portability` | pass |
+| `npm run test:release-integrity` | pass |
+| `npm run package:smoke` | pass |
+| `npm audit --omit=dev --audit-level=high` | 0 vulnerabilities |
 
-## Content checklist for the cut (owner-approved version)
+Re-run the full gate set on `main` before any future cut.
 
-Use after the owner chooses `0.2.0` or `0.2.0-beta.4`:
+## Content checklist for the next cut (owner-approved version)
+
+Use after the owner chooses non-beta `0.2.0` (or a later beta):
 
 - [ ] Bump `package.json` / `package-lock.json` to target version
 - [ ] Move `[Unreleased]` into `## [<version>] - YYYY-MM-DD` in `CHANGELOG.md`
@@ -66,10 +78,11 @@ Use after the owner chooses `0.2.0` or `0.2.0-beta.4`:
 - [ ] Confirm Release workflow still attests **one** artifact; attestation verify uses **only**
       `--signer-workflow` (not also `--signer-repo`)
 - [ ] **Do not** reuse beta.2 historical attestation exception
+- [ ] **Do not** re-tag an existing published version
 
-## Owner gates (required for publish)
+## Owner gates (required for next publish)
 
-- [ ] Version decision: `0.2.0` vs `0.2.0-beta.4` vs hold
+- [ ] Version decision: `0.2.0` vs hold (or a later beta if re-opened)
 - [ ] Explicit authorization to open prep PR + run `workflow_dispatch` Release on `main`
 - [ ] After publish: commercial re-pin to the **released** Community SHA in **all** pin locations
 - [ ] Confirm messaging: prerelease vs freeze; no accidental “production certified” claim
@@ -82,8 +95,9 @@ Use after the owner chooses `0.2.0` or `0.2.0-beta.4`:
 - Community has no paid PI implementation
 - Core does not enforce commercial licenses (ADR-006)
 - `review-ready` is never compile readiness (ADR-008)
+- Published betas are prereleases — not production certification
 
-## After owner authorization
+## After owner authorization (next cut)
 
 1. One Community prep PR (version + CHANGELOG + release notes).
 2. Merge to `main` after green CI.
@@ -94,6 +108,5 @@ Use after the owner chooses `0.2.0` or `0.2.0-beta.4`:
 
 ## Commercial pin note
 
-Commercial currently pins Track C tip `4ad0f43…` (not tip of `main` after docs-only #256). That is
-intentional until the next **feature** or **release** pin. Docs-only #256 does not require a pin
-bump; a `0.2.0` / beta.4 release cut **does**.
+Commercial should pin **`6a4789a…`** (= `v0.2.0-beta.4` tag). A future release cut requires a new
+pin to that release’s tag SHA.

--- a/docs/maintainers/next-release-checklist.md
+++ b/docs/maintainers/next-release-checklist.md
@@ -1,27 +1,28 @@
 ---
 Title: Next Release Checklist
-Description: Maintainer checklist for Community releases after the published 0.2.0-beta.3 cut and Track F freeze readiness.
+Description: Maintainer checklist for Community releases after the published 0.2.0-beta.4 cut. Full 0.2.0 remains owner-gated.
 Last Updated: 2026-07-25
 ---
 
 # Next release checklist (Community)
 
-Current package version on `main` (this prep cut): **0.2.0-beta.4**.
+Current package version on `main`: **0.2.0-beta.4** (published).
 
-Last closed prerelease before this prep: [`v0.2.0-beta.3`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.3)
-@ `f1b6f29…`. After beta.4 publishes, update the closed-cut table below.
+Last published prerelease: [`v0.2.0-beta.4`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.4)
+@ `6a4789a…`. **Do not re-tag** beta.4.
 
 This checklist prepares Community releases. Tag/publish still require the Release
 `workflow_dispatch` after merge to `main`.
 
 **Track F freeze package:** [`freeze-readiness-0.2.0.md`](./freeze-readiness-0.2.0.md)  
-(preflight for freeze assessment; next non-beta cut remains owner-gated).
+(beta.4 shipped; next non-beta cut remains owner-gated).
 
 ## Recommended next version (after beta.4)
 
 | Candidate | When                                                        |
 | --------- | ----------------------------------------------------------- |
 | `0.2.0`   | Only after owner decision that beta surface is freeze-ready |
+| Hold      | Owner wants more soak or product work before non-beta       |
 
 ## Preflight (local)
 
@@ -62,10 +63,31 @@ npm run release:preflight -- --version <target-version>
 
 ## Owner gates (not automated)
 
-- [ ] Version number decision (beta.4 vs 0.2.0)
+- [ ] Version number decision (`0.2.0` vs hold)
 - [ ] Tag + publish authorization via `workflow_dispatch` Release on `main`
 - [ ] Commercial pin bump to the released Community SHA after the release commit is on `main`
 - [ ] Confirm beta.2 historical attestation exception is **not** reused
+- [ ] Confirm existing published tags (including beta.4) are **not** re-tagged
+
+## Closed cut: 0.2.0-beta.4 (2026-07-25)
+
+| Gate                    | Result                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------- |
+| Prep PR                 | [#258](https://github.com/gzeuner/zeus-rpg-promptkit/pull/258)                              |
+| Tool-catalog fix        | [#259](https://github.com/gzeuner/zeus-rpg-promptkit/pull/259)                              |
+| Tag / assets            | [`v0.2.0-beta.4`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.4) |
+| Source SHA              | `6a4789a41e827bd82d97b54bb3346e3b4228b152`                                                  |
+| Assets                  | tarball + SBOM + SHA256SUMS + attestation                                                   |
+| Commercial pin          | commercial PR pins `6a4789a…`; `overrides.brace-expansion=5.0.8`                            |
+| beta.2 exception reused | **no**                                                                                      |
+
+### Notable delivered in 0.2.0-beta.4 (relative to beta.3)
+
+- Commercial host loader UX: `profile.commercial` (#254)
+- PI depth: portable snapshot export, corpora fixtures, embeddings default off (#255)
+- ADR-009…013 body hygiene (#256)
+- Freeze-readiness package + published status docs
+- Tool catalog regenerated for beta.4; version-agnostic catalog tests (#259)
 
 ## Closed cut: 0.2.0-beta.3 (2026-07-25)
 
@@ -75,7 +97,7 @@ npm run release:preflight -- --version <target-version>
 | Attestation verify fix  | [#252](https://github.com/gzeuner/zeus-rpg-promptkit/pull/252) (`--signer-workflow` only)   |
 | Tag / assets            | [`v0.2.0-beta.3`](https://github.com/gzeuner/zeus-rpg-promptkit/releases/tag/v0.2.0-beta.3) |
 | Source SHA              | `f1b6f29b73e59089c2873146f65f277663e38a4b`                                                  |
-| Commercial pin          | commercial main pins the same SHA; `overrides.brace-expansion=5.0.8`                        |
+| Commercial pin          | commercial main pinned that SHA; `overrides.brace-expansion=5.0.8`                          |
 | beta.2 exception reused | **no**                                                                                      |
 
 ### Notable delivered in 0.2.0-beta.3
@@ -86,16 +108,3 @@ npm run release:preflight -- --version <target-version>
 - Explicit commercial module host loader (`registerCommercialModules` / `createHostZeus`)
 - Docs alignment (DE/EN README, architecture index, ZPI closure status)
 - Hardened single-artifact release with checksum, SBOM, and build-provenance attestation
-
-### Closed cut: 0.2.0-beta.4 (2026-07-25) — fill after publish
-
-| Gate                    | Result                      |
-| ----------------------- | --------------------------- |
-| Prep PR                 | (this release prep PR)      |
-| Tag / assets            | pending `workflow_dispatch` |
-| Source SHA              | set after tag               |
-| Commercial pin          | re-pin after publish        |
-| beta.2 exception reused | **no**                      |
-
-Included relative to beta.3: #254 loader UX, #255 PI export/corpora/embeddings-off, #256 ADR hygiene,
-#253 status docs, freeze-readiness package.


### PR DESCRIPTION
## Summary
- Mark `v0.2.0-beta.4` closed cut (tag SHA `6a4789a…`, assets, #258/#259).
- Refresh freeze-readiness: beta.4 shipped; full non-beta `0.2.0` remains owner-gated.
- Point commercial pin expectation at beta.4 SHA.

## Notes
- Docs-only. Do not re-tag beta.4. No Release workflow dispatch.