### PR TITLE
fix(mcp): Track G0 agent surface docs sync

### DIFF
--- a/docs/ai/session-prompt.md
+++ b/docs/ai/session-prompt.md
@@ -1,16 +1,17 @@
 ---
 Title: AI Session Prompt
 Description: Standardisierter Session-Startprompt fuer CLI/MCP-first, evidence-first und safety-first Arbeit mit Zeus.
-Last Updated: 2026-07-09
+Last Updated: 2026-07-25
 ---
 
-# Zeus RPG PromptKit - AI Session Prompt (v2.2)
+# Zeus RPG PromptKit - AI Session Prompt (v2.3)
 
 Nutze diesen Prompt am Start einer neuen Zeus-Session mit KI-Assistenten.
 
 Related:
 
 - [`../tool-catalog.md`](../tool-catalog.md)
+- [`../mcp/operator-guide.md`](../mcp/operator-guide.md)
 - [`../index.md`](../index.md)
 - [`../cli/reference.md`](../cli/reference.md)
 
@@ -26,11 +27,13 @@ Core operating model:
 - Read-only by default on IBM i / DB2
 - Local workspace changes only unless the user explicitly approves higher-risk actions
 - Always explain why you ran a command or MCP tool and what evidence it produced
+- Do not invent tool or command names
 
-Authoritative references:
-- `docs/tool-catalog.md` is the source of truth for command purpose, scope, and safety level
-- `docs/mcp/operator-guide.md` describes the current MCP tool surface and allowlist posture
-- `docs/ai/session-prompt.md` is the standard session bootstrap prompt
+Authoritative references (priority order when MCP is available):
+1) MCP `tools/list` and `zeus.help` (live allowlist + structured help — prefer these first)
+2) `docs/tool-catalog.md` / `zeus://docs/tool-catalog.json` for purpose, scope, and safety levels
+3) `docs/mcp/operator-guide.md` for allowlist posture and operator startup
+4) This session prompt for operating model and safety rules
 
 Safety rules:
 1) Never run write operations on production systems.
@@ -38,46 +41,57 @@ Safety rules:
 3) For risky actions, show the exact CLI command or MCP tool call first, then wait for confirmation.
 4) Keep credentials out of prompts, outputs, logs, summaries, and generated artifacts.
 5) Prefer read-only evidence collection before proposing conclusions.
+6) Default MCP allowlist includes selected S2 remote-read tools; still explain why you use them. Project-knowledge index/write and S3/S4 are not on the default allowlist.
 
 Execution protocol:
 1) Confirm the current goal, profile, and whether MCP tools are available.
-2) Load the environment explicitly in the current shell if it is not already loaded.
-3) Run `doctor` first.
-4) Use read-only CLI or MCP commands to collect evidence.
-5) Run `analyze` or `workflow` locally to produce artifacts.
-6) Deepen evidence with query/search/inspection commands only as needed.
-7) Summarize findings with references to generated artifacts and note the risk level of the next step.
+2) If MCP: call `zeus.help` (overview) or use `tools/list` — do not hunt docs for tool names.
+3) Load the environment explicitly in the current shell if it is not already loaded.
+4) Run `doctor` first (`zeus.doctor`).
+5) Optional: `zeus.project-knowledge.discover` (commercial present/absent; fail-closed — do not thrash missing ops).
+6) Use read-only CLI or MCP commands to collect evidence.
+7) Run `analyze` or `workflow` locally to produce artifacts.
+8) Deepen evidence with search/investigation/query commands only as needed.
+9) Summarize findings with references to generated artifacts and note the risk level of the next step.
 
-Tooling quick reference:
-| Command | Safety | Purpose |
-|---|---|---|
-| doctor | S0 | Validate runtime, profile, and env wiring |
-| fetch | S2 | Read sources from IBM i into workspace; use `--system <name>` for named profile systems |
-| analyze | S1 | Generate core analysis artifacts |
-| workflow | S1 | Run preset analysis flows |
-| bundle | S1 | Package artifacts for sharing |
-| impact | S1 | Reverse-impact analysis |
-| assess-risk | S1 | Risk-oriented summary |
-| generate-test | S1 | Test planning output |
-| generate-checklist | S1 | Deployment/change checklist |
-| query-table | S2 | DB2 metadata read |
-| query-sql | S2 | One or more read-only SQL statements |
-| joblog | S2 | IBM i joblog read |
-| field-search | S0/S2 | Cross-reference field/table usage |
-| search-source | S0 | Local source search |
-| resolve-object | S2 | Resolve SQL/system object names read-only |
-| inspect-object | S2 | IBM i object inspection |
-| copy-to-workspace | S1 | Local source copy operations |
-| diff | S2 | Compare local vs IBM i member |
-| qa | S1 | QA validation output |
-| serve | S0 | Optional local artifact viewer |
-| test-run | S2/S1 | Before/after test snapshots |
-| upsert / upsert-sql | S3 | Controlled DML (approval required) |
-| insert | S3 | Insert-only DML (approval required) |
-| update | S3 | Update-only DML (approval required) |
-| bridge | S4 | Operator-gated bridge workflow |
-| pui-edit | S1 | Structured local display-artifact edits |
-| docs:generate-catalog | S0 | Regenerate tool catalog docs |
+Tooling quick reference (CLI names; MCP tools are typically `zeus.<name>`):
+| Command / MCP family | Safety | Purpose | Notes |
+|---|---|---|---|
+| help (`zeus.help`) | S0 | Structured help / overview | Prefer first when MCP is available |
+| doctor | S0 | Validate runtime, profile, and env wiring | Always early |
+| profiles | S0 | List profiles | |
+| onboarding | S0 | Guided first-time IBM i setup | |
+| resources (`zeus.resources`) | S0 | MCP resource introspection | Default allowlist |
+| discover-environment | S0/S2 | Environment discovery helpers | Default allowlist |
+| fetch | S2 | Read sources from IBM i; `--system <name>` for named targets | Often needs explicit allow if not default |
+| analyze | S1 | Generate core analysis artifacts | Primary local evidence |
+| workflow | S1 | Run preset analysis flows | |
+| investigation.* | S0 | Focused investigation on existing analyze artifacts | Default allowlist |
+| search-source | S0 | Local source search | |
+| field-search | S0/S2 | Cross-reference field/table usage | |
+| bundle | S1 | Package artifacts for sharing | |
+| impact | S1 | Reverse-impact analysis | |
+| assess-risk | S1 | Risk-oriented summary | |
+| generate-test | S1 | Test planning output | |
+| generate-checklist | S1 | Deployment/change checklist | |
+| qa | S1 | QA validation output | |
+| validate-rpg-sql | S1 | RPG/SQL validation helpers | |
+| query-table | S2 | DB2 metadata read | Default allowlist remote-read |
+| query-sql | S2 | Read-only SQL | Default allowlist remote-read |
+| joblog | S2 | IBM i joblog read | Default allowlist remote-read |
+| resolve-object | S2 | Resolve SQL/system object names | Default allowlist remote-read |
+| inspect-object | S2 | IBM i object inspection | Default allowlist remote-read |
+| fetch-member | S2 | Fetch a single member | Default allowlist |
+| copy-to-workspace | S1 | Local source copy operations | |
+| diff | S2 | Compare local vs IBM i member | |
+| serve | S0 | Optional local artifact viewer | |
+| test-run | S2/S1 | Before/after test snapshots | |
+| project-knowledge.discover / .status | S1 | PI present/absent + status | Default allowlist only these two |
+| project-knowledge index/query/... | S1 | Commercial PI ops | Explicit allow-tools + module |
+| upsert / insert / update | S3 | Controlled DML | Approval + not default allowlist |
+| bridge | S4 | Operator-gated bridge workflow | Approval + not default allowlist |
+| pui-edit | S1 | Structured local display-artifact edits | |
+| docs:generate-catalog | S0 | Regenerate tool catalog docs | |
 
 Workflow presets:
 - onboarding
@@ -138,6 +152,7 @@ Now proceed with this session goal:
 
 ## Usage Notes
 
-- Behandle `docs/tool-catalog.md` als verbindliche Referenz, nicht nur als Beispiel.
-- Bei Command-Aenderungen zuerst `docs/tool-catalog.md`, dann diese Datei aktualisieren.
+- Bei MCP: Live-Toolnamen aus `tools/list` / `zeus.help`; Kataloge fuer Purpose/Safety.
+- Bei Command-Aenderungen: Katalog-Metadaten + `DEFAULT_MCP_SAFE_TOOL_NAMES` (`src/mcp/mcpPolicy.js`) + diese Datei abstimmen.
+- Operator-Guide empfohlene `--allow-tools`-CSV muss die Code-Default-Liste enthalten (siehe Tests).
 - Fuer Enterprise-Setups mit projektspezifischen Policy-Dateien kombinieren.

--- a/docs/mcp/operator-guide.md
+++ b/docs/mcp/operator-guide.md
@@ -1,25 +1,27 @@
 ---
 Title: MCP Operator Guide
 Description: Local-first MCP startup, policy boundaries, and troubleshooting for Zeus RPG PromptKit.
-Last Updated: 2026-07-09
+Last Updated: 2026-07-25
 ---
 
 # MCP Operator Guide
 
 ## Purpose
 
-Expose a safe, local-only subset of Zeus capabilities over MCP stdio for AI clients and automation.
+Expose a safe, policy-gated subset of Zeus capabilities over MCP stdio for AI clients and automation.
 
 ## Security Posture
 
 - Transport: stdio only (local process boundary)
-- Default behavior: safe expanded default surface (health, doctor, profiles, help, onboarding, analyze, workflow, searches, queries, review/planning tools, etc. — see mcpPolicy.js)
-- Policy: explicit allowlist gate (`--allow-tools`) for any broader tool surface
+- Default behavior: safe expanded default surface from `src/mcp/mcpPolicy.js` (`DEFAULT_MCP_SAFE_TOOL_NAMES`) — S0/S1 local tools **plus** selected S2 remote-read tools; **not** S3/S4 writes or project-knowledge index/write
+- Policy: `--allow-tools` **replaces** the allowlist (does not merge/extend). Omit it to use the full default safe list; pass a smaller list to restrict further
 - Curated discovery surfaces: first-class MCP `resources/*` and `prompts/*` for safe docs/metadata/prompt access
 - Redaction: response/error masking for common secret patterns
 - Audit: append-only local JSONL audit trail for `tools/call`
 - Runtime guardrails: per-tool timeout and maximum response-size limits with deterministic `-32000` failures
 - Local path policy: local path inputs for local source-root tools must resolve inside the current workspace root, including absolute paths
+
+**Live tool names for agents:** prefer MCP `tools/list` and `zeus.help` (overview) over hunting markdown. Catalog docs remain authoritative for purpose/safety levels but are secondary for “what is available right now.”
 
 Out of scope for MVP:
 
@@ -33,18 +35,20 @@ Out of scope for MVP:
 node cli/zeus.js mcp serve --stdio true --verbose
 ```
 
-Without `--allow-tools`, MCP exposes the safe default surface (see above). Use `--allow-tools` to provide a custom (usually smaller) list.
+Without `--allow-tools`, MCP exposes the full default safe surface (`DEFAULT_MCP_SAFE_TOOL_NAMES` in `src/mcp/mcpPolicy.js`).
 
-Restrict exposed tools explicitly for real workflows (recommended):
+### Recommended default allowlist (must match runtime)
+
+This CSV is the **same set** as the code default. Use it when you want an explicit, reproducible allowlist (equivalent to omitting `--allow-tools`). You may pass a **smaller** subset to restrict the agent.
 
 ```bash
 node cli/zeus.js mcp serve --verbose \
-  --allow-tools zeus.health,zeus.version,zeus.profiles,zeus.doctor,zeus.help,zeus.onboarding,zeus.analyze,zeus.workflow,zeus.bundle,zeus.search-source,zeus.field-search,zeus.resolve-object,zeus.inspect-object,zeus.query-table,zeus.query-sql,zeus.impact,zeus.assess-risk,zeus.generate-test,zeus.generate-checklist,zeus.qa,zeus.validate-rpg-sql,zeus.analyses,zeus.fetch-member,zeus.diff,zeus.copy-to-workspace,zeus.joblog,zeus.docs-generate-catalog,zeus.serve,zeus.test-run
+  --allow-tools zeus.health,zeus.version,zeus.profiles,zeus.doctor,zeus.help,zeus.onboarding,zeus.resources,zeus.discover-environment,zeus.analyze,zeus.workflow,zeus.bundle,zeus.search-source,zeus.field-search,zeus.investigation.start,zeus.investigation.focus,zeus.investigation.search,zeus.investigation.generate-prompt,zeus.resolve-object,zeus.inspect-object,zeus.query-table,zeus.query-sql,zeus.impact,zeus.assess-risk,zeus.generate-test,zeus.generate-checklist,zeus.qa,zeus.validate-rpg-sql,zeus.analyses,zeus.fetch-member,zeus.diff,zeus.copy-to-workspace,zeus.joblog,zeus.docs-generate-catalog,zeus.serve,zeus.test-run,zeus.project-knowledge.discover,zeus.project-knowledge.status
 ```
 
-(This is the single recommended list for most agentic coding + legacy IBM i / RPG work. You can always use a smaller subset.)
+**Note:** `--allow-tools` replaces the default list. If you paste an incomplete CSV, tools such as `zeus.resources`, `zeus.investigation.*`, and `zeus.project-knowledge.*` disappear even though they are on the code default.
 
-See also the new onboarding guide: `docs/quickstart/onboarding-new-ibm-i.md` (covers connection, source location, PGM/Table objects, metadata & data discovery).
+See also: `docs/quickstart/onboarding-new-ibm-i.md` (connection, source location, PGM/table objects, metadata & data discovery).
 
 ## Supported MCP Methods (Current)
 
@@ -62,42 +66,43 @@ Curated prompts expose the standard Zeus session bootstrap prompt plus prompt-te
 
 ## Supported MCP Tools (Current)
 
-The safe default surface (when running without `--allow-tools`) is defined in `src/mcp/mcpPolicy.js` (includes health, doctor, profiles, analyze, searches, queries, review tools, etc.).
+Source of truth for the default safe surface: `src/mcp/mcpPolicy.js` (`DEFAULT_MCP_SAFE_TOOL_NAMES` / `formatDefaultMcpAllowToolsCsv()`).
 
-For reproducibility and explicit control, we recommend always passing this single list:
+Includes among others:
 
-```bash
-node cli/zeus.js mcp serve --verbose --allow-tools zeus.health,zeus.version,zeus.profiles,zeus.doctor,zeus.help,zeus.onboarding,zeus.analyze,zeus.workflow,zeus.bundle,zeus.search-source,zeus.field-search,zeus.resolve-object,zeus.inspect-object,zeus.query-table,zeus.query-sql,zeus.impact,zeus.assess-risk,zeus.generate-test,zeus.generate-checklist,zeus.qa,zeus.validate-rpg-sql,zeus.analyses,zeus.fetch-member,zeus.diff,zeus.copy-to-workspace,zeus.joblog,zeus.docs-generate-catalog,zeus.serve,zeus.test-run
-```
-
-Use a smaller subset via `--allow-tools` when you want to restrict the agent more tightly.
+- health / version / profiles / doctor / help / onboarding / resources / discover-environment
+- analyze / workflow / bundle / searches / investigation.\*
+- selected remote-read: resolve-object, inspect-object, query-table, query-sql, fetch-member, diff, joblog, test-run
+- project-knowledge: **discover + status only** (index/query/write need explicit allow-tools + commercial module)
 
 Example with a profile (recommended for real-target agent sessions):
 
 ```bash
 source ./config/load-env.sh myenv
 node cli/zeus.js doctor --profile my-profile
-# MCP server with safe local surface + some read
+# MCP server with default safe surface (omit --allow-tools) or paste the full CSV above
 ./.local/mcp/start-zeus-mcp-myenv.sh
 # or
-node cli/zeus.js mcp serve --stdio true --allow-tools [paste the recommended list above]
+node cli/zeus.js mcp serve --stdio true --verbose
 ```
 
 ## Perfect AI Agent Interaction Pattern (Example)
 
-An AI can bootstrap and operate fully via MCP without prior hard-coded knowledge beyond the protocol:
+An AI can bootstrap and operate via MCP **without inventing tool names** and without multi-doc hunting:
 
 1. `initialize`
-2. `resources/list` then `resources/read` for `zeus://docs/ai/session-prompt.md`, `zeus://docs/tool-catalog.json`, `zeus://metadata/mcp-tools.json`, `zeus://metadata/workflow-presets.json`
-3. `prompts/get` `zeus.session.start` with goal describing the task (e.g. "Perform local analysis of the RPG sources in this workspace and prepare a modernization review bundle")
+2. `tools/list` (live allowlisted surface) **or** `tools/call` `zeus.help` (overview + `defaultTools` + recommended sequence)
+3. Optional: `prompts/get` `zeus.session.start` with the user goal (secondary; help is enough for local analysis)
 4. `tools/call` `zeus.doctor` + `zeus.profiles`
-5. `tools/call` `zeus.help` (for self-service guidance) or `zeus.search-source`
-6. `tools/call` `zeus.analyze` with `source` pointing to local sources + `program`
-7. Use `resources/list` / `resources/read` `zeus://runs/PROGRAM/...` to fetch manifests, reports and generated `ai_prompt_*.md` files
-8. `tools/call` `zeus.bundle` or `zeus.impact` etc.
-9. `tools/call` `zeus.help` "bundle" for usage.
+5. `tools/call` `zeus.project-knowledge.discover` (present/absent; do not thrash commercial-only ops)
+6. `tools/call` `zeus.analyze` with `source` + `program` (or `zeus.workflow` with a preset)
+7. Optional deepen: `zeus.search-source`, `zeus.investigation.*`, allowlisted remote-read tools if needed
+8. `tools/call` `zeus.bundle` or `zeus.impact` as needed
+9. Optional: `resources/read` `zeus://runs/PROGRAM/...` for manifests and `ai_prompt_*.md`
 
-All via stdio, all outputs structured + enveloped, all bounded to workspace, secrets redacted. Use the default allowlist for pure local evidence work.
+Docs/resources (`zeus://docs/tool-catalog.json`, session-prompt, onboarding) remain available but are **secondary** after `tools/list` / `zeus.help`.
+
+All via stdio, outputs structured + enveloped, workspace-bounded, secrets redacted.
 
 ````
 

--- a/src/mcp/mcpPolicy.js
+++ b/src/mcp/mcpPolicy.js
@@ -41,6 +41,16 @@ const DEFAULT_MCP_SAFE_TOOL_NAMES = Object.freeze([
   'zeus.project-knowledge.status',
 ]);
 
+/**
+ * Comma-separated default safe tool list for docs and operator examples.
+ * Keep operator-guide recommended --allow-tools in sync with this (see tests).
+ * @returns {string}
+ */
+function formatDefaultMcpAllowToolsCsv() {
+  return DEFAULT_MCP_SAFE_TOOL_NAMES.join(',');
+}
+
 module.exports = {
   DEFAULT_MCP_SAFE_TOOL_NAMES,
+  formatDefaultMcpAllowToolsCsv,
 };

--- a/src/mcp/mcpTools.js
+++ b/src/mcp/mcpTools.js
@@ -6777,24 +6777,27 @@ async function executeMcpToolCall(name, args = {}, context = {}) {
       const safeDefaults = [...DEFAULT_MCP_SAFE_TOOL_NAMES];
       helpData = {
         overview:
-          'Zeus RPG PromptKit MCP default safe surface (S0/S1 local only). Use for evidence gathering and AI context preparation without remote access.',
+          'Zeus RPG PromptKit MCP default safe surface (see defaultTools). Includes S0/S1 local tools plus selected S2 remote-read tools (query/inspect/joblog/etc.) that are already on the default allowlist. S3/S4 writes, bridge mutations, and project-knowledge index/write ops are NOT on the default allowlist.',
         defaultTools: safeDefaults,
         safetyReminder:
-          'Always prefer S0. Use S1 only for local artifact generation inside workspace. Never S2+ without explicit operator allowlist and approval.',
+          'Prefer S0, then S1 local artifact generation. Default-allowlisted S2 tools are remote-read only — still explain why you call them. Never use S3/S4, write-sql apply, or bridge mutation without explicit operator --allow-tools and human approval. Project-knowledge: only discover + status by default.',
         recommendedSequence: [
+          'zeus.help (overview — do not invent tool names)',
           'zeus.doctor (check readiness)',
           'zeus.profiles (discover config)',
-          'zeus.onboarding (guided first-time IBM i setup)',
-          'zeus.search-source or zeus.field-search (local code exploration)',
+          'zeus.project-knowledge.discover (commercial PI present/absent; fail-closed)',
+          'zeus.onboarding (guided first-time IBM i setup) or zeus.resources / zeus.discover-environment',
+          'zeus.search-source, zeus.field-search, or zeus.investigation.* (local exploration)',
           'zeus.analyze (with source) or zeus.workflow --preset X (full local evidence)',
           'zeus.impact / zeus.assess-risk / zeus.generate-test / zeus.generate-checklist / zeus.qa / zeus.validate-rpg-sql',
+          'Optional default-allowlisted remote-read: zeus.query-table / zeus.query-sql / zeus.inspect-object / zeus.joblog',
           'zeus.bundle (package for review)',
           'Read generated artifacts + AI prompts via zeus://runs/... resources',
         ],
         howToGetMore:
-          'Call zeus.help with a command name for details. Use resources like zeus://docs/tool-catalog.md , zeus://docs/quickstart/onboarding-new-ibm-i.md , zeus://onboarding/checklist.json and zeus://metadata/* for full catalog + onboarding guidance.',
+          'Live tool names: tools/list and this overview defaultTools. Call zeus.help with a command name for details. Docs/resources (zeus://docs/tool-catalog.md, onboarding, metadata/*) are secondary — prefer tools/list + zeus.help first.',
         aiTip:
-          'Start new IBM i systems with zeus.onboarding or read zeus://docs/quickstart/onboarding-new-ibm-i.md + zeus://onboarding/checklist.json . After analysis, use resources/read on run URIs or specific ai_prompt_*.md artifacts to load evidence into your context.',
+          'Do not invent tool names. Start with tools/list or zeus.help overview. New IBM i: zeus.onboarding or zeus://docs/quickstart/onboarding-new-ibm-i.md. After analysis, resources/read run URIs or ai_prompt_*.md. If project-knowledge ops other than discover/status fail, commercial module is absent or not allowlisted — use analyze/search-source/impact instead.',
       };
     } else {
       const meta = COMMAND_METADATA[cmd] || COMMAND_METADATA[cmd.replace(':', '')] || null;

--- a/tests/mcp-default-allowlist-docs.test.js
+++ b/tests/mcp-default-allowlist-docs.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { describe, it } = require('node:test');
+
+const {
+  DEFAULT_MCP_SAFE_TOOL_NAMES,
+  formatDefaultMcpAllowToolsCsv,
+} = require('../src/mcp/mcpPolicy');
+
+const ROOT = path.resolve(__dirname, '..');
+const OPERATOR_GUIDE = path.join(ROOT, 'docs', 'mcp', 'operator-guide.md');
+const SESSION_PROMPT = path.join(ROOT, 'docs', 'ai', 'session-prompt.md');
+const MCP_TOOLS = path.join(ROOT, 'src', 'mcp', 'mcpTools.js');
+
+describe('Track G0: default MCP allowlist docs sync', () => {
+  it('formatDefaultMcpAllowToolsCsv matches DEFAULT_MCP_SAFE_TOOL_NAMES', () => {
+    assert.equal(formatDefaultMcpAllowToolsCsv(), DEFAULT_MCP_SAFE_TOOL_NAMES.join(','));
+    assert.ok(DEFAULT_MCP_SAFE_TOOL_NAMES.length >= 30);
+  });
+
+  it('operator-guide recommended --allow-tools includes every default safe tool', () => {
+    const text = fs.readFileSync(OPERATOR_GUIDE, 'utf8');
+    const csv = formatDefaultMcpAllowToolsCsv();
+    assert.ok(
+      text.includes(csv),
+      'docs/mcp/operator-guide.md must embed the full formatDefaultMcpAllowToolsCsv() string'
+    );
+    for (const name of DEFAULT_MCP_SAFE_TOOL_NAMES) {
+      assert.ok(text.includes(name), `operator-guide missing default tool: ${name}`);
+    }
+  });
+
+  it('session-prompt covers key default-safe families for agents', () => {
+    const text = fs.readFileSync(SESSION_PROMPT, 'utf8');
+    const requiredSnippets = [
+      'zeus.help',
+      'tools/list',
+      'investigation',
+      'discover-environment',
+      'project-knowledge.discover',
+      'Do not invent tool',
+    ];
+    for (const snippet of requiredSnippets) {
+      assert.ok(text.includes(snippet), `session-prompt missing: ${snippet}`);
+    }
+  });
+
+  it('zeus.help overview does not claim S0/S1 local only for the default surface', () => {
+    const text = fs.readFileSync(MCP_TOOLS, 'utf8');
+    assert.ok(
+      !text.includes('S0/S1 local only'),
+      'mcpTools.js must not describe default safe surface as S0/S1 local only'
+    );
+    assert.ok(
+      text.includes('selected S2 remote-read'),
+      'mcpTools.js help overview should acknowledge default-allowlisted S2 remote-read tools'
+    );
+  });
+});


### PR DESCRIPTION
﻿## Summary
Track G0 (zero-search agent path): stop teaching agents a stale MCP surface.

- Operator guide recommended --allow-tools now matches full DEFAULT_MCP_SAFE_TOOL_NAMES (resources, discover-environment, investigation.*, project-knowledge discover/status)
- Document that --allow-tools replaces the default list
- Session prompt: live SoT is tools/list and zeus.help; expanded tool table
- zeus.help overview no longer claims S0/S1 local-only defaults
- formatDefaultMcpAllowToolsCsv() plus docs sync tests

## Plan
Approved AI-first toolset plan: G0 then G1 then G2 on 0.2.0-beta.5+ line.

## Test plan
- [x] node --test tests/mcp-default-allowlist-docs.test.js
- [x] node --test tests/mcp-server.test.js
- [x] node --test tests/ai-session-prompt-service.test.js
